### PR TITLE
Add multi-step onboarding flow for new users

### DIFF
--- a/__tests__/app/auth/callback.test.ts
+++ b/__tests__/app/auth/callback.test.ts
@@ -18,7 +18,7 @@ describe('Auth Callback Route', () => {
     jest.clearAllMocks()
   })
 
-  it('exchanges code for session and redirects to /quests by default', async () => {
+  it('exchanges code for session and redirects to /onboarding by default', async () => {
     mockExchangeCodeForSession.mockResolvedValue({ error: null })
 
     const request = new Request('http://localhost:3000/auth/callback?code=test-code')
@@ -26,7 +26,7 @@ describe('Auth Callback Route', () => {
 
     expect(mockExchangeCodeForSession).toHaveBeenCalledWith('test-code')
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost:3000/quests')
+    expect(response.headers.get('location')).toBe('http://localhost:3000/onboarding')
   })
 
   it('redirects to specified next URL on success', async () => {

--- a/__tests__/app/auth/join-code.test.tsx
+++ b/__tests__/app/auth/join-code.test.tsx
@@ -87,7 +87,7 @@ describe('Join Family Page (with code)', () => {
 
     await waitFor(() => {
       expect(mockSignUp).toHaveBeenCalled()
-      expect(mockPush).toHaveBeenCalledWith('/quests')
+      expect(mockPush).toHaveBeenCalledWith('/onboarding')
     })
   })
 
@@ -157,20 +157,21 @@ describe('Join Family Page (with code)', () => {
     await userEvent.click(screen.getByRole('button', { name: /join the smiths/i }))
 
     await waitFor(() => {
-      // Should navigate to quests even when user is null (skips profile update)
-      expect(mockPush).toHaveBeenCalledWith('/quests')
+      // Should navigate to onboarding even when user is null (skips profile update)
+      expect(mockPush).toHaveBeenCalledWith('/onboarding')
     })
   })
 
-  it('shows role selector with Parent and Kid options', async () => {
+  it('does not show role selector (role moved to onboarding)', async () => {
     render(<JoinFamilyPage />)
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Join Family' })).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('button', { name: 'Parent' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Kid' })).toBeInTheDocument()
+    expect(screen.queryByText('I am a...')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Parent' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Kid' })).not.toBeInTheDocument()
   })
 
   it('shows Joining... while loading', async () => {

--- a/__tests__/app/auth/join.test.tsx
+++ b/__tests__/app/auth/join.test.tsx
@@ -44,7 +44,7 @@ describe('Join Family Page', () => {
     })
   })
 
-  it('renders join form with role selector after loading', async () => {
+  it('renders join form without role selector after loading', async () => {
     render(<JoinFamilyPage />)
 
     await waitFor(() => {
@@ -52,9 +52,9 @@ describe('Join Family Page', () => {
     })
 
     expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
-    expect(screen.getByText('I am a...')).toBeInTheDocument()
-    expect(screen.getByText('Parent')).toBeInTheDocument()
-    expect(screen.getByText('Kid')).toBeInTheDocument()
+    expect(screen.queryByText('I am a...')).not.toBeInTheDocument()
+    expect(screen.queryByText('Parent')).not.toBeInTheDocument()
+    expect(screen.queryByText('Kid')).not.toBeInTheDocument()
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
   })
@@ -80,7 +80,7 @@ describe('Join Family Page', () => {
     })
   })
 
-  it('calls signUp with child role by default', async () => {
+  it('calls signUp with display_name only (no role)', async () => {
     mockSignUp.mockResolvedValue({
       data: { user: { id: 'user-123' } },
       error: null,
@@ -107,42 +107,6 @@ describe('Join Family Page', () => {
         options: {
           data: {
             display_name: 'Test Kid',
-            role: 'child',
-          },
-        },
-      })
-    })
-  })
-
-  it('calls signUp with parent role when selected', async () => {
-    mockSignUp.mockResolvedValue({
-      data: { user: { id: 'user-123' } },
-      error: null,
-    })
-    mockUpdate.mockReturnValue({
-      eq: jest.fn().mockResolvedValue({ error: null }),
-    })
-
-    render(<JoinFamilyPage />)
-
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /join family/i })).toBeInTheDocument()
-    })
-
-    await userEvent.type(screen.getByLabelText(/display name/i), 'Test Parent')
-    await userEvent.click(screen.getByText('Parent'))
-    await userEvent.type(screen.getByLabelText(/email/i), 'parent@example.com')
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123')
-    await userEvent.click(screen.getByRole('button', { name: /join test family/i }))
-
-    await waitFor(() => {
-      expect(mockSignUp).toHaveBeenCalledWith({
-        email: 'parent@example.com',
-        password: 'password123',
-        options: {
-          data: {
-            display_name: 'Test Parent',
-            role: 'parent',
           },
         },
       })

--- a/__tests__/app/auth/signup.test.tsx
+++ b/__tests__/app/auth/signup.test.tsx
@@ -33,14 +33,14 @@ describe('Signup Page', () => {
     jest.clearAllMocks()
   })
 
-  it('renders signup form with role selector', () => {
+  it('renders signup form without role selector', () => {
     render(<SignupPage />)
 
     expect(screen.getByRole('heading', { name: /chore champions/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
-    expect(screen.getByText('I am a...')).toBeInTheDocument()
-    expect(screen.getByText('Parent')).toBeInTheDocument()
-    expect(screen.getByText('Kid')).toBeInTheDocument()
+    expect(screen.queryByText('I am a...')).not.toBeInTheDocument()
+    expect(screen.queryByText('Parent')).not.toBeInTheDocument()
+    expect(screen.queryByText('Kid')).not.toBeInTheDocument()
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument()
@@ -125,7 +125,7 @@ describe('Signup Page', () => {
     expect(await screen.findByText(/email already registered/i)).toBeInTheDocument()
   })
 
-  it('calls signUp with default child role on form submit', async () => {
+  it('calls signUp with display_name only (no role) on form submit', async () => {
     mockSignUp.mockResolvedValue({ error: null })
     render(<SignupPage />)
 
@@ -140,29 +140,6 @@ describe('Signup Page', () => {
       options: {
         data: {
           display_name: 'Test User',
-          role: 'child',
-        },
-      },
-    })
-  })
-
-  it('calls signUp with parent role when selected', async () => {
-    mockSignUp.mockResolvedValue({ error: null })
-    render(<SignupPage />)
-
-    await userEvent.type(screen.getByLabelText(/display name/i), 'Test Parent')
-    await userEvent.click(screen.getByText('Parent'))
-    await userEvent.type(screen.getByLabelText(/email/i), 'parent@example.com')
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123')
-    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
-
-    expect(mockSignUp).toHaveBeenCalledWith({
-      email: 'parent@example.com',
-      password: 'password123',
-      options: {
-        data: {
-          display_name: 'Test Parent',
-          role: 'parent',
         },
       },
     })

--- a/__tests__/components/onboarding/family-step.test.tsx
+++ b/__tests__/components/onboarding/family-step.test.tsx
@@ -1,0 +1,331 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FamilyStep } from '@/components/onboarding/family-step'
+
+// Mock Supabase client
+const mockRpc = jest.fn()
+const mockGetUser = jest.fn()
+const mockUpdate = jest.fn()
+const mockInsert = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    rpc: (...args: unknown[]) => ({
+      single: () => mockRpc(...args),
+    }),
+    from: () => ({
+      update: (...args: unknown[]) => ({
+        eq: (...eqArgs: unknown[]) => mockUpdate(...args, ...eqArgs),
+      }),
+      insert: (...args: unknown[]) => ({
+        select: () => ({
+          single: () => mockInsert(...args),
+        }),
+      }),
+    }),
+  }),
+}))
+
+describe('FamilyStep', () => {
+  const mockOnComplete = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockUpdate.mockResolvedValue({ error: null })
+  })
+
+  describe('Choose mode', () => {
+    it('renders choose mode by default with join and create buttons', () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      expect(screen.getByText('Join or Create a Family')).toBeInTheDocument()
+      expect(screen.getByText('Join existing family')).toBeInTheDocument()
+      expect(screen.getByText('Create new family')).toBeInTheDocument()
+    })
+
+    it('shows description text', () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      expect(screen.getByText(/every champion needs a team/i)).toBeInTheDocument()
+    })
+
+    it('shows subtitle text for join option', () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      expect(screen.getByText('I have an invite code')).toBeInTheDocument()
+    })
+
+    it('shows subtitle text for create option', () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      expect(screen.getByText('Start fresh and invite others later')).toBeInTheDocument()
+    })
+  })
+
+  describe('Join mode', () => {
+    it('shows invite code input when clicking Join', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+
+      expect(screen.getByText('Join a Family')).toBeInTheDocument()
+      expect(screen.getByLabelText('Invite Code')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /join family/i })).toBeInTheDocument()
+    })
+
+    it('shows back button in join mode', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+
+      expect(screen.getByText('Back')).toBeInTheDocument()
+    })
+
+    it('returns to choose mode when Back is clicked', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      expect(screen.getByText('Join a Family')).toBeInTheDocument()
+
+      await userEvent.click(screen.getByText('Back'))
+      expect(screen.getByText('Join or Create a Family')).toBeInTheDocument()
+    })
+
+    it('calls onComplete with familyId on successful join', async () => {
+      mockRpc.mockResolvedValue({ data: { id: 'family-1', name: 'The Smiths' }, error: null })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      await userEvent.type(screen.getByLabelText('Invite Code'), 'ABC123')
+      await userEvent.click(screen.getByRole('button', { name: /join family/i }))
+
+      await waitFor(() => {
+        expect(mockOnComplete).toHaveBeenCalledWith('family-1')
+      })
+    })
+
+    it('shows error on invalid invite code', async () => {
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      await userEvent.type(screen.getByLabelText('Invite Code'), 'BADCODE')
+      await userEvent.click(screen.getByRole('button', { name: /join family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/invalid or expired invite code/i)).toBeInTheDocument()
+      })
+      expect(mockOnComplete).not.toHaveBeenCalled()
+    })
+
+    it('shows error when user is not logged in during join', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } })
+      mockRpc.mockResolvedValue({ data: { id: 'family-1', name: 'Test' }, error: null })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      await userEvent.type(screen.getByLabelText('Invite Code'), 'ABC123')
+      await userEvent.click(screen.getByRole('button', { name: /join family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/you must be logged in to join/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows error when profile update fails during join', async () => {
+      mockRpc.mockResolvedValue({ data: { id: 'family-1', name: 'Test' }, error: null })
+      mockUpdate.mockResolvedValue({ error: { message: 'Update failed' } })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      await userEvent.type(screen.getByLabelText('Invite Code'), 'ABC123')
+      await userEvent.click(screen.getByRole('button', { name: /join family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to join family/i)).toBeInTheDocument()
+      })
+    })
+
+    it('trims whitespace from invite code', async () => {
+      mockRpc.mockResolvedValue({ data: { id: 'family-1', name: 'Test' }, error: null })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      await userEvent.type(screen.getByLabelText('Invite Code'), '  ABC123  ')
+      await userEvent.click(screen.getByRole('button', { name: /join family/i }))
+
+      await waitFor(() => {
+        expect(mockRpc).toHaveBeenCalledWith('get_family_by_invite_code', { code: 'ABC123' })
+      })
+    })
+  })
+
+  describe('Create mode', () => {
+    it('shows family name input when clicking Create', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+
+      expect(screen.getByText('Create a Family')).toBeInTheDocument()
+      expect(screen.getByLabelText('Family Name')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /create family/i })).toBeInTheDocument()
+    })
+
+    it('shows back button in create mode', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+
+      expect(screen.getByText('Back')).toBeInTheDocument()
+    })
+
+    it('returns to choose mode when Back is clicked from create', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+      expect(screen.getByText('Create a Family')).toBeInTheDocument()
+
+      await userEvent.click(screen.getByText('Back'))
+      expect(screen.getByText('Join or Create a Family')).toBeInTheDocument()
+    })
+
+    it('calls onComplete with familyId on successful creation', async () => {
+      mockInsert.mockResolvedValue({ data: { id: 'new-family-1' }, error: null })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+      await userEvent.type(screen.getByLabelText('Family Name'), 'The Champions')
+      await userEvent.click(screen.getByRole('button', { name: /create family/i }))
+
+      await waitFor(() => {
+        expect(mockOnComplete).toHaveBeenCalledWith('new-family-1')
+      })
+    })
+
+    it('shows error on failed family creation', async () => {
+      mockInsert.mockResolvedValue({ data: null, error: { message: 'Insert failed' } })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+      await userEvent.type(screen.getByLabelText('Family Name'), 'Test Family')
+      await userEvent.click(screen.getByRole('button', { name: /create family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to create family/i)).toBeInTheDocument()
+      })
+      expect(mockOnComplete).not.toHaveBeenCalled()
+    })
+
+    it('shows error when user is not logged in during create', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+      await userEvent.type(screen.getByLabelText('Family Name'), 'Test Family')
+      await userEvent.click(screen.getByRole('button', { name: /create family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/you must be logged in to create/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows error when profile update fails after family creation', async () => {
+      mockInsert.mockResolvedValue({ data: { id: 'new-family-1' }, error: null })
+      mockUpdate.mockResolvedValue({ error: { message: 'Update failed' } })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+      await userEvent.type(screen.getByLabelText('Family Name'), 'Test Family')
+      await userEvent.click(screen.getByRole('button', { name: /create family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/family created but failed to link/i)).toBeInTheDocument()
+      })
+    })
+
+    it('trims whitespace from family name', async () => {
+      mockInsert.mockResolvedValue({ data: { id: 'new-family-1' }, error: null })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+      await userEvent.type(screen.getByLabelText('Family Name'), '  The Smiths  ')
+      await userEvent.click(screen.getByRole('button', { name: /create family/i }))
+
+      await waitFor(() => {
+        expect(mockInsert).toHaveBeenCalledWith({ name: 'The Smiths' })
+      })
+    })
+  })
+
+  describe('Empty input guards', () => {
+    it('does not submit join when invite code is only whitespace', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+
+      // Type only spaces
+      const input = screen.getByLabelText('Invite Code')
+      await userEvent.type(input, '   ')
+
+      // Submit the form directly (bypass HTML validation)
+      const form = input.closest('form')!
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+      expect(mockRpc).not.toHaveBeenCalled()
+      expect(mockOnComplete).not.toHaveBeenCalled()
+    })
+
+    it('does not submit create when family name is only whitespace', async () => {
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Create new family'))
+
+      // Type only spaces
+      const input = screen.getByLabelText('Family Name')
+      await userEvent.type(input, '   ')
+
+      // Submit the form directly (bypass HTML validation)
+      const form = input.closest('form')!
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+      expect(mockInsert).not.toHaveBeenCalled()
+      expect(mockOnComplete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Error clearing', () => {
+    it('clears error when navigating back from join mode', async () => {
+      mockRpc.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+
+      render(<FamilyStep onComplete={mockOnComplete} />)
+
+      await userEvent.click(screen.getByText('Join existing family'))
+      await userEvent.type(screen.getByLabelText('Invite Code'), 'BADCODE')
+      await userEvent.click(screen.getByRole('button', { name: /join family/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/invalid or expired invite code/i)).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByText('Back'))
+
+      // Go back to join mode - error should be cleared
+      await userEvent.click(screen.getByText('Join existing family'))
+      expect(screen.queryByText(/invalid or expired invite code/i)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/components/onboarding/onboarding-page.test.tsx
+++ b/__tests__/components/onboarding/onboarding-page.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import OnboardingPage from '@/app/(auth)/onboarding/page'
+
+// Mock next/navigation
+const mockPush = jest.fn()
+const mockRefresh = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}))
+
+// Mock next/image
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => <img alt={props.alt} src={props.src} />,
+}))
+
+// Mock Supabase client
+const mockGetUser = jest.fn()
+const mockSelect = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: () => ({
+      select: (...args: unknown[]) => ({
+        eq: (...eqArgs: unknown[]) => ({
+          single: () => mockSelect(...args, ...eqArgs),
+        }),
+      }),
+      update: () => ({
+        eq: () => ({ error: null }),
+      }),
+      insert: () => ({
+        select: () => ({
+          single: () => ({ data: { id: 'new-family' }, error: null }),
+        }),
+      }),
+    }),
+    rpc: () => ({
+      single: () => ({ data: { id: 'family-1', name: 'Test' }, error: null }),
+    }),
+  }),
+}))
+
+// Mock child components to simplify testing
+jest.mock('@/components/onboarding/step-indicator', () => ({
+  StepIndicator: ({ currentStep, totalSteps, labels }: { currentStep: number; totalSteps: number; labels: string[] }) => (
+    <div data-testid="step-indicator" data-current={currentStep} data-total={totalSteps}>
+      {labels.join(', ')}
+    </div>
+  ),
+}))
+
+jest.mock('@/components/onboarding/family-step', () => ({
+  FamilyStep: ({ onComplete }: { onComplete: (id: string) => void }) => (
+    <div data-testid="family-step">
+      <button onClick={() => onComplete('family-123')}>Complete Family</button>
+    </div>
+  ),
+}))
+
+jest.mock('@/components/onboarding/role-avatar-step', () => ({
+  RoleAvatarStep: ({ onComplete }: { onComplete: () => void }) => (
+    <div data-testid="role-avatar-step">
+      <button onClick={() => onComplete()}>Complete Role</button>
+    </div>
+  ),
+}))
+
+describe('OnboardingPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+  })
+
+  it('shows loading spinner initially', () => {
+    // Never resolves - stays loading
+    mockSelect.mockReturnValue(new Promise(() => {}))
+
+    render(<OnboardingPage />)
+
+    // Should show spinner (no step content yet)
+    expect(screen.queryByTestId('family-step')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('role-avatar-step')).not.toBeInTheDocument()
+  })
+
+  it('starts at family step when user has no family_id', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: null }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('family-step')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('role-avatar-step')).not.toBeInTheDocument()
+  })
+
+  it('starts at role-avatar step when user has family_id', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: 'existing-family' }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-avatar-step')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('family-step')).not.toBeInTheDocument()
+  })
+
+  it('shows step indicator with 2 steps when no family_id', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: null }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      const indicator = screen.getByTestId('step-indicator')
+      expect(indicator).toHaveAttribute('data-total', '2')
+      expect(indicator).toHaveAttribute('data-current', '1')
+      expect(indicator).toHaveTextContent('Family, Role & Avatar')
+    })
+  })
+
+  it('shows step indicator with 1 step when family_id exists', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: 'existing-family' }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      const indicator = screen.getByTestId('step-indicator')
+      expect(indicator).toHaveAttribute('data-total', '1')
+      expect(indicator).toHaveAttribute('data-current', '1')
+      expect(indicator).toHaveTextContent('Role & Avatar')
+    })
+  })
+
+  it('transitions from family to role-avatar step on family completion', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: null }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('family-step')).toBeInTheDocument()
+    })
+
+    // Complete family step
+    await userEvent.click(screen.getByText('Complete Family'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-avatar-step')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('family-step')).not.toBeInTheDocument()
+  })
+
+  it('redirects to /quests on role-avatar completion', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: 'existing-family' }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-avatar-step')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('Complete Role'))
+
+    expect(mockPush).toHaveBeenCalledWith('/quests')
+    expect(mockRefresh).toHaveBeenCalled()
+  })
+
+  it('redirects to /login when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  it('shows Welcome heading', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: null }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Welcome!' })).toBeInTheDocument()
+    })
+  })
+
+  it('shows setup text', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: null }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/let's get you set up/i)).toBeInTheDocument()
+    })
+  })
+
+  it('updates step indicator to step 2 after family completion', async () => {
+    mockSelect.mockResolvedValue({ data: { family_id: null }, error: null })
+
+    render(<OnboardingPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('family-step')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('Complete Family'))
+
+    await waitFor(() => {
+      const indicator = screen.getByTestId('step-indicator')
+      expect(indicator).toHaveAttribute('data-current', '2')
+      expect(indicator).toHaveAttribute('data-total', '2')
+    })
+  })
+})

