### PR TITLE
Redesign Me page with editorial style

### DIFF
--- a/__tests__/app/dashboard/me.test.tsx
+++ b/__tests__/app/dashboard/me.test.tsx
@@ -88,11 +88,19 @@ describe('Me Page', () => {
     expect(document.querySelector('.animate-spin')).toBeInTheDocument()
   })
 
+  it('renders page header with My Profile title', async () => {
+    render(<MePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
+    })
+  })
+
   it('renders profile with role selector', async () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     expect(screen.getByText('Role')).toBeInTheDocument()
@@ -104,7 +112,7 @@ describe('Me Page', () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     const kidButton = screen.getByRole('button', { name: 'Kid' })
@@ -118,7 +126,7 @@ describe('Me Page', () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     expect(screen.getByText(/only parent/i)).toBeInTheDocument()
@@ -136,7 +144,7 @@ describe('Me Page', () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     expect(screen.queryByText(/only parent/i)).not.toBeInTheDocument()
@@ -149,7 +157,7 @@ describe('Me Page', () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     const kidButton = screen.getByRole('button', { name: 'Kid' })
@@ -164,41 +172,16 @@ describe('Me Page', () => {
     expect(parentButton).not.toBeDisabled()
   })
 
-  it('displays points in header', async () => {
+  it('renders section headers', async () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('100')).toBeInTheDocument()
-    expect(screen.getByText('points')).toBeInTheDocument()
-  })
-
-  it('displays role badge in header', async () => {
-    render(<MePage />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
-    })
-
-    // Role badge has specific styling class
-    const badge = document.querySelector('.bg-gray-100.rounded-full')
-    expect(badge).toHaveTextContent('Kid')
-  })
-
-  it('displays Parent badge for parent role', async () => {
-    mockSupabaseData.profile = { ...mockProfile, role: 'parent' }
-
-    render(<MePage />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
-    })
-
-    // Role badge has specific styling class
-    const badge = document.querySelector('.bg-gray-100.rounded-full')
-    expect(badge).toHaveTextContent('Parent')
+    // Section headers have uppercase CSS class but DOM text is title case
+    expect(screen.getByText('Personal Info')).toBeInTheDocument()
+    expect(screen.getByText('Role')).toBeInTheDocument()
   })
 
   it('opens avatar modal when avatar is clicked', async () => {
@@ -206,12 +189,11 @@ describe('Me Page', () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
-    // Find avatar button by the "Change" text inside it
-    const changeText = screen.getByText('Change')
-    const avatarButton = changeText.closest('button')!
+    // Find avatar button by aria-label
+    const avatarButton = screen.getByRole('button', { name: 'Change avatar' })
     await user.click(avatarButton)
 
     expect(screen.getByText('Choose Avatar')).toBeInTheDocument()
@@ -221,7 +203,7 @@ describe('Me Page', () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     expect(screen.getByText('Display Name')).toBeInTheDocument()
@@ -229,34 +211,33 @@ describe('Me Page', () => {
     expect(screen.getByDisplayValue('Test User')).toBeInTheDocument()
   })
 
-  it('renders centered Save Changes button', async () => {
+  it('renders Save Changes button', async () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
-    const saveButton = screen.getByRole('button', { name: 'Save Changes' })
-    expect(saveButton).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument()
   })
 
   it('renders Sign Out button', async () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Test User')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
 
     expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument()
   })
 
-  it('displays nickname when available', async () => {
-    mockSupabaseData.profile = { ...mockProfile, nickname: 'Cool Kid' }
-
+  it('displays "Tap to change avatar" caption under avatar', async () => {
     render(<MePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Cool Kid')).toBeInTheDocument()
+      expect(screen.getByText('My Profile')).toBeInTheDocument()
     })
+
+    expect(screen.getByText('Tap to change avatar')).toBeInTheDocument()
   })
 })

--- a/__tests__/components/ui/avatar.test.tsx
+++ b/__tests__/components/ui/avatar.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import { Avatar } from '@/components/ui/avatar'
+
+// Mock next/image
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => <img alt={props.alt} src={props.src} />,
+}))
+
+describe('Avatar', () => {
+  it('renders with image when src is provided', () => {
+    render(<Avatar src="/avatar.png" alt="User avatar" />)
+
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('src', '/avatar.png')
+    expect(img).toHaveAttribute('alt', 'User avatar')
+  })
+
+  it('renders fallback initials when no src', () => {
+    render(<Avatar fallback="John Doe" />)
+
+    expect(screen.getByText('JD')).toBeInTheDocument()
+  })
+
+  it('renders question mark when no src or fallback', () => {
+    render(<Avatar />)
+
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
+  it('applies sm size classes', () => {
+    const { container } = render(<Avatar size="sm" fallback="A" />)
+
+    expect(container.firstChild).toHaveClass('h-8', 'w-8')
+  })
+
+  it('applies md size classes (default)', () => {
+    const { container } = render(<Avatar fallback="A" />)
+
+    expect(container.firstChild).toHaveClass('h-10', 'w-10')
+  })
+
+  it('applies lg size classes', () => {
+    const { container } = render(<Avatar size="lg" fallback="A" />)
+
+    expect(container.firstChild).toHaveClass('h-12', 'w-12')
+  })
+
+  it('applies xl size classes', () => {
+    const { container } = render(<Avatar size="xl" fallback="A" />)
+
+    expect(container.firstChild).toHaveClass('h-16', 'w-16')
+  })
+
+  it('applies 2xl size classes', () => {
+    const { container } = render(<Avatar size="2xl" fallback="A" />)
+
+    expect(container.firstChild).toHaveClass('h-28', 'w-28')
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<Avatar fallback="A" className="custom-class" />)
+
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('has rounded-full class for circular shape', () => {
+    const { container } = render(<Avatar fallback="A" />)
+
+    expect(container.firstChild).toHaveClass('rounded-full')
+  })
+})

--- a/__tests__/components/ui/button.test.tsx
+++ b/__tests__/components/ui/button.test.tsx
@@ -52,4 +52,35 @@ describe('Button', () => {
     rerender(<Button size="lg">Large</Button>)
     expect(screen.getByRole('button')).toHaveClass('px-6')
   })
+
+  it('shows loading state with spinner', () => {
+    render(<Button loading>Save</Button>)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeDisabled()
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+    expect(button.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('shows success state with checkmark', () => {
+    render(<Button success>Save</Button>)
+
+    const button = screen.getByRole('button')
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('loading state takes precedence over success', () => {
+    render(<Button loading success>Save</Button>)
+
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+  })
+
+  it('is disabled when loading', async () => {
+    const handleClick = jest.fn()
+    render(<Button loading onClick={handleClick}>Save</Button>)
+
+    await userEvent.click(screen.getByRole('button'))
+    expect(handleClick).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/components/ui/underline-input.test.tsx
+++ b/__tests__/components/ui/underline-input.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { UnderlineInput } from '@/components/ui/underline-input'
+
+describe('UnderlineInput', () => {
+  it('renders with label', () => {
+    render(<UnderlineInput label="Email" value="" onChange={() => {}} />)
+
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('shows required indicator when required', () => {
+    render(<UnderlineInput label="Email" value="" onChange={() => {}} required />)
+
+    expect(screen.getByText('*')).toBeInTheDocument()
+  })
+
+  it('does not show required indicator when not required', () => {
+    render(<UnderlineInput label="Email" value="" onChange={() => {}} />)
+
+    expect(screen.queryByText('*')).not.toBeInTheDocument()
+  })
+
+  it('displays helper text when provided', () => {
+    render(
+      <UnderlineInput
+        label="Nickname"
+        value=""
+        onChange={() => {}}
+        helperText="A fun name to display"
+      />
+    )
+
+    expect(screen.getByText('A fun name to display')).toBeInTheDocument()
+  })
+
+  it('displays placeholder when provided', () => {
+    render(
+      <UnderlineInput
+        label="Name"
+        value=""
+        onChange={() => {}}
+        placeholder="Enter your name"
+      />
+    )
+
+    expect(screen.getByPlaceholderText('Enter your name')).toBeInTheDocument()
+  })
+
+  it('calls onChange when typing', async () => {
+    const handleChange = jest.fn()
+    const user = userEvent.setup()
+
+    render(<UnderlineInput label="Name" value="" onChange={handleChange} />)
+
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'John')
+
+    expect(handleChange).toHaveBeenCalled()
+  })
+
+  it('generates id from label', () => {
+    render(<UnderlineInput label="Display Name" value="" onChange={() => {}} />)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute('id', 'display-name')
+  })
+
+  it('uses provided id over generated one', () => {
+    render(<UnderlineInput label="Display Name" id="custom-id" value="" onChange={() => {}} />)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute('id', 'custom-id')
+  })
+
+  it('displays current value', () => {
+    render(<UnderlineInput label="Name" value="John Doe" onChange={() => {}} />)
+
+    expect(screen.getByDisplayValue('John Doe')).toBeInTheDocument()
+  })
+})

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -6,7 +6,7 @@ export interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
   src?: string | null
   alt?: string
   fallback?: string
-  size?: 'sm' | 'md' | 'lg' | 'xl'
+  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'
 }
 
 const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
@@ -16,6 +16,7 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
       md: 'h-10 w-10 text-sm',
       lg: 'h-12 w-12 text-base',
       xl: 'h-16 w-16 text-lg',
+      '2xl': 'h-28 w-28 text-xl',
     }
 
     const imageSizes = {
@@ -23,6 +24,7 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
       md: 40,
       lg: 48,
       xl: 64,
+      '2xl': 112,
     }
 
     return (

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,16 +4,60 @@ import { cn } from '@/lib/utils'
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'ghost' | 'danger'
   size?: 'sm' | 'md' | 'lg'
+  loading?: boolean
+  success?: boolean
 }
 
+const Spinner = () => (
+  <svg
+    className="animate-spin h-5 w-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+    />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+    />
+  </svg>
+)
+
+const Checkmark = () => (
+  <svg
+    className="h-5 w-5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={2.5}
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M4.5 12.75l6 6 9-13.5"
+    />
+  </svg>
+)
+
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'primary', size = 'md', disabled, ...props }, ref) => {
+  ({ className, variant = 'primary', size = 'md', disabled, loading, success, children, ...props }, ref) => {
+    const isDisabled = disabled || loading
+
     return (
       <button
         ref={ref}
-        disabled={disabled}
+        disabled={isDisabled}
         className={cn(
-          'inline-flex items-center justify-center rounded-lg font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed',
+          'inline-flex items-center justify-center gap-2 rounded-lg font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed',
           {
             'bg-purple-600 text-white hover:bg-purple-700 focus:ring-purple-500':
               variant === 'primary',
@@ -32,7 +76,21 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           className
         )}
         {...props}
-      />
+      >
+        {loading ? (
+          <>
+            <Spinner />
+            <span>Saving...</span>
+          </>
+        ) : success ? (
+          <>
+            <Checkmark />
+            <span>Saved</span>
+          </>
+        ) : (
+          children
+        )}
+      </button>
     )
   }
 )

--- a/components/ui/sticky-footer.tsx
+++ b/components/ui/sticky-footer.tsx
@@ -1,0 +1,63 @@
+// TODO: Might use this component later for edit pages with Cancel/Save actions
+// Uncomment and add tests when needed
+
+/*
+'use client'
+
+import { cn } from '@/lib/utils'
+import { Button, ButtonProps } from './button'
+
+export interface StickyFooterProps {
+  onCancel: () => void
+  onSave: () => void
+  cancelLabel?: string
+  saveLabel?: string
+  saving?: boolean
+  saveSuccess?: boolean
+  disabled?: boolean
+  className?: string
+}
+
+export function StickyFooter({
+  onCancel,
+  onSave,
+  cancelLabel = 'Cancel',
+  saveLabel = 'Save',
+  saving = false,
+  saveSuccess = false,
+  disabled = false,
+  className,
+}: StickyFooterProps) {
+  return (
+    <footer
+      className={cn(
+        'sticky bottom-0 z-40 bg-white border-t border-gray-100',
+        'px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]',
+        className
+      )}
+    >
+      <div className="flex gap-3 max-w-md mx-auto">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onCancel}
+          className="flex-1 h-14"
+        >
+          {cancelLabel}
+        </Button>
+        <Button
+          type="submit"
+          variant="primary"
+          onClick={onSave}
+          loading={saving}
+          success={saveSuccess}
+          disabled={disabled || saving}
+          className="flex-1 h-14"
+        >
+          {saveLabel}
+        </Button>
+      </div>
+    </footer>
+  )
+}
+*/

--- a/components/ui/sticky-header.tsx
+++ b/components/ui/sticky-header.tsx
@@ -1,0 +1,68 @@
+// TODO: Might use this component later for sub-pages with back navigation
+// Uncomment and add tests when needed
+
+/*
+'use client'
+
+import { ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+export interface StickyHeaderProps {
+  title: string
+  onBack?: () => void
+  rightContent?: ReactNode
+  className?: string
+}
+
+export function StickyHeader({ title, onBack, rightContent, className }: StickyHeaderProps) {
+  const router = useRouter()
+
+  const handleBack = () => {
+    if (onBack) {
+      onBack()
+    } else {
+      router.back()
+    }
+  }
+
+  return (
+    <header
+      className={cn(
+        'sticky top-0 z-40 bg-white border-b border-gray-100',
+        'flex items-center justify-between px-4 py-3',
+        className
+      )}
+    >
+      <button
+        onClick={handleBack}
+        className="p-2 -ml-2 text-gray-600 hover:text-gray-900 transition-colors"
+        aria-label="Go back"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 19.5L8.25 12l7.5-7.5"
+          />
+        </svg>
+      </button>
+
+      <h1 className="text-base font-semibold text-gray-900 absolute left-1/2 -translate-x-1/2">
+        {title}
+      </h1>
+
+      <div className="w-9">
+        {rightContent}
+      </div>
+    </header>
+  )
+}
+*/

--- a/components/ui/underline-input.tsx
+++ b/components/ui/underline-input.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { forwardRef, InputHTMLAttributes, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+export interface UnderlineInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
+  label: string
+  helperText?: string
+}
+
+const UnderlineInput = forwardRef<HTMLInputElement, UnderlineInputProps>(
+  ({ label, helperText, required, id, ...props }, ref) => {
+    const [isFocused, setIsFocused] = useState(false)
+    const inputId = id || label.toLowerCase().replace(/\s+/g, '-')
+
+    return (
+      <div className="relative">
+        <label
+          htmlFor={inputId}
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {label}
+          {required && <span className="text-red-500 ml-1">*</span>}
+        </label>
+        <div className="relative">
+          <input
+            ref={ref}
+            id={inputId}
+            required={required}
+            onFocus={(e) => {
+              setIsFocused(true)
+              props.onFocus?.(e)
+            }}
+            onBlur={(e) => {
+              setIsFocused(false)
+              props.onBlur?.(e)
+            }}
+            className={cn(
+              'w-full py-2 px-0 text-gray-900 bg-transparent border-0 border-b border-gray-200',
+              'focus:outline-none focus:ring-0',
+              'placeholder:text-gray-400',
+              'transition-colors duration-300'
+            )}
+            {...props}
+          />
+          {/* Animated underline */}
+          <div
+            className={cn(
+              'absolute bottom-0 left-1/2 h-0.5 bg-purple-600',
+              'transition-all duration-300 ease-out',
+              isFocused ? 'w-full -translate-x-1/2' : 'w-0 -translate-x-1/2'
+            )}
+          />
+        </div>
+        {helperText && (
+          <p className="mt-1 text-xs text-gray-500">{helperText}</p>
+        )}
+      </div>
+    )
+  }
+)
+
+UnderlineInput.displayName = 'UnderlineInput'
+
+export { UnderlineInput }

--- a/e2e/me.spec.ts
+++ b/e2e/me.spec.ts
@@ -12,36 +12,63 @@ test.describe('Me Page', () => {
   test.describe('Authenticated', () => {
     test.skip(({ browserName }) => true, 'Requires authentication setup')
 
-    test('displays profile header with avatar, name, and points', async ({ page }) => {
+    test('displays page header with My Profile title', async ({ page }) => {
       await page.goto('/me')
 
-      // Header should have horizontal layout with avatar on left
-      await expect(page.locator('header')).toBeVisible()
-
-      // Avatar should be visible and clickable
-      const avatarButton = page.locator('header button').first()
-      await expect(avatarButton).toBeVisible()
-
-      // Name should be displayed
-      await expect(page.locator('header h1')).toBeVisible()
-
-      // Points should be displayed
-      await expect(page.getByText('points')).toBeVisible()
+      // Header should be visible with title
+      await expect(page.getByText('My Profile')).toBeVisible()
     })
 
-    test('displays profile form with two-column layout', async ({ page }) => {
+    test('displays avatar section with change photo caption', async ({ page }) => {
+      await page.goto('/me')
+
+      // Avatar button should be visible
+      const avatarButton = page.getByRole('button', { name: 'Change avatar' })
+      await expect(avatarButton).toBeVisible()
+
+      // Caption should be visible
+      await expect(page.getByText('Tap to change avatar')).toBeVisible()
+    })
+
+    test('avatar shows edit overlay on hover', async ({ page }) => {
+      await page.goto('/me')
+
+      const avatarButton = page.getByRole('button', { name: 'Change avatar' })
+
+      // Edit overlay should be hidden initially
+      const overlay = avatarButton.locator('span.opacity-0')
+      await expect(overlay).toBeVisible()
+
+      // Hover over avatar
+      await avatarButton.hover()
+
+      // Overlay should become visible (opacity changes via group-hover)
+      await expect(avatarButton.locator('span.group-hover\\:opacity-100')).toBeVisible()
+    })
+
+    test('displays section headers', async ({ page }) => {
+      await page.goto('/me')
+
+      // Section headers should be visible (CSS transforms to uppercase)
+      await expect(page.getByText('Personal Info')).toBeVisible()
+      await expect(page.getByText('Role')).toBeVisible()
+    })
+
+    test('displays form with underline inputs', async ({ page }) => {
       await page.goto('/me')
 
       // Form fields should be visible
       await expect(page.getByText('Display Name')).toBeVisible()
       await expect(page.getByText('Nickname')).toBeVisible()
-      await expect(page.getByText('Role')).toBeVisible()
 
       // Role selector buttons
       await expect(page.getByRole('button', { name: 'Parent' })).toBeVisible()
       await expect(page.getByRole('button', { name: 'Kid' })).toBeVisible()
+    })
 
-      // Save button should be centered
+    test('displays Save Changes button', async ({ page }) => {
+      await page.goto('/me')
+
       await expect(page.getByRole('button', { name: 'Save Changes' })).toBeVisible()
     })
 
@@ -49,7 +76,7 @@ test.describe('Me Page', () => {
       await page.goto('/me')
 
       // Click the avatar button
-      const avatarButton = page.locator('header button').first()
+      const avatarButton = page.getByRole('button', { name: 'Change avatar' })
       await avatarButton.click()
 
       // Modal should open
@@ -60,13 +87,19 @@ test.describe('Me Page', () => {
       await page.goto('/me')
 
       // Open modal
-      const avatarButton = page.locator('header button').first()
+      const avatarButton = page.getByRole('button', { name: 'Change avatar' })
       await avatarButton.click()
       await expect(page.getByText('Choose Avatar')).toBeVisible()
 
-      // Close modal (click outside or close button)
+      // Close modal (press Escape)
       await page.keyboard.press('Escape')
       await expect(page.getByText('Choose Avatar')).not.toBeVisible()
+    })
+
+    test('sign out button is visible', async ({ page }) => {
+      await page.goto('/me')
+
+      await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible()
     })
 
     test('role selector is interactive', async ({ page }) => {
@@ -84,18 +117,30 @@ test.describe('Me Page', () => {
       await expect(kidButton).toHaveClass(/bg-purple-600/)
     })
 
-    test('sign out button is visible', async ({ page }) => {
+    test('underline inputs have animated focus effect', async ({ page }) => {
       await page.goto('/me')
 
-      await expect(page.getByRole('button', { name: 'Sign Out' })).toBeVisible()
+      // Focus on display name input
+      const displayNameInput = page.locator('input[id="display-name"]')
+
+      // Underline should start with width 0
+      const underline = page.locator('input[id="display-name"] + div')
+      await expect(underline).toHaveClass(/w-0/)
+
+      // Focus the input
+      await displayNameInput.focus()
+
+      // The animated underline should expand to full width
+      await expect(underline).toHaveClass(/w-full/)
+      await expect(underline).toHaveClass(/bg-purple-600/)
     })
 
-    test('displays role badge in header', async ({ page }) => {
+    test('page has mobile-first max-width container', async ({ page }) => {
       await page.goto('/me')
 
-      // Role badge should show either Parent or Kid
-      const badge = page.locator('.bg-gray-100.rounded-full')
-      await expect(badge).toBeVisible()
+      // Main content should have max-w-md class (448px)
+      const container = page.locator('main .max-w-md')
+      await expect(container).toBeVisible()
     })
   })
 })


### PR DESCRIPTION
## Summary
- Redesign Me page with minimalist editorial style
- Add UnderlineInput component with animated purple focus effect
- Add 2xl size (112px) to Avatar component
- Add loading/success props to Button with spinner and checkmark states

## Changes
- **Me page**: "My Profile" header, large centered avatar with edit overlay, uppercase section headers, underline-style inputs, mobile-first layout
- **UnderlineInput**: New component with animated focus effect
- **Button**: Added `loading` and `success` props
- **Avatar**: Added `2xl` size
- **StickyHeader/StickyFooter**: Created but commented out for future use

## Test plan
- [x] Unit tests pass (150 tests)
- [x] E2E tests pass (24 passed, 13 skipped - require auth)
- [x] Avatar edit overlay shows on hover
- [x] Underline inputs animate on focus
- [x] Save button shows loading/success states
- [x] Sign Out button works

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)