### PR TITLE
Add Google OAuth login

### DIFF
--- a/__tests__/app/auth/login.test.tsx
+++ b/__tests__/app/auth/login.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LoginPage from '@/app/(auth)/login/page'
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}))
+
+// Mock Supabase client
+const mockSignInWithPassword = jest.fn()
+const mockSignInWithOAuth = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      signInWithPassword: mockSignInWithPassword,
+      signInWithOAuth: mockSignInWithOAuth,
+    },
+  }),
+}))
+
+describe('Login Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders login form', () => {
+    render(<LoginPage />)
+
+    expect(screen.getByRole('heading', { name: /chore champions/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+  })
+
+  it('renders Google login button', () => {
+    render(<LoginPage />)
+
+    expect(screen.getByText(/or continue with/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
+  })
+
+  it('calls signInWithOAuth when Google button is clicked', async () => {
+    mockSignInWithOAuth.mockResolvedValue({ error: null })
+    render(<LoginPage />)
+
+    const googleButton = screen.getByRole('button', { name: /google/i })
+    await userEvent.click(googleButton)
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: expect.stringContaining('/auth/callback'),
+      },
+    })
+  })
+
+  it('shows error when Google login fails', async () => {
+    mockSignInWithOAuth.mockResolvedValue({
+      error: { message: 'Google login failed' }
+    })
+    render(<LoginPage />)
+
+    const googleButton = screen.getByRole('button', { name: /google/i })
+    await userEvent.click(googleButton)
+
+    expect(await screen.findByText(/google login failed/i)).toBeInTheDocument()
+  })
+
+  it('calls signInWithPassword on form submit', async () => {
+    mockSignInWithPassword.mockResolvedValue({ error: null })
+    render(<LoginPage />)
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'test@example.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+
+    expect(mockSignInWithPassword).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      password: 'password123',
+    })
+  })
+})

--- a/__tests__/app/auth/signup.test.tsx
+++ b/__tests__/app/auth/signup.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SignupPage from '@/app/(auth)/signup/page'
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}))
+
+// Mock Supabase client
+const mockSignUp = jest.fn()
+const mockSignInWithOAuth = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      signUp: mockSignUp,
+      signInWithOAuth: mockSignInWithOAuth,
+    },
+  }),
+}))
+
+describe('Signup Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders signup form', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByRole('heading', { name: /chore champions/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument()
+  })
+
+  it('renders Google signup button', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByText(/or continue with/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
+  })
+
+  it('calls signInWithOAuth when Google button is clicked', async () => {
+    mockSignInWithOAuth.mockResolvedValue({ error: null })
+    render(<SignupPage />)
+
+    const googleButton = screen.getByRole('button', { name: /google/i })
+    await userEvent.click(googleButton)
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: expect.stringContaining('/auth/callback'),
+      },
+    })
+  })
+
+  it('shows error when Google signup fails', async () => {
+    mockSignInWithOAuth.mockResolvedValue({
+      error: { message: 'Google signup failed' }
+    })
+    render(<SignupPage />)
+
+    const googleButton = screen.getByRole('button', { name: /google/i })
+    await userEvent.click(googleButton)
+
+    expect(await screen.findByText(/google signup failed/i)).toBeInTheDocument()
+  })
+
+  it('calls signUp on form submit', async () => {
+    mockSignUp.mockResolvedValue({ error: null })
+    render(<SignupPage />)
+
+    await userEvent.type(screen.getByLabelText(/display name/i), 'Test User')
+    await userEvent.type(screen.getByLabelText(/email/i), 'test@example.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    expect(mockSignUp).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      password: 'password123',
+      options: {
+        data: {
+          display_name: 'Test User',
+        },
+      },
+    })
+  })
+})

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -10,8 +10,26 @@ export default function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [socialLoading, setSocialLoading] = useState(false)
   const router = useRouter()
   const supabase = createClient()
