### PR TITLE
Fix recurring tasks per-date completion tracking

### DIFF
--- a/components/tasks/task-card.tsx
+++ b/components/tasks/task-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { cn } from '@/lib/utils'
 import { Avatar } from '@/components/ui/avatar'
 import type { TaskWithAssignee } from '@/lib/types'
@@ -13,6 +13,11 @@ interface TaskCardProps {
 export function TaskCard({ task, onComplete }: TaskCardProps) {
   const [isCompleting, setIsCompleting] = useState(false)
   const [isCompleted, setIsCompleted] = useState(task.completed)
+
+  // Sync with prop when task data changes (e.g., navigating between days)
+  useEffect(() => {
+    setIsCompleted(task.completed)
+  }, [task.completed])
 
   async function handleComplete() {
     if (isCompleted || isCompleting) return

--- a/components/tasks/task-form.tsx
+++ b/components/tasks/task-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Modal } from '@/components/ui/modal'
+import { toDateString } from '@/lib/utils'
 import { TIME_OF_DAY_OPTIONS, type Profile } from '@/lib/types'
 
 interface TaskFormProps {
@@ -46,7 +47,7 @@ export function TaskForm({ isOpen, onClose, onSubmit, familyMembers, selectedDat
         time_of_day: timeOfDay,
         recurring,
         assigned_to: assignedTo,
-        due_date: selectedDate.toISOString().split('T')[0],
+        due_date: toDateString(selectedDate),
       })
 
       // Reset form

--- a/components/tasks/task-list.tsx
+++ b/components/tasks/task-list.tsx
@@ -7,9 +7,10 @@ interface TaskListProps {
   tasks: TaskWithAssignee[]
   onComplete: (taskId: string) => Promise<void>
   emptyMessage?: string
+  dateKey?: string
 }
 
-export function TaskList({ tasks, onComplete, emptyMessage = 'No quests found' }: TaskListProps) {
+export function TaskList({ tasks, onComplete, emptyMessage = 'No quests found', dateKey }: TaskListProps) {
   if (tasks.length === 0) {
     return (
       <div className="text-center py-12">
@@ -26,7 +27,7 @@ export function TaskList({ tasks, onComplete, emptyMessage = 'No quests found' }
   return (
     <div className="space-y-3">
       {tasks.map((task) => (
-        <TaskCard key={task.id} task={task} onComplete={onComplete} />
+        <TaskCard key={`${task.id}-${dateKey || ''}`} task={task} onComplete={onComplete} />
       ))}
     </div>
   )

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -105,6 +105,7 @@ export type Database = {
           completed_by: string | null
           completed_at: string
           points_earned: number
+          completion_date: string | null
         }
         Insert: {
           id?: string
@@ -112,6 +113,7 @@ export type Database = {
           completed_by?: string | null
           completed_at?: string
           points_earned: number
+          completion_date?: string | null
         }
         Update: {
           id?: string
@@ -119,6 +121,7 @@ export type Database = {
           completed_by?: string | null
           completed_at?: string
           points_earned?: number
+          completion_date?: string | null
         }
       }
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -47,9 +47,12 @@ export function isSameDay(date1: Date, date2: Date): boolean {
   )
 }
 
-// Format date as YYYY-MM-DD for database
+// Format date as YYYY-MM-DD using local timezone
 export function toDateString(date: Date): string {
-  return date.toISOString().split('T')[0]
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 // Get initials from name

--- a/supabase/migrations/002_add_completion_date.sql
+++ b/supabase/migrations/002_add_completion_date.sql
@@ -1,0 +1,22 @@
+ALTER TABLE task_completions ADD COLUMN completion_date date;
+
+-- Backfill existing rows
+UPDATE task_completions
+SET completion_date = (completed_at AT TIME ZONE 'UTC')::date
+WHERE completion_date IS NULL;
+
+-- Remove duplicate completions per task per day, keeping the earliest
+DELETE FROM task_completions a
+USING task_completions b
+WHERE a.task_id = b.task_id
+  AND a.completion_date = b.completion_date
+  AND a.completion_date IS NOT NULL
+  AND a.completed_at > b.completed_at;
+
+-- Index for fast date lookups
+CREATE INDEX idx_task_completions_date ON task_completions(completion_date);
+
+-- Prevent duplicate completions per task per day
+CREATE UNIQUE INDEX idx_task_completions_unique_per_day
+ON task_completions(task_id, completion_date)
+WHERE completion_date IS NOT NULL;


### PR DESCRIPTION
## Summary
- Fix recurring tasks (daily/weekly) not persisting completion state when navigating between dates, caused by timezone mismatches in timestamp-range queries
- Add `completion_date date` column to `task_completions` and query by simple date equality instead of `gte`/`lte` on `completed_at` timestamps
- Fix `toDateString` to use local timezone instead of UTC, sync task-card state on date navigation, and add `dateKey`-based remounting for task list

## Test plan
- [ ] Run SQL migration `002_add_completion_date.sql` in Supabase dashboard
- [ ] Mark a daily task done today → navigate away → come back → still shows done
- [ ] Mark a daily task done today → go to tomorrow → shows NOT done
- [ ] Mark a weekly task done → go to same day next week → shows NOT done
- [ ] Verify one-time tasks still work as before
- [ ] Verify completing the same recurring task twice on the same day is blocked by unique index

🤖 Generated with [Claude Code](https://claude.com/claude-code)