### PR TITLE
Add natural language quest creation (#64)

### DIFF
--- a/__tests__/api/parse-quest.test.ts
+++ b/__tests__/api/parse-quest.test.ts
@@ -1,0 +1,553 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/ai/parse-quest/route'
+
+// Mock Supabase server client
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () => Promise.resolve({
+    auth: {
+      getUser: () => mockGetUser(),
+    },
+    from: (table: string) => mockFrom(table),
+  }),
+}))
+
+// Store original fetch
+const originalFetch = global.fetch
+
+const mockMembers = [
+  { id: 'user-1', display_name: 'Sarah', nickname: 'Sar' },
+  { id: 'user-2', display_name: 'Timothy', nickname: 'Timmy' },
+]
+
+function setupAuthenticatedUser() {
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+  // Mock profiles.select().eq().single() for family_id
+  const mockSingle = jest.fn().mockResolvedValue({ data: { family_id: 'family-1' } })
+  const mockEqFamily = jest.fn().mockReturnValue({ single: mockSingle })
+  const mockSelectFamily = jest.fn().mockReturnValue({ eq: mockEqFamily })
+
+  // Mock profiles.select().eq() for members
+  const mockEqMembers = jest.fn().mockResolvedValue({ data: mockMembers })
+  const mockSelectMembers = jest.fn().mockReturnValue({ eq: mockEqMembers })
+
+  let callCount = 0
+  mockFrom.mockImplementation(() => {
+    callCount++
+    if (callCount === 1) {
+      return { select: mockSelectFamily }
+    }
+    return { select: mockSelectMembers }
+  })
+}
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost:3000/api/ai/parse-quest', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('POST /api/ai/parse-quest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.ANTHROPIC_API_KEY = 'test-api-key'
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const response = await POST(makeRequest({ input: 'Make bed for Sarah' }))
+    expect(response.status).toBe(401)
+
+    const data = await response.json()
+    expect(data.error).toBe('Unauthorized')
+  })
+
+  it('returns { prefill: null } when ANTHROPIC_API_KEY is missing', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    delete process.env.ANTHROPIC_API_KEY
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } on invalid JSON body', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const request = new Request('http://localhost:3000/api/ai/parse-quest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'invalid-json',
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } on empty input', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const response = await POST(makeRequest({ input: '' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } on missing input field', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const response = await POST(makeRequest({ foo: 'bar' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } on whitespace-only input', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const response = await POST(makeRequest({ input: '   ' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } when input is not a string', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const response = await POST(makeRequest({ input: 123 }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns successful prefill with snapped points and matched assignee', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: {
+              title: 'Make bed',
+              description: 'Make the bed every morning',
+              points: 7,
+              time_of_day: 'morning',
+              recurring: 'daily',
+              assigned_to: 'Sarah',
+            },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Daily quest for Sarah to make her bed, 7 points' }))
+    const data = await response.json()
+
+    expect(data.prefill).toEqual({
+      title: 'Make bed',
+      description: 'Make the bed every morning',
+      points: 5, // 7 snapped to 5
+      time_of_day: 'morning',
+      recurring: 'daily',
+      assigned_to: 'user-1', // Sarah matched
+    })
+  })
+
+  it('returns prefill with defaults for missing optional fields', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: {
+              title: 'Clean room',
+            },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Clean room' }))
+    const data = await response.json()
+
+    expect(data.prefill).toEqual({
+      title: 'Clean room',
+      description: '',
+      points: 10, // default 10, snapped
+      time_of_day: 'anytime',
+      recurring: null,
+      assigned_to: null,
+    })
+  })
+
+  it('returns { prefill: null } when Anthropic API returns non-ok response', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } when fetch throws (timeout/network error)', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockRejectedValue(new Error('AbortError'))
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('returns { prefill: null } when AI response has no tool_use block', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          { type: 'text', text: 'I cannot parse that.' },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('sends tool_choice and tools in the API request body', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Test' },
+          },
+        ],
+      }),
+    })
+
+    await POST(makeRequest({ input: 'Make bed' }))
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+
+    expect(body.tool_choice).toEqual({ type: 'tool', name: 'extract_quest' })
+    expect(body.tools).toHaveLength(1)
+    expect(body.tools[0].name).toBe('extract_quest')
+  })
+
+  it('includes family member names in the user prompt', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Test' },
+          },
+        ],
+      }),
+    })
+
+    await POST(makeRequest({ input: 'Make bed' }))
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+    const userMessage = body.messages[0].content
+
+    expect(userMessage).toContain('Sar')
+    expect(userMessage).toContain('Timmy')
+  })
+
+  it('handles user with no family_id', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: { family_id: null } })
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle })
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq })
+    mockFrom.mockReturnValue({ select: mockSelect })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Make bed', assigned_to: 'Nobody' },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+
+    expect(data.prefill).toBeDefined()
+    expect(data.prefill.assigned_to).toBeNull()
+  })
+
+  it('handles null members data from supabase', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: { family_id: 'family-1' } })
+    const mockEqFamily = jest.fn().mockReturnValue({ single: mockSingle })
+    const mockSelectFamily = jest.fn().mockReturnValue({ eq: mockEqFamily })
+
+    const mockEqMembers = jest.fn().mockResolvedValue({ data: null })
+    const mockSelectMembers = jest.fn().mockReturnValue({ eq: mockEqMembers })
+
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return { select: mockSelectFamily }
+      }
+      return { select: mockSelectMembers }
+    })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Make bed' },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+
+    expect(data.prefill).toBeDefined()
+    expect(data.prefill.title).toBe('Make bed')
+  })
+
+  it('uses 5-second timeout for abort controller', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Test' },
+          },
+        ],
+      }),
+    })
+
+    await POST(makeRequest({ input: 'Make bed' }))
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+    expect(fetchCall[1].signal).toBeDefined()
+    expect(fetchCall[1].signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('aborts fetch when timeout fires', async () => {
+    setupAuthenticatedUser()
+
+    // Make setTimeout fire immediately so the abort signal triggers
+    const originalSetTimeout = global.setTimeout
+    global.setTimeout = ((fn: () => void) => originalSetTimeout(fn, 0)) as typeof global.setTimeout
+
+    // Make fetch reject with AbortError when signal is aborted
+    global.fetch = jest.fn().mockImplementation((_url: string, options: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        if (options.signal.aborted) {
+          reject(new DOMException('The operation was aborted', 'AbortError'))
+          return
+        }
+        options.signal.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted', 'AbortError'))
+        })
+      })
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+
+    global.setTimeout = originalSetTimeout
+  })
+
+  it('returns { prefill: null } when tool_use block has no input', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: null,
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+    expect(data.prefill).toBeNull()
+  })
+
+  it('handles null profile data (no profile found)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: null })
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle })
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq })
+    mockFrom.mockReturnValue({ select: mockSelect })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Make bed' },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Make bed' }))
+    const data = await response.json()
+
+    expect(data.prefill).toBeDefined()
+    expect(data.prefill.title).toBe('Make bed')
+  })
+
+  it('uses display_name when member has no nickname in memberNames', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: { family_id: 'family-1' } })
+    const mockEqFamily = jest.fn().mockReturnValue({ single: mockSingle })
+    const mockSelectFamily = jest.fn().mockReturnValue({ eq: mockEqFamily })
+
+    const mockEqMembers = jest.fn().mockResolvedValue({
+      data: [{ id: 'user-3', display_name: 'Alex', nickname: null }],
+    })
+    const mockSelectMembers = jest.fn().mockReturnValue({ eq: mockEqMembers })
+
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return { select: mockSelectFamily }
+      }
+      return { select: mockSelectMembers }
+    })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Test' },
+          },
+        ],
+      }),
+    })
+
+    await POST(makeRequest({ input: 'Make bed' }))
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+    const userMessage = body.messages[0].content
+
+    expect(userMessage).toContain('Alex')
+  })
+
+  it('returns prefill with empty title when AI returns no title', async () => {
+    setupAuthenticatedUser()
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: {
+              description: 'Some task',
+            },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(makeRequest({ input: 'Something vague' }))
+    const data = await response.json()
+
+    expect(data.prefill.title).toBe('')
+  })
+
+  it('includes "No family members" text when no members exist', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: { family_id: null } })
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle })
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq })
+    mockFrom.mockReturnValue({ select: mockSelect })
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'extract_quest',
+            input: { title: 'Test' },
+          },
+        ],
+      }),
+    })
+
+    await POST(makeRequest({ input: 'Make bed' }))
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+    const userMessage = body.messages[0].content
+
+    expect(userMessage).toContain('No family members available')
+  })
+})

