### PR TITLE
Fix recurring tasks and add edit functionality

### DIFF
--- a/__tests__/components/tasks/task-card.test.tsx
+++ b/__tests__/components/tasks/task-card.test.tsx
@@ -26,50 +26,51 @@ const mockTask: TaskWithAssignee = {
 
 describe('TaskCard', () => {
   it('renders task title', () => {
-    render(<TaskCard task={mockTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
     expect(screen.getByText('Clean your room')).toBeInTheDocument()
   })
 
   it('renders task description', () => {
-    render(<TaskCard task={mockTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
     expect(screen.getByText('Make bed and pick up toys')).toBeInTheDocument()
   })
 
   it('renders points', () => {
-    render(<TaskCard task={mockTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
     expect(screen.getByText('10 pts')).toBeInTheDocument()
   })
 
   it('renders time of day badge', () => {
-    render(<TaskCard task={mockTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
     expect(screen.getByText('Morning')).toBeInTheDocument()
   })
 
   it('renders recurring badge when task is recurring', () => {
     const recurringTask = { ...mockTask, recurring: 'daily' as const }
-    render(<TaskCard task={recurringTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={recurringTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
     expect(screen.getByText('Daily')).toBeInTheDocument()
   })
 
   it('does not render recurring badge for one-time tasks', () => {
-    render(<TaskCard task={mockTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
     expect(screen.queryByText('Daily')).not.toBeInTheDocument()
     expect(screen.queryByText('Weekly')).not.toBeInTheDocument()
   })
 
   it('calls onComplete when checkbox clicked', async () => {
     const handleComplete = jest.fn()
-    render(<TaskCard task={mockTask} onComplete={handleComplete} />)
+    render(<TaskCard task={mockTask} onComplete={handleComplete} onEdit={jest.fn()} />)
 
-    const checkbox = screen.getByRole('button')
-    await userEvent.click(checkbox)
+    const buttons = screen.getAllByRole('button')
+    // First button is the complete checkbox
+    await userEvent.click(buttons[0])
 
     expect(handleComplete).toHaveBeenCalledWith('task-1')
   })
 
   it('shows completed state', () => {
     const completedTask = { ...mockTask, completed: true }
-    render(<TaskCard task={completedTask} onComplete={jest.fn()} />)
+    render(<TaskCard task={completedTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
 
     expect(screen.getByText('Clean your room')).toHaveClass('line-through')
   })
@@ -77,11 +78,50 @@ describe('TaskCard', () => {
   it('disables checkbox when already completed', async () => {
     const completedTask = { ...mockTask, completed: true }
     const handleComplete = jest.fn()
-    render(<TaskCard task={completedTask} onComplete={handleComplete} />)
+    render(<TaskCard task={completedTask} onComplete={handleComplete} onEdit={jest.fn()} />)
 
+    // When completed, only the checkbox button is visible (edit button is hidden)
     const checkbox = screen.getByRole('button')
     await userEvent.click(checkbox)
 
     expect(handleComplete).not.toHaveBeenCalled()
+  })
+
+  describe('Edit Button', () => {
+    it('renders edit button for incomplete tasks', () => {
+      render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
+
+      const editButton = screen.getByTitle('Edit quest')
+      expect(editButton).toBeInTheDocument()
+    })
+
+    it('calls onEdit with task when edit button is clicked', async () => {
+      const handleEdit = jest.fn()
+      render(<TaskCard task={mockTask} onComplete={jest.fn()} onEdit={handleEdit} />)
+
+      const editButton = screen.getByTitle('Edit quest')
+      await userEvent.click(editButton)
+
+      expect(handleEdit).toHaveBeenCalledWith(mockTask)
+    })
+
+    it('hides edit button when task is completed', () => {
+      const completedTask = { ...mockTask, completed: true }
+      render(<TaskCard task={completedTask} onComplete={jest.fn()} onEdit={jest.fn()} />)
+
+      expect(screen.queryByTitle('Edit quest')).not.toBeInTheDocument()
+    })
+
+    it('does not call onComplete when edit button is clicked', async () => {
+      const handleComplete = jest.fn()
+      const handleEdit = jest.fn()
+      render(<TaskCard task={mockTask} onComplete={handleComplete} onEdit={handleEdit} />)
+
+      const editButton = screen.getByTitle('Edit quest')
+      await userEvent.click(editButton)
+
+      expect(handleComplete).not.toHaveBeenCalled()
+      expect(handleEdit).toHaveBeenCalled()
+    })
   })
 })

--- a/__tests__/components/tasks/task-form.test.tsx
+++ b/__tests__/components/tasks/task-form.test.tsx
@@ -1,0 +1,271 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TaskForm } from '@/components/tasks/task-form'
+import type { TaskWithAssignee, Profile } from '@/lib/types'
+
+const mockFamilyMembers: Profile[] = [
+  {
+    id: 'user-1',
+    display_name: 'Timmy',
+    nickname: 'Little T',
+    avatar_url: null,
+    role: 'child',
+    family_id: 'family-1',
+    points: 100,
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'user-2',
+    display_name: 'Parent',
+    nickname: null,
+    avatar_url: null,
+    role: 'parent',
+    family_id: 'family-1',
+    points: 0,
+    created_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+const mockTask: TaskWithAssignee = {
+  id: 'task-1',
+  family_id: 'family-1',
+  title: 'Clean your room',
+  description: 'Make bed and pick up toys',
+  assigned_to: 'user-1',
+  points: 20,
+  time_of_day: 'morning',
+  recurring: 'daily',
+  due_date: '2024-01-15',
+  completed: false,
+  created_by: 'user-2',
+  created_at: '2024-01-01T00:00:00Z',
+  profiles: {
+    id: 'user-1',
+    display_name: 'Timmy',
+    avatar_url: null,
+    nickname: 'Little T',
+  },
+}
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onSubmit: jest.fn().mockResolvedValue(undefined),
+  familyMembers: mockFamilyMembers,
+  selectedDate: new Date('2024-01-15'),
+}
+
+describe('TaskForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Create Mode', () => {
+    it('renders with "New Quest" title', () => {
+      render(<TaskForm {...defaultProps} />)
+      expect(screen.getByText('New Quest')).toBeInTheDocument()
+    })
+
+    it('renders with "Create Quest" button', () => {
+      render(<TaskForm {...defaultProps} />)
+      expect(screen.getByRole('button', { name: 'Create Quest' })).toBeInTheDocument()
+    })
+
+    it('starts with empty form fields', () => {
+      render(<TaskForm {...defaultProps} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      expect(titleInput).toHaveValue('')
+
+      const descriptionInput = screen.getByPlaceholderText('Optional details...')
+      expect(descriptionInput).toHaveValue('')
+    })
+
+    it('calls onSubmit without taskId when creating', async () => {
+      const handleSubmit = jest.fn().mockResolvedValue(undefined)
+      render(<TaskForm {...defaultProps} onSubmit={handleSubmit} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      await userEvent.type(titleInput, 'New Task')
+
+      const submitButton = screen.getByRole('button', { name: 'Create Quest' })
+      await userEvent.click(submitButton)
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'New Task' }),
+          undefined
+        )
+      })
+    })
+
+    it('shows "Creating..." while submitting', async () => {
+      const handleSubmit = jest.fn().mockImplementation(() => new Promise(() => {}))
+      render(<TaskForm {...defaultProps} onSubmit={handleSubmit} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      await userEvent.type(titleInput, 'New Task')
+
+      const submitButton = screen.getByRole('button', { name: 'Create Quest' })
+      await userEvent.click(submitButton)
+
+      expect(screen.getByRole('button', { name: 'Creating...' })).toBeInTheDocument()
+    })
+
+    it('shows error message on create failure', async () => {
+      const handleSubmit = jest.fn().mockRejectedValue(new Error('Network error'))
+      render(<TaskForm {...defaultProps} onSubmit={handleSubmit} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      await userEvent.type(titleInput, 'New Task')
+
+      const submitButton = screen.getByRole('button', { name: 'Create Quest' })
+      await userEvent.click(submitButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Edit Mode', () => {
+    it('renders with "Edit Quest" title', () => {
+      render(<TaskForm {...defaultProps} task={mockTask} />)
+      expect(screen.getByText('Edit Quest')).toBeInTheDocument()
+    })
+
+    it('renders with "Save Changes" button', () => {
+      render(<TaskForm {...defaultProps} task={mockTask} />)
+      expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument()
+    })
+
+    it('pre-populates form with task data', () => {
+      render(<TaskForm {...defaultProps} task={mockTask} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      expect(titleInput).toHaveValue('Clean your room')
+
+      const descriptionInput = screen.getByPlaceholderText('Optional details...')
+      expect(descriptionInput).toHaveValue('Make bed and pick up toys')
+    })
+
+    it('pre-populates points select', () => {
+      render(<TaskForm {...defaultProps} task={mockTask} />)
+
+      const pointsSelect = screen.getByDisplayValue('20 points')
+      expect(pointsSelect).toBeInTheDocument()
+    })
+
+    it('pre-populates time of day select', () => {
+      render(<TaskForm {...defaultProps} task={mockTask} />)
+
+      const timeSelect = screen.getByDisplayValue('Morning')
+      expect(timeSelect).toBeInTheDocument()
+    })
+
+    it('pre-populates recurring select', () => {
+      render(<TaskForm {...defaultProps} task={mockTask} />)
+
+      const recurringSelect = screen.getByDisplayValue('Daily')
+      expect(recurringSelect).toBeInTheDocument()
+    })
+
+    it('calls onSubmit with taskId when editing', async () => {
+      const handleSubmit = jest.fn().mockResolvedValue(undefined)
+      render(<TaskForm {...defaultProps} task={mockTask} onSubmit={handleSubmit} />)
+
+      const submitButton = screen.getByRole('button', { name: 'Save Changes' })
+      await userEvent.click(submitButton)
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Clean your room' }),
+          'task-1'
+        )
+      })
+    })
+
+    it('shows "Saving..." while submitting', async () => {
+      const handleSubmit = jest.fn().mockImplementation(() => new Promise(() => {}))
+      render(<TaskForm {...defaultProps} task={mockTask} onSubmit={handleSubmit} />)
+
+      const submitButton = screen.getByRole('button', { name: 'Save Changes' })
+      await userEvent.click(submitButton)
+
+      expect(screen.getByRole('button', { name: 'Saving...' })).toBeInTheDocument()
+    })
+
+    it('shows error message on update failure', async () => {
+      const handleSubmit = jest.fn().mockRejectedValue(new Error('Update failed'))
+      render(<TaskForm {...defaultProps} task={mockTask} onSubmit={handleSubmit} />)
+
+      const submitButton = screen.getByRole('button', { name: 'Save Changes' })
+      await userEvent.click(submitButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Update failed')).toBeInTheDocument()
+      })
+    })
+
+    it('allows editing fields', async () => {
+      const handleSubmit = jest.fn().mockResolvedValue(undefined)
+      render(<TaskForm {...defaultProps} task={mockTask} onSubmit={handleSubmit} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      await userEvent.clear(titleInput)
+      await userEvent.type(titleInput, 'Updated Task Title')
+
+      const submitButton = screen.getByRole('button', { name: 'Save Changes' })
+      await userEvent.click(submitButton)
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Updated Task Title' }),
+          'task-1'
+        )
+      })
+    })
+  })
+
+  describe('Common Behavior', () => {
+    it('does not render when isOpen is false', () => {
+      render(<TaskForm {...defaultProps} isOpen={false} />)
+      expect(screen.queryByText('New Quest')).not.toBeInTheDocument()
+    })
+
+    it('calls onClose when Cancel button is clicked', async () => {
+      const handleClose = jest.fn()
+      render(<TaskForm {...defaultProps} onClose={handleClose} />)
+
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+      await userEvent.click(cancelButton)
+
+      expect(handleClose).toHaveBeenCalled()
+    })
+
+    it('disables submit button when title is empty', () => {
+      render(<TaskForm {...defaultProps} />)
+
+      const submitButton = screen.getByRole('button', { name: 'Create Quest' })
+      expect(submitButton).toBeDisabled()
+    })
+
+    it('enables submit button when title has value', async () => {
+      render(<TaskForm {...defaultProps} />)
+
+      const titleInput = screen.getByPlaceholderText('e.g., Clean your room')
+      await userEvent.type(titleInput, 'A task')
+
+      const submitButton = screen.getByRole('button', { name: 'Create Quest' })
+      expect(submitButton).not.toBeDisabled()
+    })
+
+    it('renders family members in assign dropdown', () => {
+      render(<TaskForm {...defaultProps} />)
+
+      expect(screen.getByRole('option', { name: 'Anyone' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Little T' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Parent' })).toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/components/tasks/task-list.test.tsx
+++ b/__tests__/components/tasks/task-list.test.tsx
@@ -37,14 +37,14 @@ const mockTasks: TaskWithAssignee[] = [
 
 describe('TaskList', () => {
   it('renders all tasks', () => {
-    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} />)
+    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} onEdit={jest.fn()} />)
 
     expect(screen.getByText('Clean room')).toBeInTheDocument()
     expect(screen.getByText('Do homework')).toBeInTheDocument()
   })
 
   it('shows empty message when no tasks', () => {
-    render(<TaskList tasks={[]} onComplete={jest.fn()} />)
+    render(<TaskList tasks={[]} onComplete={jest.fn()} onEdit={jest.fn()} />)
 
     expect(screen.getByText('No quests found')).toBeInTheDocument()
   })
@@ -54,6 +54,7 @@ describe('TaskList', () => {
       <TaskList
         tasks={[]}
         onComplete={jest.fn()}
+        onEdit={jest.fn()}
         emptyMessage="No tasks for today!"
       />
     )
@@ -62,9 +63,10 @@ describe('TaskList', () => {
   })
 
   it('renders correct number of task cards', () => {
-    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} />)
+    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} onEdit={jest.fn()} />)
 
+    // Each task has 2 buttons (complete checkbox and edit button)
     const taskTitles = screen.getAllByRole('button')
-    expect(taskTitles).toHaveLength(2)
+    expect(taskTitles).toHaveLength(4)
   })
 })

--- a/components/tasks/task-card.tsx
+++ b/components/tasks/task-card.tsx
@@ -8,9 +8,10 @@ import type { TaskWithAssignee } from '@/lib/types'
 interface TaskCardProps {
   task: TaskWithAssignee
   onComplete: (taskId: string) => Promise<void>
+  onEdit: (task: TaskWithAssignee) => void
 }
 
-export function TaskCard({ task, onComplete }: TaskCardProps) {
+export function TaskCard({ task, onComplete, onEdit }: TaskCardProps) {
   const [isCompleting, setIsCompleting] = useState(false)
   const [isCompleted, setIsCompleted] = useState(task.completed)
 
@@ -109,15 +110,26 @@ export function TaskCard({ task, onComplete }: TaskCardProps) {
           </div>
         </div>
 
-        {task.profiles && (
-          <div className="flex-shrink-0">
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {!isCompleted && (
+            <button
+              onClick={() => onEdit(task)}
+              className="p-1.5 text-gray-400 hover:text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+              title="Edit quest"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+              </svg>
+            </button>
+          )}
+          {task.profiles && (
             <Avatar
               src={task.profiles.avatar_url}
               fallback={task.profiles.nickname || task.profiles.display_name}
               size="sm"
             />
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   )

--- a/components/tasks/task-list.tsx
+++ b/components/tasks/task-list.tsx
@@ -6,11 +6,12 @@ import type { TaskWithAssignee } from '@/lib/types'
 interface TaskListProps {
   tasks: TaskWithAssignee[]
   onComplete: (taskId: string) => Promise<void>
+  onEdit: (task: TaskWithAssignee) => void
   emptyMessage?: string
   dateKey?: string
 }
 
-export function TaskList({ tasks, onComplete, emptyMessage = 'No quests found', dateKey }: TaskListProps) {
+export function TaskList({ tasks, onComplete, onEdit, emptyMessage = 'No quests found', dateKey }: TaskListProps) {
   if (tasks.length === 0) {
     return (
       <div className="text-center py-12">
@@ -27,7 +28,7 @@ export function TaskList({ tasks, onComplete, emptyMessage = 'No quests found', 
   return (
     <div className="space-y-3">
       {tasks.map((task) => (
-        <TaskCard key={`${task.id}-${dateKey || ''}`} task={task} onComplete={onComplete} />
+        <TaskCard key={`${task.id}-${dateKey || ''}`} task={task} onComplete={onComplete} onEdit={onEdit} />
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary

- Fix recurring tasks not appearing on future dates by querying tasks with `due_date <= selectedDate` instead of exact match
- Fix recurring task completion tracking to be per-date using a new `completion_date` column in `task_completions` table
- Add ability to edit existing tasks by clicking the pencil icon on task cards

## Changes

**Recurring Tasks Fixes:**
- Query recurring tasks that started on or before the selected date
- Filter weekly tasks by matching day of week
- Track completions per-date so recurring tasks can be completed independently each day

**Edit Task Feature:**
- Extended `TaskForm` to support both create and edit modes
- Added edit button (pencil icon) to `TaskCard` (hidden when task is completed)
- Form pre-populates with task data when editing
- Updates task via Supabase when saving changes

**Database Migration:**
- Added `completion_date` column to `task_completions` table for per-date tracking

## Test plan

- [x] Verify recurring daily tasks appear on future dates
- [x] Verify recurring weekly tasks appear only on matching days of week
- [x] Verify completing a recurring task on one day doesn't mark it complete on other days
- [x] Verify clicking edit button opens form with pre-populated data
- [x] Verify editing and saving a task updates it in the list
- [x] Verify edit button is hidden on completed tasks
- [x] All 82 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)