### PR TITLE
Fix invite code lookup failing due to RLS

### DIFF
--- a/app/(auth)/join/[code]/page.tsx
+++ b/app/(auth)/join/[code]/page.tsx
@@ -28,10 +28,8 @@ export default function JoinFamilyPage() {
       }
 
       const { data, error } = await supabase
-        .from('families')
-        .select('id, name')
-        .eq('invite_code', code)
-        .single()
+        .rpc('get_family_by_invite_code', { code })
+        .single<{ id: string; name: string }>()
 
       if (error || !data) {
         setError('Invalid or expired invite code')


### PR DESCRIPTION
Use the get_family_by_invite_code RPC function instead of querying the families table directly. The RPC function has SECURITY DEFINER which bypasses RLS, allowing unauthenticated users to validate invite codes.

Fixes #10