--- a/__tests__/lib/parse-quest.test.ts
+++ b/__tests__/lib/parse-quest.test.ts
@@ -1,0 +1,140 @@
+import { snapToNearest, matchAssignee, VALID_POINTS } from '@/lib/parse-quest'
+
+describe('snapToNearest', () => {
+  it('returns exact match', () => {
+    expect(snapToNearest(10, VALID_POINTS)).toBe(10)
+  })
+
+  it('rounds down to nearest option', () => {
+    expect(snapToNearest(7, VALID_POINTS)).toBe(5)
+  })
+
+  it('rounds up to nearest option', () => {
+    expect(snapToNearest(8, VALID_POINTS)).toBe(10)
+  })
+
+  it('clamps to max when value exceeds all options', () => {
+    expect(snapToNearest(100, VALID_POINTS)).toBe(50)
+  })
+
+  it('clamps to min when value is below all options', () => {
+    expect(snapToNearest(1, VALID_POINTS)).toBe(5)
+  })
+
+  it('returns value when options array is empty', () => {
+    expect(snapToNearest(7, [])).toBe(7)
+  })
+
+  it('handles tie by picking first encountered', () => {
+    // 12.5 is equidistant from 10 and 15, picks 10 (first encountered)
+    expect(snapToNearest(12, VALID_POINTS)).toBe(10)
+  })
+
+  it('returns single option when only one exists', () => {
+    expect(snapToNearest(99, [25])).toBe(25)
+  })
+
+  it('handles zero value', () => {
+    expect(snapToNearest(0, VALID_POINTS)).toBe(5)
+  })
+
+  it('handles negative value', () => {
+    expect(snapToNearest(-5, VALID_POINTS)).toBe(5)
+  })
+})
+
+describe('matchAssignee', () => {
+  const members = [
+    { id: 'user-1', display_name: 'Sarah', nickname: 'Sar' },
+    { id: 'user-2', display_name: 'Timothy', nickname: 'Timmy' },
+    { id: 'user-3', display_name: 'Alex', nickname: null },
+  ]
+
+  it('returns null for null name', () => {
+    expect(matchAssignee(null, members)).toBeNull()
+  })
+
+  it('returns null for undefined name', () => {
+    expect(matchAssignee(undefined, members)).toBeNull()
+  })
+
+  it('returns null for empty string name', () => {
+    expect(matchAssignee('', members)).toBeNull()
+  })
+
+  it('returns null for empty member list', () => {
+    expect(matchAssignee('Sarah', [])).toBeNull()
+  })
+
+  it('matches exact display_name (case-insensitive)', () => {
+    expect(matchAssignee('sarah', members)).toBe('user-1')
+  })
+
+  it('matches exact display_name (exact case)', () => {
+    expect(matchAssignee('Sarah', members)).toBe('user-1')
+  })
+
+  it('matches exact nickname (case-insensitive)', () => {
+    expect(matchAssignee('timmy', members)).toBe('user-2')
+  })
+
+  it('matches exact nickname (exact case)', () => {
+    expect(matchAssignee('Sar', members)).toBe('user-1')
+  })
+
+  it('matches by prefix of display_name', () => {
+    expect(matchAssignee('Tim', members)).toBe('user-2')
+  })
+
+  it('matches by prefix of nickname', () => {
+    expect(matchAssignee('Ti', members)).toBe('user-2')
+  })
+
+  it('matches by prefix of nickname when display_name does not match', () => {
+    const membersWithUniqueNick = [
+      { id: 'user-x', display_name: 'Robert', nickname: 'Bob' },
+    ]
+    expect(matchAssignee('Bo', membersWithUniqueNick)).toBe('user-x')
+  })
+
+  it('matches by substring of display_name', () => {
+    expect(matchAssignee('imoth', members)).toBe('user-2')
+  })
+
+  it('matches by substring of nickname', () => {
+    expect(matchAssignee('imm', members)).toBe('user-2')
+  })
+
+  it('returns null when no match found', () => {
+    expect(matchAssignee('Bob', members)).toBeNull()
+  })
+
+  it('prefers exact match over prefix match', () => {
+    const membersWithOverlap = [
+      { id: 'user-a', display_name: 'Al', nickname: null },
+      { id: 'user-b', display_name: 'Alex', nickname: null },
+    ]
+    expect(matchAssignee('Al', membersWithOverlap)).toBe('user-a')
+  })
+
+  it('prefers prefix match over substring match', () => {
+    const membersForTest = [
+      { id: 'user-a', display_name: 'Xander', nickname: null },
+      { id: 'user-b', display_name: 'Alexander', nickname: null },
+    ]
+    // "Xan" is prefix of "Xander" and substring of "Alexander"
+    expect(matchAssignee('Xan', membersForTest)).toBe('user-a')
+  })
+
+  it('handles member with null nickname in all tiers', () => {
+    expect(matchAssignee('Alex', members)).toBe('user-3')
+    expect(matchAssignee('Al', members)).toBe('user-3')
+    expect(matchAssignee('lex', members)).toBe('user-3')
+  })
+})
+
+describe('VALID_POINTS', () => {
+  it('contains expected point values', () => {
+    expect([...VALID_POINTS]).toEqual([5, 10, 15, 20, 25, 50])
+  })
+})

