### PR TITLE
Fix: Input text color too light grey

### DIFF
--- a/app/(auth)/join/[code]/page.tsx
+++ b/app/(auth)/join/[code]/page.tsx
@@ -141,7 +141,7 @@ export default function JoinFamilyPage() {
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="Your name"
             />
           </div>
@@ -156,7 +156,7 @@ export default function JoinFamilyPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="you@example.com"
             />
           </div>
@@ -172,7 +172,7 @@ export default function JoinFamilyPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="••••••••"
             />
           </div>

--- a/app/(auth)/join/page.tsx
+++ b/app/(auth)/join/page.tsx
@@ -34,7 +34,7 @@ export default function JoinPage() {
               value={code}
               onChange={(e) => setCode(e.target.value.toUpperCase())}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-center text-2xl tracking-widest font-mono"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-center text-2xl tracking-widest font-mono text-gray-900"
               placeholder="ABCD1234"
               maxLength={8}
             />

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -58,7 +58,7 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="you@example.com"
             />
           </div>
@@ -73,7 +73,7 @@ export default function LoginPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="••••••••"
             />
           </div>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -64,7 +64,7 @@ export default function SignupPage() {
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="Your name"
             />
           </div>
@@ -79,7 +79,7 @@ export default function SignupPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="you@example.com"
             />
           </div>
@@ -95,7 +95,7 @@ export default function SignupPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="••••••••"
             />
             <p className="text-xs text-gray-500 mt-1">At least 6 characters</p>

--- a/app/(dashboard)/family/page.tsx
+++ b/app/(dashboard)/family/page.tsx
@@ -145,7 +145,7 @@ export default function FamilyPage() {
                   onChange={(e) => setFamilyName(e.target.value)}
                   required
                   placeholder="e.g., The Smiths"
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
                 />
               </div>
               <Button type="submit" disabled={creating} className="w-full">

--- a/app/(dashboard)/me/page.tsx
+++ b/app/(dashboard)/me/page.tsx
@@ -144,7 +144,7 @@ export default function MePage() {
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
                 required
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
               />
             </div>
 
@@ -157,7 +157,7 @@ export default function MePage() {
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
                 placeholder="e.g., Baby Bison, Panther"
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
               />
               <p className="text-xs text-gray-500 mt-1">
                 A fun name to display on tasks

--- a/components/family/invite-modal.tsx
+++ b/components/family/invite-modal.tsx
@@ -60,7 +60,7 @@ export function InviteModal({ isOpen, onClose, inviteCode }: InviteModalProps) {
               type="text"
               readOnly
               value={inviteLink}
-              className="flex-1 px-3 py-2 bg-gray-100 rounded-lg text-sm text-gray-600 truncate"
+              className="flex-1 px-3 py-2 bg-gray-100 rounded-lg text-sm text-gray-900 truncate"
             />
             <Button
               onClick={() => copyToClipboard(inviteLink)}

--- a/components/tasks/task-form.tsx
+++ b/components/tasks/task-form.tsx
@@ -82,7 +82,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             required
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
             placeholder="e.g., Clean your room"
           />
         </div>
@@ -95,7 +95,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={2}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none resize-none"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none resize-none text-gray-900"
             placeholder="Optional details..."
           />
         </div>
@@ -108,7 +108,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
             <select
               value={points}
               onChange={(e) => setPoints(Number(e.target.value))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
             >
               <option value={5}>5 points</option>
               <option value={10}>10 points</option>
@@ -126,7 +126,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
             <select
               value={timeOfDay}
               onChange={(e) => setTimeOfDay(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
             >
               {TIME_OF_DAY_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -144,7 +144,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
           <select
             value={assignedTo || ''}
             onChange={(e) => setAssignedTo(e.target.value || null)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
           >
             <option value="">Anyone</option>
             {familyMembers.map((member) => (
@@ -162,7 +162,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
           <select
             value={recurring || ''}
             onChange={(e) => setRecurring(e.target.value || null)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none text-gray-900"
           >
             <option value="">One time only</option>
             <option value="daily">Daily</option>


### PR DESCRIPTION
## Summary
- Added `text-gray-900` to all input, textarea, and select elements across 8 files
- Browsers don't inherit body text color on form elements by default, causing typed text to appear as light grey
- Changed invite modal link input from `text-gray-600` to `text-gray-900`

## Test plan
- [ ] Verify input text is dark/black on login, signup, and join pages
- [ ] Verify task form inputs and selects show dark text
- [ ] Verify profile edit inputs show dark text
- [ ] Verify family name input shows dark text

🤖 Generated with [Claude Code](https://claude.com/claude-code)