--- a/__tests__/components/onboarding/role-avatar-step.test.tsx
+++ b/__tests__/components/onboarding/role-avatar-step.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RoleAvatarStep } from '@/components/onboarding/role-avatar-step'
+import { AVATAR_OPTIONS } from '@/lib/types'
+
+// Mock next/image
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => <img alt={props.alt} src={props.src} />,
+}))
+
+// Mock Supabase client
+const mockGetUser = jest.fn()
+const mockUpdate = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: () => ({
+      update: (...args: unknown[]) => ({
+        eq: (...eqArgs: unknown[]) => mockUpdate(...args, ...eqArgs),
+      }),
+    }),
+  }),
+}))
+
+describe('RoleAvatarStep', () => {
+  const mockOnComplete = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockUpdate.mockResolvedValue({ error: null })
+  })
+
+  it('renders role selector with Parent and Kid buttons', () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    expect(screen.getByText('I am a...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Parent' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Kid' })).toBeInTheDocument()
+  })
+
+  it('renders heading and description', () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    expect(screen.getByText('Choose Your Role & Avatar')).toBeInTheDocument()
+    expect(screen.getByText(/pick your role and select an avatar/i)).toBeInTheDocument()
+  })
+
+  it('renders avatar grid with all AVATAR_OPTIONS', () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    for (const avatar of AVATAR_OPTIONS) {
+      expect(screen.getByAltText(avatar.name)).toBeInTheDocument()
+    }
+  })
+
+  it('renders Continue button', () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+  })
+
+  it('highlights selected avatar with ring', async () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    const pantherButton = screen.getByAltText('Panther').closest('button')!
+    await userEvent.click(pantherButton)
+
+    expect(pantherButton).toHaveClass('ring-2', 'ring-purple-600', 'bg-purple-50')
+  })
+
+  it('updates profile and calls onComplete on continue', async () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    // Select an avatar
+    const foxButton = screen.getByAltText('Fox').closest('button')!
+    await userEvent.click(foxButton)
+
+    // Click continue
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        { role: 'child', avatar_url: '/avatars/fox.svg' },
+        'id',
+        'user-1'
+      )
+      expect(mockOnComplete).toHaveBeenCalled()
+    })
+  })
+
+  it('sends parent role when Parent is selected', async () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Parent' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        { role: 'parent', avatar_url: null },
+        'id',
+        'user-1'
+      )
+    })
+  })
+
+  it('sends null avatar_url when no avatar selected', async () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        { role: 'child', avatar_url: null },
+        'id',
+        'user-1'
+      )
+    })
+  })
+
+  it('shows loading state during submission', async () => {
+    mockUpdate.mockReturnValue(new Promise(() => {}))
+
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Saving...')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error on profile update failure', async () => {
+    mockUpdate.mockResolvedValue({ error: { message: 'Update failed' } })
+
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to save your profile/i)).toBeInTheDocument()
+    })
+    expect(mockOnComplete).not.toHaveBeenCalled()
+  })
+
+  it('shows error when user is not logged in', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/you must be logged in/i)).toBeInTheDocument()
+    })
+    expect(mockOnComplete).not.toHaveBeenCalled()
+  })
+
+  it('renders all avatar names as text', () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    for (const avatar of AVATAR_OPTIONS) {
+      expect(screen.getByText(avatar.name)).toBeInTheDocument()
+    }
+  })
+
+  it('displays choose your avatar label', () => {
+    render(<RoleAvatarStep onComplete={mockOnComplete} />)
+
+    expect(screen.getByText('Choose your avatar')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/onboarding/step-indicator.test.tsx
+++ b/__tests__/components/onboarding/step-indicator.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react'
+import { StepIndicator } from '@/components/onboarding/step-indicator'
+
+describe('StepIndicator', () => {
+  it('renders correct number of steps', () => {
+    render(<StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    expect(screen.getByText('Family')).toBeInTheDocument()
+    expect(screen.getByText('Role & Avatar')).toBeInTheDocument()
+  })
+
+  it('highlights current step with aria-current', () => {
+    render(<StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    const currentStepCircle = screen.getByText('1').closest('div')
+    expect(currentStepCircle).toHaveAttribute('aria-current', 'step')
+  })
+
+  it('shows step 2 as current when currentStep is 2', () => {
+    render(<StepIndicator currentStep={2} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    const step2Circle = screen.getByText('2').closest('div')
+    expect(step2Circle).toHaveAttribute('aria-current', 'step')
+  })
+
+  it('shows completed steps with checkmark instead of number', () => {
+    render(<StepIndicator currentStep={2} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    // Step 1 is complete - should not show "1" text
+    expect(screen.queryByText('1')).not.toBeInTheDocument()
+    // Step 2 is current - should show "2"
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders a single step when totalSteps is 1', () => {
+    render(<StepIndicator currentStep={1} totalSteps={1} labels={['Role & Avatar']} />)
+
+    expect(screen.getByText('Role & Avatar')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('shows labels for all steps', () => {
+    render(<StepIndicator currentStep={1} totalSteps={3} labels={['Step A', 'Step B', 'Step C']} />)
+
+    expect(screen.getByText('Step A')).toBeInTheDocument()
+    expect(screen.getByText('Step B')).toBeInTheDocument()
+    expect(screen.getByText('Step C')).toBeInTheDocument()
+  })
+
+  it('applies purple styling to current step label', () => {
+    render(<StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    const familyLabel = screen.getByText('Family')
+    expect(familyLabel).toHaveClass('text-purple-600')
+    expect(familyLabel).toHaveClass('font-medium')
+  })
+
+  it('applies gray styling to non-current step labels', () => {
+    render(<StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    const roleLabel = screen.getByText('Role & Avatar')
+    expect(roleLabel).toHaveClass('text-gray-400')
+  })
+
+  it('does not set aria-current on non-current steps', () => {
+    render(<StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />)
+
+    const step2Circle = screen.getByText('2').closest('div')
+    expect(step2Circle).not.toHaveAttribute('aria-current')
+  })
+
+  it('renders connecting line between steps', () => {
+    const { container } = render(
+      <StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />
+    )
+
+    // There should be a connecting line (div with h-0.5)
+    const lines = container.querySelectorAll('.h-0\\.5')
+    expect(lines).toHaveLength(1)
+  })
+
+  it('does not render connecting line after last step', () => {
+    const { container } = render(
+      <StepIndicator currentStep={1} totalSteps={1} labels={['Only Step']} />
+    )
+
+    const lines = container.querySelectorAll('.h-0\\.5')
+    expect(lines).toHaveLength(0)
+  })
+
+  it('fills connecting line with purple when step before it is complete', () => {
+    const { container } = render(
+      <StepIndicator currentStep={2} totalSteps={2} labels={['Family', 'Role & Avatar']} />
+    )
+
+    const line = container.querySelector('.h-0\\.5')
+    expect(line).toHaveClass('bg-purple-600')
+  })
+
+  it('fills connecting line with gray when step before it is not complete', () => {
+    const { container } = render(
+      <StepIndicator currentStep={1} totalSteps={2} labels={['Family', 'Role & Avatar']} />
+    )
+
+    const line = container.querySelector('.h-0\\.5')
+    expect(line).toHaveClass('bg-gray-300')
+  })
+})

--- a/app/(auth)/join/[code]/page.tsx
+++ b/app/(auth)/join/[code]/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
-import { RoleSelector, type Role } from '@/components/ui/role-selector'
 
 export default function JoinFamilyPage() {
   const params = useParams()
@@ -12,7 +11,6 @@ export default function JoinFamilyPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [displayName, setDisplayName] = useState('')
-  const [role, setRole] = useState<Role>('child')
   const [familyName, setFamilyName] = useState<string | null>(null)
   const [familyId, setFamilyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -61,7 +59,6 @@ export default function JoinFamilyPage() {
       options: {
         data: {
           display_name: displayName,
-          role,
         },
       },
     })
@@ -76,7 +73,7 @@ export default function JoinFamilyPage() {
     if (authData.user) {
       const { error: profileError } = await supabase
         .from('profiles')
-        .update({ family_id: familyId, role })
+        .update({ family_id: familyId })
         .eq('id', authData.user.id)
 
       if (profileError) {
@@ -86,7 +83,7 @@ export default function JoinFamilyPage() {
       }
     }
 
-    router.push('/quests')
+    router.push('/onboarding')
     router.refresh()
   }
 
@@ -145,13 +142,6 @@ export default function JoinFamilyPage() {
               className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="Your name"
             />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              I am a...
-            </label>
-            <RoleSelector selected={role} onChange={setRole} />
           </div>
 
           <div>

--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import { StepIndicator } from '@/components/onboarding/step-indicator'
+import { FamilyStep } from '@/components/onboarding/family-step'
+import { RoleAvatarStep } from '@/components/onboarding/role-avatar-step'
+
+type OnboardingStep = 'family-choose' | 'family-join' | 'family-create' | 'role-avatar'
+
+export default function OnboardingPage() {
+  const [step, setStep] = useState<OnboardingStep | null>(null)
+  // Tracks whether the family step was skipped (user already had family_id on load)
+  const [skippedFamilyStep, setSkippedFamilyStep] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const router = useRouter()
+  const supabaseRef = useRef(createClient())
+  const hasFetchedRef = useRef(false)
+
+  useEffect(() => {
+    // Only fetch once on mount
+    if (hasFetchedRef.current) return
+    hasFetchedRef.current = true
+
+    async function fetchProfile() {
+      const supabase = supabaseRef.current
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        router.push('/login')
+        return
+      }
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('family_id')
+        .eq('id', user.id)
+        .single()
+
+      if (profile?.family_id) {
+        setSkippedFamilyStep(true)
+        setStep('role-avatar')
+      } else {
+        setStep('family-choose')
+      }
+      setLoading(false)
+    }
+
+    fetchProfile()
+  }, [router])
+
+  function handleFamilyComplete() {
+    setStep('role-avatar')
+  }
+
+  function handleRoleAvatarComplete() {
+    router.push('/quests')
+    router.refresh()
+  }
+
+  if (loading || !step) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 to-blue-500">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+      </div>
+    )
+  }
+
+  // If family step was skipped, show only 1 step; otherwise show 2
+  const totalSteps = skippedFamilyStep ? 1 : 2
+  const currentStepNumber = step === 'role-avatar' ? totalSteps : 1
+  const labels = skippedFamilyStep ? ['Role & Avatar'] : ['Family', 'Role & Avatar']
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 to-blue-500 p-4">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8">
+        <div className="text-center mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">Welcome!</h1>
+          <p className="text-gray-600 mt-1">Let&apos;s get you set up</p>
+        </div>
+
+        <div className="mb-8">
+          <StepIndicator
+            currentStep={currentStepNumber}
+            totalSteps={totalSteps}
+            labels={labels}
+          />
+        </div>
+
+        {step === 'role-avatar' ? (
+          <RoleAvatarStep onComplete={handleRoleAvatarComplete} />
+        ) : (
+          <FamilyStep onComplete={handleFamilyComplete} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -4,14 +4,12 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
-import { RoleSelector, type Role } from '@/components/ui/role-selector'
 import { InAppBrowserBanner } from '@/components/ui/in-app-browser-banner'
 
 export default function SignupPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [displayName, setDisplayName] = useState('')
-  const [role, setRole] = useState<Role>('child')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [socialLoading, setSocialLoading] = useState(false)
@@ -63,7 +61,6 @@ export default function SignupPage() {
       options: {
         data: {
           display_name: displayName,
-          role,
         },
       },
     })
@@ -74,7 +71,7 @@ export default function SignupPage() {
       return
     }
 
-    router.push('/quests')
+    router.push('/onboarding')
     router.refresh()
   }
 
@@ -108,13 +105,6 @@ export default function SignupPage() {
               className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
               placeholder="Your name"
             />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              I am a...
-            </label>
-            <RoleSelector selected={role} onChange={setRole} />
           </div>
 
           <div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -16,6 +16,17 @@ export default async function DashboardLayout({
     redirect('/login')
   }
 
+  // Ensure user has completed onboarding (has a family)
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    redirect('/onboarding')
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
       {children}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/quests'
+  const next = searchParams.get('next') ?? '/onboarding'
 
   if (code) {
     const supabase = await createClient()

--- a/components/onboarding/family-step.tsx
+++ b/components/onboarding/family-step.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+
+type FamilyMode = 'choose' | 'join' | 'create'
+
+interface FamilyStepProps {
+  onComplete: (familyId: string) => void
+}
+
+export function FamilyStep({ onComplete }: FamilyStepProps) {
+  const [mode, setMode] = useState<FamilyMode>('choose')
+  const [inviteCode, setInviteCode] = useState('')
+  const [familyName, setFamilyName] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const supabase = createClient()
+
+  async function handleJoin(e: React.FormEvent) {
+    e.preventDefault()
+    if (!inviteCode.trim()) return
+
+    setLoading(true)
+    setError(null)
+
+    const { data, error: rpcError } = await supabase
+      .rpc('get_family_by_invite_code', { code: inviteCode.trim() })
+      .single<{ id: string; name: string }>()
+
+    if (rpcError || !data) {
+      setError('Invalid or expired invite code. Please check and try again.')
+      setLoading(false)
+      return
+    }
+
+    // Update user's profile with family_id
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      setError('You must be logged in to join a family.')
+      setLoading(false)
+      return
+    }
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ family_id: data.id })
+      .eq('id', user.id)
+
+    if (updateError) {
+      setError('Failed to join family. Please try again.')
+      setLoading(false)
+      return
+    }
+
+    setLoading(false)
+    onComplete(data.id)
+  }
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!familyName.trim()) return
+
+    setLoading(true)
+    setError(null)
+
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      setError('You must be logged in to create a family.')
+      setLoading(false)
+      return
+    }
+
+    const { data, error: insertError } = await supabase
+      .from('families')
+      .insert({ name: familyName.trim() })
+      .select('id')
+      .single()
+
+    if (insertError || !data) {
+      setError('Failed to create family. Please try again.')
+      setLoading(false)
+      return
+    }
+
+    // Update user's profile with family_id
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ family_id: data.id })
+      .eq('id', user.id)
+
+    if (updateError) {
+      setError('Family created but failed to link your profile. Please try again.')
+      setLoading(false)
+      return
+    }
+
+    setLoading(false)
+    onComplete(data.id)
+  }
+
+  function handleBack() {
+    setMode('choose')
+    setError(null)
+    setInviteCode('')
+    setFamilyName('')
+  }
+
+  if (mode === 'choose') {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold text-gray-900 text-center">Join or Create a Family</h2>
+        <p className="text-gray-600 text-center text-sm">
+          Every champion needs a team! Join an existing family or start a new one.
+        </p>
+        <div className="space-y-3 pt-2">
+          <button
+            onClick={() => setMode('join')}
+            className="w-full p-4 border-2 border-gray-200 rounded-xl text-left hover:border-purple-300 hover:bg-purple-50 transition"
+          >
+            <span className="font-semibold text-gray-900 block">Join existing family</span>
+            <span className="text-sm text-gray-500">I have an invite code</span>
+          </button>
+          <button
+            onClick={() => setMode('create')}
+            className="w-full p-4 border-2 border-gray-200 rounded-xl text-left hover:border-purple-300 hover:bg-purple-50 transition"
+          >
+            <span className="font-semibold text-gray-900 block">Create new family</span>
+            <span className="text-sm text-gray-500">Start fresh and invite others later</span>
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (mode === 'join') {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold text-gray-900 text-center">Join a Family</h2>
+        <p className="text-gray-600 text-center text-sm">
+          Enter the invite code shared by your family member.
+        </p>
+
+        <form onSubmit={handleJoin} className="space-y-4">
+          {error && (
+            <div className="bg-red-50 text-red-600 p-3 rounded-lg text-sm">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="inviteCode" className="block text-sm font-medium text-gray-700 mb-1">
+              Invite Code
+            </label>
+            <input
+              id="inviteCode"
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              required
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900 uppercase"
+              placeholder="Enter code"
+            />
+          </div>
+
+          <Button type="submit" loading={loading} className="w-full h-12">
+            Join Family
+          </Button>
+
+          <button
+            type="button"
+            onClick={handleBack}
+            className="w-full text-sm text-gray-500 hover:text-gray-700 transition"
+          >
+            Back
+          </button>
+        </form>
+      </div>
+    )
+  }
+
+  // mode === 'create'
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold text-gray-900 text-center">Create a Family</h2>
+      <p className="text-gray-600 text-center text-sm">
+        Give your family a name. You can invite members later.
+      </p>
+
+      <form onSubmit={handleCreate} className="space-y-4">
+        {error && (
+          <div className="bg-red-50 text-red-600 p-3 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="familyName" className="block text-sm font-medium text-gray-700 mb-1">
+            Family Name
+          </label>
+          <input
+            id="familyName"
+            type="text"
+            value={familyName}
+            onChange={(e) => setFamilyName(e.target.value)}
+            required
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none transition text-gray-900"
+            placeholder="e.g., The Smiths"
+          />
+        </div>
+
+        <Button type="submit" loading={loading} className="w-full h-12">
+          Create Family
+        </Button>
+
+        <button
+          type="button"
+          onClick={handleBack}
+          className="w-full text-sm text-gray-500 hover:text-gray-700 transition"
+        >
+          Back
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/components/onboarding/role-avatar-step.tsx
+++ b/components/onboarding/role-avatar-step.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import { createClient } from '@/lib/supabase/client'
+import { RoleSelector, type Role } from '@/components/ui/role-selector'
+import { Button } from '@/components/ui/button'
+import { AVATAR_OPTIONS } from '@/lib/types'
+
+interface RoleAvatarStepProps {
+  onComplete: () => void
+}
+
+export function RoleAvatarStep({ onComplete }: RoleAvatarStepProps) {
+  const [role, setRole] = useState<Role>('child')
+  const [selectedAvatar, setSelectedAvatar] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const supabase = createClient()
+
+  async function handleSubmit() {
+    setLoading(true)
+    setError(null)
+
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      setError('You must be logged in.')
+      setLoading(false)
+      return
+    }
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({
+        role,
+        avatar_url: selectedAvatar,
+      })
+      .eq('id', user.id)
+
+    if (updateError) {
+      setError('Failed to save your profile. Please try again.')
+      setLoading(false)
+      return
+    }
+
+    setLoading(false)
+    onComplete()
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h2 className="text-xl font-bold text-gray-900">Choose Your Role & Avatar</h2>
+        <p className="text-gray-600 text-sm mt-1">
+          Pick your role and select an avatar to represent you.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 text-red-600 p-3 rounded-lg text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Role Selection */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          I am a...
+        </label>
+        <RoleSelector selected={role} onChange={setRole} />
+      </div>
+
+      {/* Avatar Selection */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Choose your avatar
+        </label>
+        <div className="grid grid-cols-4 gap-3">
+          {AVATAR_OPTIONS.map((avatar) => (
+            <button
+              key={avatar.id}
+              type="button"
+              onClick={() => setSelectedAvatar(avatar.url)}
+              className={`p-2 rounded-xl transition hover:bg-gray-100 ${
+                selectedAvatar === avatar.url ? 'ring-2 ring-purple-600 bg-purple-50' : ''
+              }`}
+            >
+              <Image
+                src={avatar.url}
+                alt={avatar.name}
+                width={64}
+                height={64}
+                className="w-full h-auto"
+              />
+              <span className="text-xs text-gray-600 mt-1 block">{avatar.name}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        onClick={handleSubmit}
+        loading={loading}
+        className="w-full h-12"
+      >
+        Continue
+      </Button>
+    </div>
+  )
+}

--- a/components/onboarding/step-indicator.tsx
+++ b/components/onboarding/step-indicator.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+interface StepIndicatorProps {
+  currentStep: number
+  totalSteps: number
+  labels: string[]
+}
+
+export function StepIndicator({ currentStep, totalSteps, labels }: StepIndicatorProps) {
+  return (
+    <div className="flex items-center justify-center gap-0">
+      {Array.from({ length: totalSteps }, (_, i) => {
+        const stepNumber = i + 1
+        const isComplete = stepNumber < currentStep
+        const isCurrent = stepNumber === currentStep
+
+        return (
+          <div key={stepNumber} className="flex items-center">
+            <div className="flex flex-col items-center">
+              <div
+                className={cn(
+                  'w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition',
+                  isComplete && 'bg-purple-600 text-white',
+                  isCurrent && 'border-2 border-purple-600 text-purple-600',
+                  !isComplete && !isCurrent && 'border-2 border-gray-300 text-gray-400'
+                )}
+                aria-current={isCurrent ? 'step' : undefined}
+              >
+                {isComplete ? (
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2.5}
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                ) : (
+                  stepNumber
+                )}
+              </div>
+              <span
+                className={cn(
+                  'text-xs mt-1 whitespace-nowrap',
+                  isCurrent ? 'text-purple-600 font-medium' : 'text-gray-400'
+                )}
+              >
+                {labels[i]}
+              </span>
+            </div>
+            {stepNumber < totalSteps && (
+              <div
+                className={cn(
+                  'w-12 h-0.5 mx-1 mb-5',
+                  stepNumber < currentStep ? 'bg-purple-600' : 'bg-gray-300'
+                )}
+              />
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/docs/adr/012-multi-step-onboarding.md
+++ b/docs/adr/012-multi-step-onboarding.md
@@ -1,0 +1,138 @@
+# ADR-012: Multi-Step Onboarding Flow
+
+**Status:** Proposed
+**Issue:** #35
+**Date:** 2026-02-21
+
+## Context
+
+Currently, the signup page collects display name, role, email, and password on a single page, then drops users directly into the dashboard. Users who sign up without an invite code have no family and see empty states everywhere — no quests, no family members, no rewards. This creates a confusing first-run experience that likely contributes to early abandonment.
+
+The app needs a post-authentication onboarding flow that ensures every user belongs to a family and has a role and avatar configured before reaching the dashboard. This flow must work for both email signup and OAuth authentication, and must handle the case where a user already has a family (e.g., they signed up via an invite link on the `/join/[code]` page).
+
+## Decision
+
+### Separate `/onboarding` Route
+
+The onboarding flow lives at `app/(auth)/onboarding/page.tsx`, separate from the signup page. This keeps signup simple (just credentials) and ensures onboarding runs regardless of how the user authenticated — email signup, OAuth callback, or invite code join. All post-auth redirects point to `/onboarding` instead of `/quests`.
+
+### Two-Step Flow with Conditional Step Skipping
+
+The onboarding has two logical steps:
+
+1. **Family step** — Join an existing family via invite code, or create a new family
+2. **Role + Avatar step** — Select parent/child role and pick an avatar
+
+Users who already have a `family_id` (e.g., invite code signups via the `/join/[code]` page) skip step 1 entirely and go straight to step 2. This avoids redundant prompts while ensuring every user completes role and avatar selection.
+
+### Dashboard Layout Redirect Guard
+
+Rather than adding complex middleware logic (which cannot efficiently query Supabase for profile data), the `app/(dashboard)/layout.tsx` checks `profile.family_id` after authentication. If `family_id` is null, the user is redirected to `/onboarding`. This prevents users from accessing any dashboard page without completing onboarding, using a check that runs on every dashboard page load via the shared layout.
+
+### Middleware Protects `/onboarding`
+
+The `/onboarding` route is added to the middleware's protected route list, ensuring unauthenticated users cannot access it. The middleware's default redirect for authenticated users visiting auth pages (login, signup) is changed from `/quests` to `/onboarding`.
+
+### Role Removed from Signup and Join Pages
+
+The `RoleSelector` component is removed from both the signup page and the join page. Role selection moves entirely to onboarding step 2. This simplifies the signup form and consolidates profile configuration into one place. The default role remains `'child'` (set during signup), updated during onboarding.
+
+### Family Membership Mandatory, Inviting Members Optional
+
+Users must either join or create a family to proceed past step 1 — there is no "skip" option. However, after creating a family, inviting additional members is not part of the onboarding flow. Invite codes are accessible from the family management page in the dashboard. This keeps onboarding focused on the minimum viable setup.
+
+### Client-Side Step State Management
+
+The onboarding page is a client component that manages step state internally: `'family-choose' | 'family-join' | 'family-create' | 'role-avatar'`. On mount, it fetches the user's profile to determine the starting step. Step transitions are handled via callbacks passed to child components. No server actions or URL-based step routing — the entire flow is a single page with component swapping.
+
+### Reuse Existing Components
+
+The `RoleSelector` component (`components/ui/role-selector.tsx`) is reused directly in the role+avatar step. The avatar grid follows the existing pattern from `app/(dashboard)/me/page.tsx`, using `AVATAR_OPTIONS` from `lib/types.ts`. The family join flow reuses the existing `get_family_by_invite_code` RPC. No new database tables, columns, or RLS policies are needed.
+
+## Consequences
+
+### Positive
+- Every user is guaranteed to have a family, role, and avatar before reaching the dashboard, eliminating empty-state confusion on first login
+- Works identically for email signup, OAuth, and invite code flows — a single onboarding path regardless of authentication method
+- No database migration required — the flow uses existing tables and columns (`profiles.family_id`, `profiles.role`, `profiles.avatar_url`, `families`)
+- Removing role selection from signup simplifies the signup form, reducing friction at the account creation step
+- Conditional step skipping means invite code users get a streamlined experience (one step instead of two)
+- Dashboard layout guard is a reliable catch-all — even if a user somehow bypasses onboarding, they cannot access the dashboard without a family
+
+### Negative
+- Adds a new page and three new components, increasing the codebase surface area
+- Dashboard layout now makes a profile query on every page load to check `family_id`, adding a small performance cost (mitigated by Supabase's connection pooling and the query being a simple single-row fetch by user ID)
+- Client-side step management means the step state is lost on page refresh — the user restarts from the beginning (mitigated by the profile check determining the correct starting step on mount)
+- Changing the default redirect from `/quests` to `/onboarding` affects all authentication flows, requiring coordinated updates to signup, join, callback, and middleware
+
+## Alternatives Considered
+
+1. **Embed onboarding in the signup form**: Add family creation/joining and avatar selection as additional fields on the existing signup page. This would make the signup form significantly longer and more complex, increasing abandonment risk. It also would not work for OAuth users who bypass the signup form entirely. Rejected because a separate post-auth flow handles all authentication methods uniformly.
+
+2. **URL-based step routing (`/onboarding/family`, `/onboarding/role`)**: Use separate routes for each onboarding step instead of client-side state management. This would make steps bookmarkable and support browser back/forward navigation, but adds routing complexity, requires server-side step validation, and is over-engineered for a two-step flow that most users complete in under a minute. Rejected for unnecessary complexity.
+
+3. **Middleware-based profile check instead of layout guard**: Check `profile.family_id` in the Supabase middleware and redirect to `/onboarding` before the dashboard loads. Middleware runs on the edge and cannot efficiently query the Supabase database for profile data — it only has access to the auth session. Adding a database call to middleware would add latency to every request. Rejected because the layout-level check is simpler and runs only on dashboard page loads.
+
+4. **Optional onboarding with "skip" button**: Allow users to skip onboarding and reach the dashboard without a family, showing a persistent banner prompting them to complete setup. This would preserve the current empty-state problem for users who skip, and the app's core features (quests, rewards) require a family to function at all. Rejected because family membership is a prerequisite for the app to be useful.
+
+5. **Server Component with server actions for step transitions**: Implement onboarding as a Server Component using `redirect()` and server actions instead of client-side state. This would require form submissions for every step transition and lose the smooth single-page-app feel. The onboarding flow benefits from immediate client-side transitions and optimistic updates. Rejected for worse user experience.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    A[User authenticates] --> B{Auth method?}
+
+    B -->|Email signup| C[Signup page]
+    B -->|OAuth| D[Auth callback]
+    B -->|Invite code| E[Join page]
+
+    C -->|Redirect| F[/onboarding]
+    D -->|Redirect| F
+    E -->|Sets family_id, redirect| F
+
+    F --> G[Fetch profile]
+    G --> H{family_id exists?}
+
+    H -->|No| I[Step 1: Family]
+    H -->|Yes| L[Step 2: Role + Avatar]
+
+    I --> J{Choose mode}
+    J -->|Join existing| K1[Enter invite code]
+    J -->|Create new| K2[Enter family name]
+
+    K1 -->|Validate code, set family_id| L
+    K2 -->|Insert family, set family_id| L
+
+    L --> M[Select role]
+    M --> N[Select avatar]
+    N --> O[Update profile]
+    O --> P[Redirect to /quests]
+
+    P --> Q[Dashboard layout]
+    Q --> R{family_id exists?}
+    R -->|Yes| S[Render dashboard]
+    R -->|No| F
+```
+
+## Implementation
+
+Key files and changes:
+
+**New files (4 source, 4 test, 1 E2E):**
+- `app/(auth)/onboarding/page.tsx` — Client component with step state management, profile fetch on mount, step transitions, redirect to `/quests` on completion
+- `components/onboarding/step-indicator.tsx` — Horizontal step progress indicator with circles and connecting lines, supports variable step count and labels
+- `components/onboarding/family-step.tsx` — Three sub-modes (choose, join, create) with invite code validation via Supabase RPC and family creation via insert
+- `components/onboarding/role-avatar-step.tsx` — Reuses `RoleSelector`, adds avatar grid from `AVATAR_OPTIONS`, updates profile on completion
+- `__tests__/components/onboarding/step-indicator.test.tsx` — Step rendering, current step highlighting, label display
+- `__tests__/components/onboarding/family-step.test.tsx` — Sub-mode transitions, join/create flows, error handling
+- `__tests__/components/onboarding/role-avatar-step.test.tsx` — Role selection, avatar selection, profile update, loading/error states
+- `__tests__/components/onboarding/onboarding-page.test.tsx` — Conditional step skipping, step transitions, completion redirect
+- `e2e/onboarding.spec.ts` — Full onboarding flow, join family flow, invite code signup flow, dashboard redirect guard
+
+**Modified files (5):**
+- `app/(auth)/signup/page.tsx` — Remove `RoleSelector`, remove role state, redirect to `/onboarding` instead of `/quests`
+- `app/(auth)/join/[code]/page.tsx` — Remove `RoleSelector`, remove role state, redirect to `/onboarding`
+- `app/auth/callback/route.ts` — Change default redirect from `/quests` to `/onboarding`
+- `lib/supabase/middleware.ts` — Add `/onboarding` to protected routes, change auth redirect to `/onboarding`
+- `app/(dashboard)/layout.tsx` — Add profile fetch and `family_id` null check with redirect to `/onboarding`

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -87,36 +87,17 @@ test.describe('Login Page', () => {
 })
 
 test.describe('Signup Page', () => {
-  test('displays signup form with role selector', async ({ page }) => {
+  test('displays signup form without role selector', async ({ page }) => {
     await page.goto('/signup')
 
     await expect(page.getByRole('heading', { name: /chore champions/i })).toBeVisible()
     await expect(page.getByText(/join the family adventure/i)).toBeVisible()
     await expect(page.getByLabel(/display name/i)).toBeVisible()
-    await expect(page.getByText('I am a...')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Parent' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Kid' })).toBeVisible()
+    // Role selector removed - now in onboarding
+    await expect(page.getByText('I am a...')).not.toBeVisible()
     await expect(page.getByLabel(/email/i)).toBeVisible()
     await expect(page.getByLabel(/password/i)).toBeVisible()
     await expect(page.getByRole('button', { name: /create account/i })).toBeVisible()
-  })
-
-  test('role selector defaults to Kid', async ({ page }) => {
-    await page.goto('/signup')
-
-    const kidButton = page.getByRole('button', { name: 'Kid' })
-    await expect(kidButton).toHaveClass(/bg-purple-600/)
-  })
-
-  test('can select Parent role', async ({ page }) => {
-    await page.goto('/signup')
-
-    const parentButton = page.getByRole('button', { name: 'Parent' })
-    await parentButton.click()
-    await expect(parentButton).toHaveClass(/bg-purple-600/)
-
-    const kidButton = page.getByRole('button', { name: 'Kid' })
-    await expect(kidButton).not.toHaveClass(/bg-purple-600/)
   })
 
   test('displays Google and Facebook signup buttons', async ({ page }) => {
@@ -203,27 +184,11 @@ test.describe('Join Family Page', () => {
   })
 })
 
-test.describe('Role Selector', () => {
-  test('role selector works on signup page', async ({ page }) => {
-    await page.goto('/signup')
+test.describe('Onboarding redirect', () => {
+  test('unauthenticated users cannot access /onboarding', async ({ page }) => {
+    await page.goto('/onboarding')
 
-    // Kid is selected by default
-    const kidButton = page.getByRole('button', { name: 'Kid' })
-    const parentButton = page.getByRole('button', { name: 'Parent' })
-
-    await expect(kidButton).toHaveClass(/bg-purple-600/)
-    await expect(parentButton).not.toHaveClass(/bg-purple-600/)
-
-    // Click Parent
-    await parentButton.click()
-
-    await expect(parentButton).toHaveClass(/bg-purple-600/)
-    await expect(kidButton).not.toHaveClass(/bg-purple-600/)
-
-    // Click Kid again
-    await kidButton.click()
-
-    await expect(kidButton).toHaveClass(/bg-purple-600/)
-    await expect(parentButton).not.toHaveClass(/bg-purple-600/)
+    // Should redirect to login
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 })
   })
 })

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Onboarding Flow', () => {
+  test('authenticated user can access onboarding page', async ({ page }) => {
+    // Parent project already has stored auth state — no manual login needed
+    await page.goto('/onboarding')
+    await page.waitForLoadState('networkidle')
+
+    // Should be on the onboarding page (not redirected to login)
+    await expect(page).toHaveURL(/\/onboarding/, { timeout: 10000 })
+  })
+
+  test('onboarding page shows welcome heading', async ({ page }) => {
+    await page.goto('/onboarding')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByRole('heading', { name: /welcome/i })).toBeVisible({ timeout: 10000 })
+  })
+
+  test('onboarding page shows role and avatar selection for users with family', async ({ page }) => {
+    // Test parent already has a family, so should skip family step
+    await page.goto('/onboarding')
+    await page.waitForLoadState('networkidle')
+
+    // Should see role & avatar step (family step skipped)
+    await expect(page.getByText(/choose your role/i)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('button', { name: 'Parent' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Kid' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible()
+  })
+
+  test('selecting role and avatar then clicking continue redirects to quests', async ({ page }) => {
+    await page.goto('/onboarding')
+    await page.waitForLoadState('networkidle')
+
+    // Wait for role & avatar step to load
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible({ timeout: 10000 })
+
+    // Select parent role
+    await page.getByRole('button', { name: 'Parent' }).click()
+
+    // Select an avatar
+    await page.getByAltText('Fox').click()
+
+    // Click continue
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    // Should redirect to quests
+    await expect(page).toHaveURL(/\/quests/, { timeout: 15000 })
+  })
+})

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -38,7 +38,8 @@ export async function updateSession(request: NextRequest) {
   const isProtectedRoute = request.nextUrl.pathname.startsWith('/quests') ||
     request.nextUrl.pathname.startsWith('/family') ||
     request.nextUrl.pathname.startsWith('/rewards') ||
-    request.nextUrl.pathname.startsWith('/me')
+    request.nextUrl.pathname.startsWith('/me') ||
+    request.nextUrl.pathname.startsWith('/onboarding')
 
   if (isProtectedRoute && !user) {
     const url = request.nextUrl.clone()
@@ -52,7 +53,7 @@ export async function updateSession(request: NextRequest) {
 
   if (isAuthRoute && user) {
     const url = request.nextUrl.clone()
-    url.pathname = '/quests'
+    url.pathname = '/onboarding'
     return NextResponse.redirect(url)
   }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         storageState: '.auth/parent.json',
       },
       dependencies: ['setup'],
-      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts/,
+      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts/,
     },
     // Destructive parent tests (sign-out) that invalidate the session - run last
     {


### PR DESCRIPTION
## Summary
- Adds post-auth `/onboarding` route with two steps: **Family** (join/create) and **Role & Avatar** selection
- Users who signed up via invite code skip the family step (they already have `family_id`)
- Dashboard layout guard redirects users without a family to onboarding
- RoleSelector removed from signup/join pages, consolidated into onboarding step 2
- Auth callback and middleware updated to route through `/onboarding` instead of `/quests`

## Changes
- **4 new components**: `step-indicator.tsx`, `family-step.tsx`, `role-avatar-step.tsx`, `onboarding/page.tsx`
- **5 modified source files**: signup, join, callback, middleware, dashboard layout
- **57 new unit tests** (step-indicator: 12, family-step: 21, role-avatar-step: 13, onboarding-page: 11)
- **4 E2E tests** for onboarding flow
- **ADR**: `docs/adr/012-multi-step-onboarding.md`

## Test plan
- [ ] Verify new user signup redirects to `/onboarding`
- [ ] Verify family creation flow (enter name → family created → proceeds to role/avatar)
- [ ] Verify family join flow (enter invite code → validates → joins family → proceeds to role/avatar)
- [ ] Verify invite code signup skips family step (goes straight to role/avatar)
- [ ] Verify role + avatar selection updates profile and redirects to `/quests`
- [ ] Verify dashboard redirects to `/onboarding` if user has no family
- [ ] Verify OAuth callback routes through `/onboarding`
- [ ] All 687 unit tests pass
- [ ] All 139 E2E tests pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)