--- a/app/api/ai/parse-quest/route.ts
+++ b/app/api/ai/parse-quest/route.ts
@@ -1,0 +1,159 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { snapToNearest, matchAssignee, VALID_POINTS } from '@/lib/parse-quest'
+import type { ParseQuestResponse } from '@/lib/parse-quest'
+
+export async function POST(request: Request) {
+  // Auth check
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ prefill: null } satisfies ParseQuestResponse)
+  }
+
+  let body: { input?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ prefill: null } satisfies ParseQuestResponse)
+  }
+
+  if (!body.input || typeof body.input !== 'string' || !body.input.trim()) {
+    return NextResponse.json({ prefill: null } satisfies ParseQuestResponse)
+  }
+
+  // Fetch family members for assignee matching
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  const familyId = profile?.family_id
+  let members: { id: string; display_name: string; nickname: string | null }[] = []
+
+  if (familyId) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, display_name, nickname')
+      .eq('family_id', familyId)
+
+    members = data || []
+  }
+
+  const memberNames = members.map(m => m.nickname || m.display_name).join(', ')
+
+  const systemPrompt =
+    'You extract structured quest data from natural language descriptions. ' +
+    'A quest is a chore or task assigned to a family member. ' +
+    'Extract as many fields as you can from the input. Use reasonable defaults for missing fields.'
+
+  const userPrompt =
+    `Parse this quest description: "${body.input.trim()}"\n\n` +
+    (memberNames ? `Family members: ${memberNames}` : 'No family members available.')
+
+  // 5-second timeout
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 500,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userPrompt }],
+        tools: [
+          {
+            name: 'extract_quest',
+            description: 'Extract structured quest data from a natural language description.',
+            input_schema: {
+              type: 'object',
+              properties: {
+                title: {
+                  type: 'string',
+                  description: 'Short title for the quest (e.g., "Make bed")',
+                },
+                description: {
+                  type: 'string',
+                  description: 'Optional longer description of the quest',
+                },
+                points: {
+                  type: 'number',
+                  description: 'Point value for completing the quest (typically 5-50)',
+                },
+                time_of_day: {
+                  type: 'string',
+                  enum: ['morning', 'afternoon', 'night', 'anytime'],
+                  description: 'When during the day the quest should be done',
+                },
+                recurring: {
+                  type: 'string',
+                  enum: ['daily', 'weekly'],
+                  description: 'How often the quest repeats, if mentioned',
+                },
+                assigned_to: {
+                  type: 'string',
+                  description: 'Name of the family member this quest is for, if mentioned',
+                },
+              },
+              required: ['title'],
+            },
+          },
+        ],
+        tool_choice: { type: 'tool', name: 'extract_quest' },
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      return NextResponse.json({ prefill: null } satisfies ParseQuestResponse)
+    }
+
+    const data = await response.json()
+    const toolBlock = data?.content?.find(
+      (b: { type: string }) => b.type === 'tool_use'
+    )
+
+    if (!toolBlock?.input) {
+      return NextResponse.json({ prefill: null } satisfies ParseQuestResponse)
+    }
+
+    const input = toolBlock.input as {
+      title?: string
+      description?: string
+      points?: number
+      time_of_day?: string
+      recurring?: string
+      assigned_to?: string
+    }
+
+    const prefill: ParseQuestResponse['prefill'] = {
+      title: input.title || '',
+      description: input.description || '',
+      points: snapToNearest(input.points || 10, VALID_POINTS),
+      time_of_day: input.time_of_day || 'anytime',
+      recurring: input.recurring || null,
+      assigned_to: matchAssignee(input.assigned_to, members),
+    }
+
+    return NextResponse.json({ prefill } satisfies ParseQuestResponse)
+  } catch {
+    clearTimeout(timeout)
+    return NextResponse.json({ prefill: null } satisfies ParseQuestResponse)
+  }
+}

