### PR TITLE
Detect in-app browsers and warn about OAuth sign-in

### DIFF
--- a/__tests__/app/auth/login.test.tsx
+++ b/__tests__/app/auth/login.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import LoginPage from '@/app/(auth)/login/page'
 
+// Mock InAppBrowserBanner
+jest.mock('@/components/ui/in-app-browser-banner', () => ({
+  InAppBrowserBanner: () => null,
+}))
+
 // Mock next/navigation
 jest.mock('next/navigation', () => ({
   useRouter: () => ({

--- a/__tests__/app/auth/signup.test.tsx
+++ b/__tests__/app/auth/signup.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SignupPage from '@/app/(auth)/signup/page'
 
+// Mock InAppBrowserBanner
+jest.mock('@/components/ui/in-app-browser-banner', () => ({
+  InAppBrowserBanner: () => null,
+}))
+
 // Mock next/navigation
 jest.mock('next/navigation', () => ({
   useRouter: () => ({

--- a/__tests__/components/ui/in-app-browser-banner.test.tsx
+++ b/__tests__/components/ui/in-app-browser-banner.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { InAppBrowserBanner } from '@/components/ui/in-app-browser-banner'
+
+describe('InAppBrowserBanner', () => {
+  const originalNavigator = navigator.userAgent
+
+  function setUserAgent(ua: string) {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: ua,
+      writable: true,
+      configurable: true,
+    })
+  }
+
+  afterEach(() => {
+    setUserAgent(originalNavigator)
+  })
+
+  it('shows banner in Facebook in-app browser', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) FBAN/FBIOS')
+    render(<InAppBrowserBanner />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/open in your browser/i)).toBeInTheDocument()
+    expect(screen.getByText(/google and facebook sign-in/i)).toBeInTheDocument()
+  })
+
+  it('shows banner in WhatsApp in-app browser', () => {
+    setUserAgent('Mozilla/5.0 (Linux; Android 13) WhatsApp/2.23')
+    render(<InAppBrowserBanner />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('shows banner in Instagram in-app browser', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) Instagram 275.0')
+    render(<InAppBrowserBanner />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('does not show banner in regular browser', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36')
+    render(<InAppBrowserBanner />)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -12,6 +12,7 @@ import {
   getTimeRemaining,
   formatTimeRemaining,
   toTimeString,
+  isInAppBrowser,
 } from '@/lib/utils'
 
 describe('cn (classnames utility)', () => {
@@ -294,5 +295,40 @@ describe('toTimeString', () => {
 
   it('converts end of day correctly', () => {
     expect(toTimeString('23:59')).toBe('23:59:00')
+  })
+})
+
+describe('isInAppBrowser', () => {
+  it('detects Facebook in-app browser', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) FBAN/FBIOS')).toBe(true)
+    expect(isInAppBrowser('Mozilla/5.0 (Linux; Android 13) FBAV/400.0')).toBe(true)
+  })
+
+  it('detects Instagram in-app browser', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) Instagram 275.0')).toBe(true)
+  })
+
+  it('detects WhatsApp in-app browser', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (Linux; Android 13) WhatsApp/2.23')).toBe(true)
+  })
+
+  it('detects LinkedIn in-app browser', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) LinkedInApp')).toBe(true)
+  })
+
+  it('detects WeChat in-app browser', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (Linux; Android 13) MicroMessenger/8.0')).toBe(true)
+  })
+
+  it('returns false for Safari', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1')).toBe(false)
+  })
+
+  it('returns false for Chrome', () => {
+    expect(isInAppBrowser('Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isInAppBrowser('')).toBe(false)
   })
 })

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
+import { InAppBrowserBanner } from '@/components/ui/in-app-browser-banner'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -75,6 +76,8 @@ export default function LoginPage() {
           <h1 className="text-3xl font-bold text-gray-900">Chore Champions</h1>
           <p className="text-gray-600 mt-2">Welcome back, champion!</p>
         </div>
+
+        <InAppBrowserBanner />
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { RoleSelector, type Role } from '@/components/ui/role-selector'
+import { InAppBrowserBanner } from '@/components/ui/in-app-browser-banner'
 
 export default function SignupPage() {
   const [email, setEmail] = useState('')
@@ -84,6 +85,8 @@ export default function SignupPage() {
           <h1 className="text-3xl font-bold text-gray-900">Chore Champions</h1>
           <p className="text-gray-600 mt-2">Join the family adventure!</p>
         </div>
+
+        <InAppBrowserBanner />
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (

--- a/components/ui/in-app-browser-banner.tsx
+++ b/components/ui/in-app-browser-banner.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { isInAppBrowser } from '@/lib/utils'
+
+function subscribe() {
+  // User agent never changes — no-op subscription
+  return () => {}
+}
+
+function getSnapshot() {
+  return isInAppBrowser(navigator.userAgent)
+}
+
+function getServerSnapshot() {
+  return false
+}
+
+export function InAppBrowserBanner() {
+  const show = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  if (!show) return null
+
+  return (
+    <div role="alert" className="bg-amber-50 border border-amber-200 text-amber-800 p-3 rounded-lg text-sm">
+      <p className="font-semibold">Open in your browser</p>
+      <p className="mt-1">
+        Google and Facebook sign-in won&apos;t work in this browser. Tap the menu (
+        <span className="font-mono">...</span>) and select &quot;Open in Safari&quot; or &quot;Open in Chrome&quot;.
+      </p>
+    </div>
+  )
+}

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,34 @@
 import { test, expect } from '@playwright/test'
 
+test.describe('In-App Browser Banner', () => {
+  test('shows warning banner when using in-app browser user agent', async ({ browser }) => {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) FBAN/FBIOS',
+    })
+    const page = await context.newPage()
+
+    await page.goto('/login')
+    await expect(page.getByText(/open in your browser/i)).toBeVisible()
+    await context.close()
+  })
+
+  test('shows warning banner on signup page in in-app browser', async ({ browser }) => {
+    const context = await browser.newContext({
+      userAgent: 'Mozilla/5.0 (Linux; Android 13) WhatsApp/2.23',
+    })
+    const page = await context.newPage()
+
+    await page.goto('/signup')
+    await expect(page.getByText(/open in your browser/i)).toBeVisible()
+    await context.close()
+  })
+
+  test('does not show banner in regular browser', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page.getByText(/open in your browser/i)).not.toBeVisible()
+  })
+})
+
 test.describe('Login Page', () => {
   test('displays login form', async ({ page }) => {
     await page.goto('/login')

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -125,6 +125,22 @@ export function formatTimeRemaining(remaining: {
   return isOverdue ? `${timeStr} overdue` : `${timeStr} left`
 }
 
+// Detect in-app browsers that block Google OAuth
+export function isInAppBrowser(userAgent: string): boolean {
+  const patterns = [
+    'FBAN', 'FBAV',       // Facebook
+    'Instagram',           // Instagram
+    'WhatsApp',            // WhatsApp
+    'Line/',               // Line
+    'Twitter',             // Twitter / X
+    'LinkedInApp',         // LinkedIn
+    'Snapchat',            // Snapchat
+    'Pinterest',           // Pinterest
+    'MicroMessenger',      // WeChat
+  ]
+  return patterns.some((p) => userAgent.includes(p))
+}
+
 // Convert HTML time input value ("HH:MM") to database format ("HH:MM:SS")
 export function toTimeString(timeInput: string): string {
   if (timeInput.split(':').length === 2) {


### PR DESCRIPTION
## Summary
- Adds `isInAppBrowser()` utility to detect embedded webviews (Facebook, Instagram, WhatsApp, LinkedIn, WeChat, etc.)
- Shows a warning banner on login and signup pages prompting users to open in Safari/Chrome
- Users hitting Google's `Error 403: disallowed_useragent` will now see guidance before attempting OAuth

## Test plan
- [x] Unit tests: 8 tests for `isInAppBrowser()` detection across browsers
- [x] Unit tests: 4 tests for `InAppBrowserBanner` component rendering
- [x] E2E tests: 3 tests with custom user agents (Facebook, WhatsApp, regular browser)
- [x] Full suite: 236 unit tests, 114 E2E tests passing

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)