### PR TITLE
Add ability to undo task completions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,16 @@ lib/
 
 ## Git Workflow
 
+- **Always start from updated main:** `git checkout main && git pull` before creating a new branch
 - Each bug/feature gets its own branch linked to the GitHub issue (e.g., `fix/issue-10-invite-code`, `feature/issue-5-delete-task`)
 - Never commit directly to main
 - Open a PR for review, reference the issue number
 - Only merge after CI passes
+
+## Architecture Decision Records
+
+- ADRs document design decisions for features
+- Located in `docs/adr/`
+- Each feature should have its own ADR with Mermaid diagram
+- Use `docs/adr/000-template.md` as starting point
+- Reference the GitHub issue number in each ADR

--- a/__tests__/components/tasks/task-list.test.tsx
+++ b/__tests__/components/tasks/task-list.test.tsx
@@ -37,14 +37,14 @@ const mockTasks: TaskWithAssignee[] = [
 
 describe('TaskList', () => {
   it('renders all tasks', () => {
-    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} onEdit={jest.fn()} />)
+    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} onUncomplete={jest.fn()} onEdit={jest.fn()} />)
 
     expect(screen.getByText('Clean room')).toBeInTheDocument()
     expect(screen.getByText('Do homework')).toBeInTheDocument()
   })
 
   it('shows empty message when no tasks', () => {
-    render(<TaskList tasks={[]} onComplete={jest.fn()} onEdit={jest.fn()} />)
+    render(<TaskList tasks={[]} onComplete={jest.fn()} onUncomplete={jest.fn()} onEdit={jest.fn()} />)
 
     expect(screen.getByText('No quests found')).toBeInTheDocument()
   })