--- a/docs/adr/011-natural-language-quest-creation.md
+++ b/docs/adr/011-natural-language-quest-creation.md
@@ -1,0 +1,152 @@
+# ADR-011: Natural Language Quest Creation
+
+**Status:** Proposed
+**Issue:** #64
+**Date:** 2026-02-18
+
+## Context
+
+Parents currently create quests by manually filling out a multi-field form (title, description, points, time of day, recurring flag, assignee). For parents managing multiple children with many quests, this is tedious — especially for straightforward tasks like "Make bed every morning for 5 points." A natural language input would let parents type a plain-English sentence and have the form pre-filled automatically, reducing friction while keeping the existing form as the final confirmation step.
+
+The app already has a pattern for calling the Anthropic Messages API (ADR-010, the encouragement feature), so the infrastructure and conventions for server-side AI calls are established. The key challenge is reliably extracting structured quest data from free-form text and mapping it to the existing form fields and valid values.
+
+## Decision
+
+### Claude `tool_use` for Structured Extraction
+
+Use Claude's `tool_use` capability with `tool_choice: { type: 'tool', name: 'extract_quest' }` to force the model to return structured JSON matching the quest form schema. Unlike free-text parsing or regex extraction, `tool_use` guarantees a deterministic output shape — the model must call the specified tool with the defined parameters, eliminating the need for post-hoc JSON validation or schema coercion.
+
+The tool schema defines fields for title, description, points, time_of_day, recurring, and assigned_to (a name string extracted from the input).
+
+### Server-Side Assignee Matching
+
+The API route fetches the current family's members from Supabase and includes their names in the prompt context. When the AI extracts a name string from the user's input, the server matches it to a family member UUID using a three-tier fallback strategy:
+
+1. **Exact match** — case-insensitive comparison against `display_name` and `nickname`
+2. **Prefix match** — input is a prefix of a member's name (e.g., "Sar" matches "Sarah")
+3. **Substring match** — input appears anywhere in a member's name
+
+This matching runs server-side where the family member list is already available, avoiding an extra client-side fetch.
+
+### Points Snapped to Valid Enum
+
+Quest points must be one of `[5, 10, 15, 20, 25, 50]`. Rather than rejecting an AI-extracted value like 7, the `snapToNearest` utility finds the closest valid value (7 → 5). This ensures the pre-filled form always has a valid point value regardless of what the model returns.
+
+### 5-Second Timeout
+
+The encouragement feature uses a 2-second timeout because it is non-blocking (fire-and-forget). Natural language quest parsing is a blocking UX interaction — the parent is waiting for the form to fill. A 5-second `AbortController` timeout balances responsiveness against giving the model enough time to respond. On timeout, the form remains empty with an error hint.
+
+### Graceful Degradation
+
+The natural language input is entirely optional. If `ANTHROPIC_API_KEY` is not configured, the AI call fails, or the response times out, the form works exactly as before. An error hint is shown below the NL input, and the parent can fill the form manually. The feature never blocks quest creation.
+
+### No Database Migration
+
+The parsed result is ephemeral — it pre-fills form state in memory and is discarded. The quest is ultimately created through the existing form submission path, which writes to the `tasks` table with no schema changes. No new tables, columns, or RLS policies are needed.
+
+### NL Input Hidden in Edit Mode
+
+The natural language input only appears when creating a new quest. In edit mode, the form fields are already populated, so pre-filling from natural language would overwrite the parent's existing edits. Hiding the input avoids confusion and keeps the edit flow unchanged.
+
+### Raw `fetch` Instead of Anthropic SDK
+
+Following the pattern established in ADR-010, the API route uses a raw `fetch` call to the Anthropic Messages API rather than importing the Anthropic SDK. The request shape is fixed and simple — adding ~200KB of SDK for a single POST call is not justified.
+
+## Consequences
+
+### Positive
+- Significantly reduces quest creation time for parents — a single sentence replaces filling 4-6 form fields
+- Forced `tool_use` guarantees structured output shape, eliminating fragile text parsing
+- Graceful degradation means the feature is zero-risk to the core quest creation flow
+- No database migration keeps deployment simple and reversible
+- `snapToNearest` and tiered name matching make the feature robust to imprecise AI outputs
+- Reuses the API call pattern from ADR-010, keeping the codebase consistent
+
+### Negative
+- Adds a second dependency on the Anthropic API — increases exposure to outages or API changes
+- 5-second timeout creates a noticeable wait during a blocking UX interaction; users may perceive it as slow
+- AI extraction is imperfect — ambiguous inputs ("do the thing for the kid, lots of points") may produce unexpected pre-fills, requiring the parent to correct values
+- No rate limiting in the initial implementation — rapid repeated submissions could generate excessive API calls
+- The NL input adds UI complexity to the task form component, which is already the most complex form in the app
+
+## Alternatives Considered
+
+1. **Client-side text parsing with regex/heuristics**: Extract quest fields using pattern matching (e.g., look for numbers followed by "points", time-of-day keywords). This would be instant and require no API call, but would be brittle, limited to English patterns, and unable to handle the variety of natural language inputs. A regex parser cannot reliably distinguish "Clean Sarah's room" (task for Sarah) from "Clean the Sarah Lawrence poster" (task about an object). Rejected for poor extraction quality.
+
+2. **Free-text Claude response with JSON parsing**: Ask Claude to return JSON without `tool_use`, then parse the response. This is simpler to implement but the model may return malformed JSON, include markdown fences, or deviate from the expected schema. `tool_use` eliminates these failure modes by construction. Rejected for lower reliability.
+
+3. **Streaming response for perceived speed**: Use streaming to show extracted fields appearing one at a time, reducing perceived latency. This adds significant complexity (partial state management, streaming API handling) for a response that typically completes in 1-2 seconds. The form pre-fill is an atomic operation — showing partial results would be confusing. Rejected as unnecessary complexity.
+
+4. **Dedicated NL creation page instead of inline input**: Create a separate page or modal for natural language quest creation, keeping the existing form untouched. This would be cleaner architecturally but adds navigation friction and splits the creation flow into two paths. An inline input above the existing form is more discoverable and keeps everything in one place. Rejected for worse UX.
+
+5. **Local LLM or embeddings for offline extraction**: Run a small model client-side (e.g., via WebLLM or ONNX) to avoid the API round-trip entirely. Current browser-based models are too large (~100MB+) for a family chore app and extraction quality is significantly lower than Claude. Rejected as impractical for the target audience and device constraints.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    participant Parent
+    participant TaskForm as Task Form
+    participant API as /api/ai/parse-quest
+    participant Supabase as Supabase
+    participant Claude as Claude API
+
+    Parent->>TaskForm: Type "Daily quest for Sarah to make her bed, 5 points"
+    Parent->>TaskForm: Click "Fill" or press Enter
+
+    TaskForm->>TaskForm: Set nlLoading = true
+    TaskForm->>API: POST { input }
+
+    API->>API: Verify Supabase auth
+
+    alt Unauthenticated
+        API-->>TaskForm: 401 Unauthorized
+        TaskForm->>TaskForm: Show error hint
+    else Authenticated
+        API->>Supabase: Fetch family members
+        Supabase-->>API: [{ id, display_name, nickname }]
+
+        API->>Claude: Messages API with tool_use (5s timeout)
+        Note over API,Claude: tool_choice: extract_quest<br/>Includes family member names in prompt
+
+        alt AI responds in time
+            Claude-->>API: tool_use result { title, points, recurring, ... }
+            API->>API: snapToNearest(points, VALID_POINTS)
+            API->>API: matchAssignee(name, members)
+            API-->>TaskForm: { prefill: { title, points, ... } }
+        else Timeout or error
+            API-->>TaskForm: { prefill: null, error: "..." }
+        end
+    end
+
+    alt Prefill received
+        TaskForm->>TaskForm: Set form fields from prefill
+        TaskForm->>TaskForm: Show confirmation hint
+        TaskForm->>Parent: Review pre-filled form
+    else No prefill
+        TaskForm->>TaskForm: Show error hint
+        TaskForm->>Parent: Fill form manually
+    end
+
+    Parent->>TaskForm: Review, adjust, and submit
+    Note over TaskForm: Existing submit flow unchanged
+```
+
+## Implementation
+
+Key files and changes:
+
+**New files (2 source, 3 test, 1 E2E):**
+- `lib/parse-quest.ts` — `QuestPrefill` and `ParseQuestResponse` types, `snapToNearest()` utility, `matchAssignee()` with exact → prefix → substring fallback, `VALID_POINTS` constant
+- `app/api/ai/parse-quest/route.ts` — POST handler with Supabase auth, family member fetch, Claude `tool_use` call with 5-second timeout, point snapping, assignee matching
+- `__tests__/lib/parse-quest.test.ts` — Tests for `snapToNearest` and `matchAssignee`
+- `__tests__/api/parse-quest.test.ts` — Tests for auth, successful parse, timeout, error cases
+- `__tests__/components/tasks/task-form.test.tsx` — Extended with NL input tests (create vs edit mode, pre-fill, error states)
+- `e2e/nl-quest-creation.spec.ts` — E2E tests with mocked API route
+
+**Modified files (2):**
+- `components/tasks/task-form.tsx` — Add NL text input and "Fill" button above form fields (create mode only), `handleNlParse()` function, loading/error/success states
+- `playwright.config.ts` — Add `nl-quest-creation\.spec\.ts` to parent project `testMatch`
+
+**Environment:**
+- `ANTHROPIC_API_KEY` — Already required from ADR-010 (encouragement feature)

--- a/e2e/nl-quest-creation.spec.ts
+++ b/e2e/nl-quest-creation.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '@playwright/test'
+import { createTestTask, cleanupTestTask } from './helpers'
+
+let createdTaskNames: string[] = []
+
+test.describe('Natural Language Quest Creation', () => {
+  test.beforeEach(async ({ page }) => {
+    createdTaskNames = []
+    await page.goto('/quests')
+  })
+
+  test.afterEach(async ({ page }) => {
+    for (const taskName of createdTaskNames) {
+      await cleanupTestTask(page, taskName)
+    }
+  })
+
+  test('NL input pre-fills form and parent can submit', async ({ page }) => {
+    // Mock the parse-quest API
+    await page.route('**/api/ai/parse-quest', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          prefill: {
+            title: 'NL Test Make Bed',
+            description: 'Make bed neatly every morning',
+            points: 5,
+            time_of_day: 'morning',
+            recurring: 'daily',
+            assigned_to: null,
+          },
+        }),
+      })
+    })
+
+    const taskName = `NL Test Make Bed`
+    createdTaskNames.push(taskName)
+
+    // Open the New Quest modal
+    const fab = page.locator('button.fixed.bg-purple-600')
+    await fab.click()
+    await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
+
+    // Fill in the NL input
+    const nlInput = page.getByLabel('Describe the quest')
+    await nlInput.fill('Daily quest to make bed, 5 points')
+
+    // Click Fill button
+    await page.getByRole('button', { name: 'Fill' }).click()
+
+    // Wait for form to be pre-filled
+    await expect(page.getByPlaceholder(/clean your room/i)).toHaveValue('NL Test Make Bed')
+    await expect(page.getByText('Form pre-filled! Review and submit below.')).toBeVisible()
+
+    // Submit the form
+    await page.getByRole('button', { name: /create quest/i }).click()
+
+    // Wait for modal to close and task to appear
+    await expect(page.getByRole('heading', { name: 'New Quest' })).not.toBeVisible()
+    await expect(page.getByText(taskName)).toBeVisible({ timeout: 5000 })
+  })
+
+  test('shows error when parse returns null prefill', async ({ page }) => {
+    // Mock the parse-quest API to return null prefill
+    await page.route('**/api/ai/parse-quest', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ prefill: null }),
+      })
+    })
+
+    // Open the New Quest modal
+    const fab = page.locator('button.fixed.bg-purple-600')
+    await fab.click()
+    await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
+
+    // Fill in the NL input
+    const nlInput = page.getByLabel('Describe the quest')
+    await nlInput.fill('something unclear')
+
+    // Click Fill button
+    await page.getByRole('button', { name: 'Fill' }).click()
+
+    // Error message should appear
+    await expect(page.getByText('Could not parse quest. Please fill the form manually.')).toBeVisible()
+  })
+
+  test('NL input is not shown in edit mode', async ({ page }) => {
+    const taskName = `NL Edit Test ${Date.now()}`
+    createdTaskNames.push(taskName)
+
+    // Create a task first
+    await createTestTask(page, taskName)
+
+    // Open edit modal
+    const taskCard = page.locator('.bg-white.rounded-xl').filter({ hasText: taskName })
+    await taskCard.getByTitle('Edit quest').click()
+    await expect(page.getByRole('heading', { name: 'Edit Quest' })).toBeVisible()
+
+    // NL input should not be present
+    await expect(page.getByLabel('Describe the quest')).not.toBeVisible()
+
+    // Close the edit modal
+    await page.getByRole('button', { name: 'Cancel' }).click()
+  })
+
+  test('Enter key triggers parse', async ({ page }) => {
+    // Mock the parse-quest API
+    await page.route('**/api/ai/parse-quest', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          prefill: {
+            title: 'Enter Key Quest',
+            description: '',
+            points: 10,
+            time_of_day: 'anytime',
+            recurring: null,
+            assigned_to: null,
+          },
+        }),
+      })
+    })
+
+    // Open the New Quest modal
+    const fab = page.locator('button.fixed.bg-purple-600')
+    await fab.click()
+    await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
+
+    // Fill in the NL input and press Enter
+    const nlInput = page.getByLabel('Describe the quest')
+    await nlInput.fill('Enter key test quest')
+    await nlInput.press('Enter')
+
+    // Wait for form to be pre-filled
+    await expect(page.getByPlaceholder(/clean your room/i)).toHaveValue('Enter Key Quest')
+    await expect(page.getByText('Form pre-filled! Review and submit below.')).toBeVisible()
+
+    // Close without submitting
+    await page.getByRole('button', { name: 'Cancel' }).click()
+  })
+})

--- a/lib/parse-quest.ts
+++ b/lib/parse-quest.ts
@@ -1,0 +1,71 @@
+import type { Profile } from '@/lib/types'
+
+export interface QuestPrefill {
+  title: string
+  description: string
+  points: number
+  time_of_day: string
+  recurring: string | null
+  assigned_to: string | null
+}
+
+export interface ParseQuestResponse {
+  prefill: QuestPrefill | null
+  error?: string
+}
+
+export const VALID_POINTS = [5, 10, 15, 20, 25, 50] as const
+
+/**
+ * Snaps a numeric value to the nearest valid option.
+ * Used to coerce AI-extracted point values to the valid enum.
+ */
+export function snapToNearest(value: number, options: readonly number[]): number {
+  if (options.length === 0) return value
+
+  let closest = options[0]
+  let minDist = Math.abs(value - closest)
+
+  for (let i = 1; i < options.length; i++) {
+    const dist = Math.abs(value - options[i])
+    if (dist < minDist) {
+      minDist = dist
+      closest = options[i]
+    }
+  }
+
+  return closest
+}
+
+/**
+ * Matches an AI-extracted name string to a family member UUID.
+ * Uses a three-tier fallback: exact → prefix → substring (all case-insensitive).
+ */
+export function matchAssignee(
+  name: string | null | undefined,
+  members: Pick<Profile, 'id' | 'display_name' | 'nickname'>[]
+): string | null {
+  if (!name || members.length === 0) return null
+
+  const lower = name.toLowerCase()
+
+  // Exact match against display_name or nickname
+  for (const m of members) {
+    if (m.display_name.toLowerCase() === lower) return m.id
+    if (m.nickname && m.nickname.toLowerCase() === lower) return m.id
+  }
+
+  // Prefix match
+  for (const m of members) {
+    if (m.display_name.toLowerCase().startsWith(lower)) return m.id
+    if (m.nickname && m.nickname.toLowerCase().startsWith(lower)) return m.id
+  }
+
+  // Substring match
+  for (const m of members) {
+    if (m.display_name.toLowerCase().includes(lower)) return m.id
+    if (m.nickname && m.nickname.toLowerCase().includes(lower)) return m.id
+  }
+
+  return null
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         storageState: '.auth/parent.json',
       },
       dependencies: ['setup'],
-      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts/,
+      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts/,
     },
     // Destructive parent tests (sign-out) that invalidate the session - run last
     {


### PR DESCRIPTION
## Summary
- Parents can type a plain-English description (e.g., "Daily quest for Sarah to make her bed, 5 points") and have the quest form auto-filled using Claude's `tool_use` capability
- Adds `/api/ai/parse-quest` route with auth, 5s timeout, and graceful degradation (form always works even if AI fails)
- Adds `snapToNearest()` for point snapping and `matchAssignee()` with 3-tier name matching (exact → prefix → substring)
- NL input only shown in create mode, hidden in edit mode

## Test plan
- [x] 100% test coverage on all new/changed files (lib/parse-quest.ts, route.ts, task-form.tsx)
- [x] 629 unit tests passing (37 suites)
- [x] 137 E2E tests passing (4 new NL quest creation tests with mocked API)
- [x] 12 smoke tests passing
- [x] Lint clean (0 errors)
- [x] Code review: 0 issues found

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)