+
+  async function handleGoogleLogin() {
+    setSocialLoading(true)
+    setError(null)
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      setError(error.message)
+      setSocialLoading(false)
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -80,12 +98,49 @@ export default function LoginPage() {
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || socialLoading}
             className="w-full bg-purple-600 text-white py-3 rounded-lg font-semibold hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
           >
             {loading ? 'Signing in...' : 'Sign In'}
           </button>
         </form>
+
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-white text-gray-500">Or continue with</span>
+            </div>
+          </div>
+
+          <button
+            onClick={handleGoogleLogin}
+            disabled={loading || socialLoading}
+            className="mt-4 w-full flex items-center justify-center gap-3 bg-white border border-gray-300 text-gray-700 py-3 rounded-lg font-semibold hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24">
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            {socialLoading ? 'Connecting...' : 'Google'}
+          </button>
+        </div>
 
         <p className="text-center text-gray-600 mt-6">
           Don&apos;t have an account?{' '}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -11,8 +11,26 @@ export default function SignupPage() {
   const [displayName, setDisplayName] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [socialLoading, setSocialLoading] = useState(false)
   const router = useRouter()
   const supabase = createClient()
+
+  async function handleGoogleSignup() {
+    setSocialLoading(true)
+    setError(null)
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      setError(error.message)
+      setSocialLoading(false)
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -103,12 +121,49 @@ export default function SignupPage() {
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || socialLoading}
             className="w-full bg-purple-600 text-white py-3 rounded-lg font-semibold hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
           >
             {loading ? 'Creating account...' : 'Create Account'}
           </button>
         </form>
+
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-white text-gray-500">Or continue with</span>
+            </div>
+          </div>
+
+          <button
+            onClick={handleGoogleSignup}
+            disabled={loading || socialLoading}
+            className="mt-4 w-full flex items-center justify-center gap-3 bg-white border border-gray-300 text-gray-700 py-3 rounded-lg font-semibold hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24">
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            {socialLoading ? 'Connecting...' : 'Google'}
+          </button>
+        </div>
 
         <p className="text-center text-gray-600 mt-6">
           Already have an account?{' '}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextResponse } from 'next/server'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/quests'
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`)
+    }
+  }
+
+  // Return to login page with error
+  return NextResponse.redirect(`${origin}/login?error=auth_failed`)
+}

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -11,6 +11,13 @@ test.describe('Login Page', () => {
     await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible()
   })
 
+  test('displays Google login button', async ({ page }) => {
+    await page.goto('/login')
+
+    await expect(page.getByText(/or continue with/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
+  })
+
   test('has link to signup', async ({ page }) => {
     await page.goto('/login')
 
@@ -44,6 +51,13 @@ test.describe('Signup Page', () => {
     await expect(page.getByLabel(/email/i)).toBeVisible()
     await expect(page.getByLabel(/password/i)).toBeVisible()
     await expect(page.getByRole('button', { name: /create account/i })).toBeVisible()
+  })
+
+  test('displays Google signup button', async ({ page }) => {
+    await page.goto('/signup')
+
+    await expect(page.getByText(/or continue with/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
   })
 
   test('has link to login', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9134,7 +9134,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

Add Google OAuth as a login option on both login and signup pages.

## Changes

- Add `/auth/callback` route to handle OAuth redirects
- Add Google sign-in button to login page
- Add Google sign-up button to signup page
- Add unit tests for auth pages (10 new tests)
- Add E2E tests for Google button visibility (2 new tests)

## Setup Required

To enable Google login, configure in Supabase Dashboard:
1. **Authentication → Providers → Google**
2. Add Client ID and Client Secret from Google Cloud Console
3. Add redirect URI in Google Cloud: `https://eebssnhneusiyuffoajj.supabase.co/auth/v1/callback`
4. Add site URL in Supabase: **Authentication → URL Configuration**

Partially addresses #13 (Facebook and Phone still to be added)

## Test plan

- [x] TypeScript passes
- [x] 92 unit tests pass
- [x] 20 E2E tests pass
- [ ] Manual test: Click Google button, complete OAuth flow, verify login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)