@@ -54,6 +54,7 @@ describe('TaskList', () => {
       <TaskList
         tasks={[]}
         onComplete={jest.fn()}
+        onUncomplete={jest.fn()}
         onEdit={jest.fn()}
         emptyMessage="No tasks for today!"
       />
@@ -63,7 +64,7 @@ describe('TaskList', () => {
   })
 
   it('renders correct number of task cards', () => {
-    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} onEdit={jest.fn()} />)
+    render(<TaskList tasks={mockTasks} onComplete={jest.fn()} onUncomplete={jest.fn()} onEdit={jest.fn()} />)
 
     // Each task has 2 buttons (complete checkbox and edit button)
     const taskTitles = screen.getAllByRole('button')

--- a/components/tasks/task-list.tsx
+++ b/components/tasks/task-list.tsx
@@ -6,12 +6,13 @@ import type { TaskWithAssignee } from '@/lib/types'
 interface TaskListProps {
   tasks: TaskWithAssignee[]
   onComplete: (taskId: string) => Promise<void>
+  onUncomplete: (taskId: string) => Promise<void>
   onEdit: (task: TaskWithAssignee) => void
   emptyMessage?: string
   dateKey?: string
 }
 
-export function TaskList({ tasks, onComplete, onEdit, emptyMessage = 'No quests found', dateKey }: TaskListProps) {
+export function TaskList({ tasks, onComplete, onUncomplete, onEdit, emptyMessage = 'No quests found', dateKey }: TaskListProps) {
   if (tasks.length === 0) {
     return (
       <div className="text-center py-12">
@@ -28,7 +29,7 @@ export function TaskList({ tasks, onComplete, onEdit, emptyMessage = 'No quests 
   return (
     <div className="space-y-3">
       {tasks.map((task) => (
-        <TaskCard key={`${task.id}-${dateKey || ''}`} task={task} onComplete={onComplete} onEdit={onEdit} />
+        <TaskCard key={`${task.id}-${dateKey || ''}`} task={task} onComplete={onComplete} onUncomplete={onUncomplete} onEdit={onEdit} />
       ))}
     </div>
   )

--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,42 @@
+# ADR-NNN: Feature Name
+
+**Status:** Proposed | Accepted | Deprecated | Superseded
+**Issue:** #NNN
+**Date:** YYYY-MM-DD
+
+## Context
+
+What is the problem or requirement? Why are we making this decision?
+
+## Decision
+
+What did we decide to do? Include key design choices.
+
+## Consequences
+
+### Positive
+- Benefit 1
+- Benefit 2
+
+### Negative
+- Trade-off 1
+- Trade-off 2
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Component
+    participant Database
+
+    User->>Component: Action
+    Component->>Database: Query
+    Database-->>Component: Result
+    Component-->>User: Response
+```
+
+## Implementation
+
+Key files and changes:
+- `path/to/file.tsx` - Description of change

--- a/docs/adr/001-undo-task.md
+++ b/docs/adr/001-undo-task.md
@@ -1,0 +1,76 @@
+# ADR-001: Undo Task
+
+**Status:** Accepted
+**Issue:** #7
+**Date:** 2026-02-09
+
+## Context
+
+Users need the ability to undo task completions when they accidentally mark a task as done, or when circumstances change. Currently, once a task is marked complete, there's no way to revert it.
+
+Key requirements:
+- Allow undoing task completions
+- Deduct points when undoing
+- Consider permission model for family members
+
+## Decision
+
+### Permission Model
+- **No time limit** on undoing completions
+- **Parents can undo any** family member's completions (full oversight)
+- **Kids can only undo their own** completions (prevents gaming the system)
+
+### Database Approach
+- Use **RLS (Row Level Security) policy** on `task_completions` table for DELETE operations
+- Create a **database trigger** to automatically deduct points when a completion is deleted
+- Points floor at 0 (never go negative) using `GREATEST(points - OLD.points_earned, 0)`
+
+### UI Approach
+- **Clickable green checkmark** - no separate undo button
+- **Hover hint** with `title="Click to undo"` for discoverability
+- **Spinner state** during uncomplete operation (same as complete)
+- Edit button **reappears** after uncompleting
+
+### Recurring vs Non-Recurring Tasks
+- **Non-recurring:** Set `tasks.completed = false` AND delete `task_completions` record
+- **Recurring:** Only delete `task_completions` record matching `task_id` AND `completion_date` (task row stays unchanged since it can be completed on other days)
+
+## Consequences
+
+### Positive
+- Simple, intuitive UI (click checkmark to toggle)
+- Consistent with common UX patterns (undo by clicking again)
+- Database trigger ensures points are always correctly deducted
+- RLS policy enforces permissions at database level (secure)
+
+### Negative
+- No undo confirmation dialog (could add later if users accidentally undo)
+- No audit trail of undo actions (only completion records exist while active)
+- Parents have full control which may not suit all family dynamics
+
+## Diagram
+
+```mermaid
+flowchart TD
+    A[User clicks green checkmark] --> B{Task recurring?}
+    B -->|No| C[Set task.completed = false]
+    B -->|Yes| D[Skip task update]
+    C --> E[Delete task_completion record]
+    D --> E
+    E --> F{RLS Policy Check}
+    F -->|Parent| G[Allowed: can undo any family task]
+    F -->|Kid + own task| G
+    F -->|Kid + other's task| H[Denied: operation fails]
+    G --> I[Trigger: Deduct points from profile]
+    I --> J[Refresh UI]
+    J --> K[Checkmark reverts to empty circle]
+```
+
+## Implementation
+
+Key files:
+- `supabase/migrations/004_deduct_points_on_delete.sql` - RLS policy + trigger
+- `components/tasks/task-card.tsx` - Added `onUncomplete` prop and click handler
+- `components/tasks/task-list.tsx` - Pass through `onUncomplete` prop
+- `app/(dashboard)/quests/page.tsx` - `handleUncompleteTask` function
+- `__tests__/components/tasks/task-card.test.tsx` - Unit tests for undo

--- a/e2e/quests.spec.ts
+++ b/e2e/quests.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Quests Page', () => {
+  // These tests require authentication which we skip in CI
+  // They verify the complete/undo flow works correctly
+
+  test.skip('complete and undo task flow', async ({ page }) => {
+    // This test requires a logged-in user with a family and tasks
+    // In a real test environment, we would:
+    // 1. Log in as a test user
+    // 2. Navigate to quests page
+    // 3. Find an incomplete task
+    // 4. Click the checkbox to complete it
+    // 5. Verify checkmark appears green
+    // 6. Click the checkmark again to undo
+    // 7. Verify task returns to incomplete state
+    // 8. Verify points decreased
+
+    await page.goto('/quests')
+
+    // Find a task checkbox (incomplete)
+    const checkbox = page.locator('button').filter({ hasText: '' }).first()
+
+    // Complete the task
+    await checkbox.click()
+
+    // Verify completed state (green checkmark)
+    await expect(checkbox).toHaveClass(/bg-green-500/)
+
+    // Hover should show "Click to undo" title
+    await expect(checkbox).toHaveAttribute('title', 'Click to undo')
+
+    // Undo the completion
+    await checkbox.click()
+
+    // Verify returned to incomplete state
+    await expect(checkbox).not.toHaveClass(/bg-green-500/)
+  })
+
+  test.skip('parent can undo child completion', async ({ page }) => {
+    // This test requires:
+    // 1. A parent user logged in
+    // 2. A task completed by a child in the same family
+    // 3. Verifying parent can click to undo
+
+    await page.goto('/quests')
+
+    // Find a completed task (by a child)
+    const completedCheckbox = page.locator('button.bg-green-500').first()
+
+    // Parent should be able to click to undo
+    await completedCheckbox.click()
+
+    // Task should return to incomplete
+    await expect(completedCheckbox).not.toHaveClass(/bg-green-500/)
+  })
+
+  test.skip('kid cannot undo parent completion', async ({ page }) => {
+    // This test requires:
+    // 1. A child user logged in
+    // 2. A task completed by a parent in the same family
+    // 3. Verifying child cannot undo (RLS policy blocks delete)
+
+    await page.goto('/quests')
+
+    // Find a completed task by parent
+    const parentCompletedCheckbox = page.locator('button.bg-green-500').first()
+
+    // Child clicks to try to undo
+    await parentCompletedCheckbox.click()
+
+    // Task should still be completed (undo failed silently or with error)
+    // The exact behavior depends on how the app handles RLS errors
+  })
+})

--- a/supabase/migrations/004_deduct_points_on_delete.sql
+++ b/supabase/migrations/004_deduct_points_on_delete.sql
@@ -1,0 +1,29 @@
+-- RLS policy: users can delete their own completions, parents can delete any in family
+CREATE POLICY "Users can delete completions"
+  ON task_completions FOR DELETE
+  USING (
+    completed_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid()
+        AND role = 'parent'
+        AND family_id IN (
+          SELECT family_id FROM tasks WHERE id = task_completions.task_id
+        )
+    )
+  );
+
+-- Trigger to deduct points on delete (mirrors award_points_on_completion)
+CREATE OR REPLACE FUNCTION deduct_points_on_completion_delete()
+RETURNS trigger AS $$
+BEGIN
+  UPDATE profiles
+  SET points = GREATEST(points - OLD.points_earned, 0)
+  WHERE id = OLD.completed_by;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_task_completion_deleted
+  BEFORE DELETE ON task_completions
+  FOR EACH ROW EXECUTE FUNCTION deduct_points_on_completion_delete();


### PR DESCRIPTION
## Summary
- Allow users to undo task completions by clicking the green checkmark
- Points are deducted and completion record is removed
- Parents can undo any family member's completions; kids can only undo their own

## Changes
- `components/tasks/task-card.tsx` - Add `onUncomplete` prop, clickable checkmark with tooltip
- `components/tasks/task-list.tsx` - Pass through `onUncomplete` prop
- `app/(dashboard)/quests/page.tsx` - Add `handleUncompleteTask` function
- `supabase/migrations/004_deduct_points_on_delete.sql` - RLS policy + trigger for point deduction
- `docs/adr/001-undo-task.md` - Architecture decision record with Mermaid diagram
- `CLAUDE.md` - Add ADR section and git workflow rule

## Test plan
- [x] Unit tests pass (153 tests)
- [x] E2E tests pass (24 passed, 16 skipped)
- [x] Manual test: Complete task → click checkmark → task uncompletes
- [x] Manual test: Points decrease after undo
- [x] Manual test: Works for recurring tasks
- [x] Manual test: Parent can undo kid's completion
- [x] Apply migration `004_deduct_points_on_delete.sql` in Supabase

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)