### PR TITLE
Add streak tracking with milestones and freeze system (#37)

### DIFF
--- a/__tests__/app/dashboard/me.test.tsx
+++ b/__tests__/app/dashboard/me.test.tsx
@@ -17,6 +17,13 @@ jest.mock('next/image', () => ({
   default: (props: { alt: string }) => <img alt={props.alt} />,
 }))
 
+// Mock StreakTab
+jest.mock('@/components/streaks/streak-tab', () => ({
+  StreakTab: ({ userId, userPoints }: { userId: string; userPoints: number }) => (
+    <div data-testid="streak-tab">Streak Tab for {userId} with {userPoints} points</div>
+  ),
+}))
+
 // Mock Supabase client
 const mockGetUser = jest.fn()
 const mockSignOut = jest.fn()
@@ -743,6 +750,73 @@ describe('Me Page', () => {
       await waitFor(() => {
         expect(screen.queryByText('Choose Avatar')).not.toBeInTheDocument()
       })
+    })
+  })
+
+  describe('tab switching', () => {
+    it('renders Profile and Streaks tab buttons', async () => {
+      render(<MePage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('My Profile')).toBeInTheDocument()
+      })
+
+      expect(screen.getByRole('button', { name: 'Profile' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Streaks' })).toBeInTheDocument()
+    })
+
+    it('shows profile content by default', async () => {
+      render(<MePage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('My Profile')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Personal Info')).toBeInTheDocument()
+      expect(screen.queryByTestId('streak-tab')).not.toBeInTheDocument()
+    })
+
+    it('switches to streaks tab when Streaks button clicked', async () => {
+      const user = userEvent.setup()
+      render(<MePage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('My Profile')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Streaks' }))
+
+      expect(screen.getByTestId('streak-tab')).toBeInTheDocument()
+      expect(screen.queryByText('Personal Info')).not.toBeInTheDocument()
+    })
+
+    it('switches back to profile tab', async () => {
+      const user = userEvent.setup()
+      render(<MePage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('My Profile')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Streaks' }))
+      expect(screen.getByTestId('streak-tab')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Profile' }))
+      expect(screen.getByText('Personal Info')).toBeInTheDocument()
+      expect(screen.queryByTestId('streak-tab')).not.toBeInTheDocument()
+    })
+
+    it('passes correct props to StreakTab', async () => {
+      const user = userEvent.setup()
+      render(<MePage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('My Profile')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Streaks' }))
+
+      expect(screen.getByText('Streak Tab for user-123 with 100 points')).toBeInTheDocument()
     })
   })
 

--- a/__tests__/components/streaks/freeze-section.test.tsx
+++ b/__tests__/components/streaks/freeze-section.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FreezeSection } from '@/components/streaks/freeze-section'
+
+describe('FreezeSection', () => {
+  const defaultProps = {
+    available: 3,
+    used: 1,
+    userPoints: 100,
+    onBuy: jest.fn().mockResolvedValue(undefined),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders freeze section title', () => {
+    render(<FreezeSection {...defaultProps} />)
+
+    expect(screen.getByText('Streak Freezes')).toBeInTheDocument()
+  })
+
+  it('renders snowflake icon', () => {
+    render(<FreezeSection {...defaultProps} />)
+
+    expect(screen.getByText('❄️')).toBeInTheDocument()
+  })
+
+  it('shows remaining freeze count', () => {
+    render(<FreezeSection {...defaultProps} />)
+
+    expect(screen.getByTestId('freeze-count')).toHaveTextContent('2') // 3 - 1
+  })
+
+  it('shows buy button', () => {
+    render(<FreezeSection {...defaultProps} />)
+
+    expect(screen.getByRole('button', { name: /Buy Freeze/i })).toBeInTheDocument()
+  })
+
+  it('buy button is enabled when user has enough points', () => {
+    render(<FreezeSection {...defaultProps} />)
+
+    expect(screen.getByRole('button', { name: /Buy Freeze/i })).not.toBeDisabled()
+  })
+
+  it('buy button is disabled when user has < 50 points', () => {
+    render(<FreezeSection {...defaultProps} userPoints={30} />)
+
+    expect(screen.getByRole('button', { name: /Buy Freeze/i })).toBeDisabled()
+  })
+
+  it('shows points needed message when insufficient', () => {
+    render(<FreezeSection {...defaultProps} userPoints={30} />)
+
+    expect(screen.getByText('Need 20 more points')).toBeInTheDocument()
+  })
+
+  it('does not show points needed when sufficient', () => {
+    render(<FreezeSection {...defaultProps} userPoints={100} />)
+
+    expect(screen.queryByText(/Need.*more points/)).not.toBeInTheDocument()
+  })
+
+  it('calls onBuy when buy button clicked', async () => {
+    const onBuy = jest.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    render(<FreezeSection {...defaultProps} onBuy={onBuy} />)
+
+    await user.click(screen.getByRole('button', { name: /Buy Freeze/i }))
+
+    await waitFor(() => {
+      expect(onBuy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows loading state during purchase', async () => {
+    let resolveBuy: () => void
+    const onBuy = jest.fn().mockReturnValue(new Promise<void>((resolve) => { resolveBuy = resolve }))
+    const user = userEvent.setup()
+    render(<FreezeSection {...defaultProps} onBuy={onBuy} />)
+
+    await user.click(screen.getByRole('button', { name: /Buy Freeze/i }))
+
+    // While buying, button should show loading state (from Button component)
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+
+    // Resolve the promise
+    resolveBuy!()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Buy Freeze/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows 0 remaining when all used', () => {
+    render(<FreezeSection {...defaultProps} available={2} used={2} />)
+
+    expect(screen.getByTestId('freeze-count')).toHaveTextContent('0')
+  })
+
+  it('shows description text', () => {
+    render(<FreezeSection {...defaultProps} />)
+
+    expect(screen.getByText('Protect your streak when you miss a day')).toBeInTheDocument()
+  })
+
+  it('shows exact 50 points boundary', () => {
+    render(<FreezeSection {...defaultProps} userPoints={50} />)
+
+    expect(screen.getByRole('button', { name: /Buy Freeze/i })).not.toBeDisabled()
+    expect(screen.queryByText(/Need.*more points/)).not.toBeInTheDocument()
+  })
+
+  it('shows 49 points as insufficient', () => {
+    render(<FreezeSection {...defaultProps} userPoints={49} />)
+
+    expect(screen.getByRole('button', { name: /Buy Freeze/i })).toBeDisabled()
+    expect(screen.getByText('Need 1 more points')).toBeInTheDocument()
+  })
+
+  it('handles zero available and zero used', () => {
+    render(<FreezeSection {...defaultProps} available={0} used={0} />)
+
+    expect(screen.getByTestId('freeze-count')).toHaveTextContent('0')
+  })
+})

--- a/__tests__/components/streaks/milestone-badge.test.tsx
+++ b/__tests__/components/streaks/milestone-badge.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MilestoneBadge } from '@/components/streaks/milestone-badge'
+import type { StreakMilestone } from '@/lib/types'
+
+const mockMilestone: StreakMilestone = { days: 7, bonus: 50, badge: 'Week Warrior' }
+
+describe('MilestoneBadge', () => {
+  it('renders milestone days and bonus', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="locked" />)
+
+    expect(screen.getByText('7d')).toBeInTheDocument()
+    expect(screen.getByText('+50')).toBeInTheDocument()
+  })
+
+  it('has correct aria-label', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="locked" />)
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Week Warrior - 7 days - locked'
+    )
+  })
+
+  it('is disabled when locked', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="locked" />)
+
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('is disabled when claimed', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="claimed" />)
+
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('is enabled when claimable', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="claimable" />)
+
+    expect(screen.getByRole('button')).not.toBeDisabled()
+  })
+
+  it('calls onClaim when clicked and claimable', async () => {
+    const onClaim = jest.fn()
+    const user = userEvent.setup()
+    render(<MilestoneBadge milestone={mockMilestone} status="claimable" onClaim={onClaim} />)
+
+    await user.click(screen.getByRole('button'))
+
+    expect(onClaim).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onClaim when locked', async () => {
+    const onClaim = jest.fn()
+    const user = userEvent.setup()
+    render(<MilestoneBadge milestone={mockMilestone} status="locked" onClaim={onClaim} />)
+
+    await user.click(screen.getByRole('button'))
+
+    expect(onClaim).not.toHaveBeenCalled()
+  })
+
+  it('does not call onClaim when claimed', async () => {
+    const onClaim = jest.fn()
+    const user = userEvent.setup()
+    render(<MilestoneBadge milestone={mockMilestone} status="claimed" onClaim={onClaim} />)
+
+    await user.click(screen.getByRole('button'))
+
+    expect(onClaim).not.toHaveBeenCalled()
+  })
+
+  it('handles claimable status without onClaim prop', async () => {
+    const user = userEvent.setup()
+    render(<MilestoneBadge milestone={mockMilestone} status="claimable" />)
+
+    // Should not throw
+    await user.click(screen.getByRole('button'))
+  })
+
+  it('applies claimed styles', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="claimed" />)
+
+    const button = screen.getByRole('button')
+    expect(button.className).toContain('bg-yellow-100')
+  })
+
+  it('applies claimable styles', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="claimable" />)
+
+    const button = screen.getByRole('button')
+    expect(button.className).toContain('bg-purple-100')
+    expect(button.className).toContain('animate-pulse')
+  })
+
+  it('applies locked styles', () => {
+    render(<MilestoneBadge milestone={mockMilestone} status="locked" />)
+
+    const button = screen.getByRole('button')
+    expect(button.className).toContain('bg-gray-100')
+  })
+
+  it('renders different milestone values', () => {
+    const milestone: StreakMilestone = { days: 100, bonus: 1000, badge: 'Century Champion' }
+    render(<MilestoneBadge milestone={milestone} status="locked" />)
+
+    expect(screen.getByText('100d')).toBeInTheDocument()
+    expect(screen.getByText('+1000')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Century Champion - 100 days - locked'
+    )
+  })
+})

--- a/__tests__/components/streaks/streak-card.test.tsx
+++ b/__tests__/components/streaks/streak-card.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { StreakCard } from '@/components/streaks/streak-card'
+
+describe('StreakCard', () => {
+  const defaultProps = {
+    type: 'active_day',
+    label: 'Active Day',
+    streak: 5,
+    claimedMilestones: [] as number[],
+    onClaimMilestone: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders label and streak count', () => {
+    render(<StreakCard {...defaultProps} />)
+
+    expect(screen.getByText('Active Day')).toBeInTheDocument()
+    expect(screen.getByTestId('streak-count-active_day')).toHaveTextContent('5')
+  })
+
+  it('renders fire icon', () => {
+    render(<StreakCard {...defaultProps} />)
+
+    expect(screen.getByText('🔥')).toBeInTheDocument()
+  })
+
+  it('shows progress toward next milestone', () => {
+    render(<StreakCard {...defaultProps} />)
+
+    expect(screen.getByText('5 days')).toBeInTheDocument()
+    expect(screen.getByText('Next: 7 days')).toBeInTheDocument()
+  })
+
+  it('shows singular "day" for streak of 1', () => {
+    render(<StreakCard {...defaultProps} streak={1} />)
+
+    expect(screen.getByText('1 day')).toBeInTheDocument()
+  })
+
+  it('renders progress bar with correct percentage', () => {
+    render(<StreakCard {...defaultProps} streak={5} />)
+
+    const progressBar = screen.getByRole('progressbar')
+    expect(progressBar).toHaveStyle({ width: '71%' }) // 5/7 ≈ 71%
+  })
+
+  it('renders all 5 milestone badges', () => {
+    render(<StreakCard {...defaultProps} />)
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(5)
+  })
+
+  it('shows milestone badges with correct statuses', () => {
+    render(<StreakCard {...defaultProps} streak={10} claimedMilestones={[7]} />)
+
+    // 7-day should be claimed
+    expect(screen.getByLabelText(/Week Warrior.*claimed/)).toBeInTheDocument()
+    // 14-day should be locked (streak 10 < 14)
+    expect(screen.getByLabelText(/Fortnight Fighter.*locked/)).toBeInTheDocument()
+  })
+
+  it('shows claimable milestone when streak meets threshold', () => {
+    render(<StreakCard {...defaultProps} streak={7} />)
+
+    expect(screen.getByLabelText(/Week Warrior.*claimable/)).toBeInTheDocument()
+  })
+
+  it('calls onClaimMilestone when claimable badge clicked', async () => {
+    const onClaim = jest.fn()
+    const user = userEvent.setup()
+    render(<StreakCard {...defaultProps} streak={7} onClaimMilestone={onClaim} />)
+
+    await user.click(screen.getByLabelText(/Week Warrior.*claimable/))
+
+    expect(onClaim).toHaveBeenCalledWith(7)
+  })
+
+  it('does not show "Next" text when all milestones are claimed and streak exceeds all', () => {
+    render(
+      <StreakCard
+        {...defaultProps}
+        streak={200}
+        claimedMilestones={[7, 14, 30, 60, 100]}
+      />
+    )
+
+    expect(screen.queryByText(/Next:/)).not.toBeInTheDocument()
+  })
+
+  it('progress bar is 100% when no next milestone', () => {
+    render(
+      <StreakCard
+        {...defaultProps}
+        streak={200}
+        claimedMilestones={[7, 14, 30, 60, 100]}
+      />
+    )
+
+    const progressBar = screen.getByRole('progressbar')
+    expect(progressBar).toHaveStyle({ width: '100%' })
+  })
+
+  it('renders with zero streak', () => {
+    render(<StreakCard {...defaultProps} streak={0} />)
+
+    expect(screen.getByTestId('streak-count-active_day')).toHaveTextContent('0')
+    expect(screen.getByText('0 days')).toBeInTheDocument()
+  })
+
+  it('progress bar caps at 100% when streak equals milestone', () => {
+    // When streak is 7 and 7-day is unclaimed, next milestone is still 7
+    // so 7/7 = 100%
+    render(<StreakCard {...defaultProps} streak={7} />)
+
+    const progressBar = screen.getByRole('progressbar')
+    // getNextMilestone returns 14-day since 7-day is claimable (not "next")
+    // Actually getNextMilestone: streak < milestone.days, so 7 < 7 is false, moves to 14
+    // so 7/14 = 50%
+    expect(progressBar).toHaveStyle({ width: '50%' })
+  })
+})

--- a/__tests__/components/streaks/streak-tab.test.tsx
+++ b/__tests__/components/streaks/streak-tab.test.tsx
@@ -1,0 +1,368 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
+import { StreakTab } from '@/components/streaks/streak-tab'
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+// Mock Supabase
+const mockRpc = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    rpc: mockRpc,
+    from: mockFrom,
+  }),
+}))
+
+const mockStreaks = {
+  active_day_streak: 5,
+  perfect_day_streak: 3,
+  task_streaks: [
+    { task_id: 'task-1', title: 'Make Bed', current_streak: 7 },
+    { task_id: 'task-2', title: 'Brush Teeth', current_streak: 0 },
+  ],
+}
+
+const mockMilestones = [
+  { streak_type: 'active_day', task_id: null, milestone_days: 7, points_awarded: 50, badge_name: 'Week Warrior' },
+]
+
+function setupMocks(overrides?: {
+  streaks?: typeof mockStreaks | null
+  freezes?: { available: number; used: number } | null
+  milestones?: typeof mockMilestones | null
+}) {
+  mockRpc.mockImplementation((fn: string) => {
+    if (fn === 'get_user_streaks') {
+      return Promise.resolve({ data: overrides?.streaks ?? mockStreaks })
+    }
+    if (fn === 'claim_streak_milestone') {
+      return Promise.resolve({ data: { success: true, bonus: 50, badge: 'Week Warrior' } })
+    }
+    if (fn === 'buy_streak_freeze') {
+      return Promise.resolve({ data: { success: true } })
+    }
+    return Promise.resolve({ data: null })
+  })
+
+  mockFrom.mockImplementation((table: string) => ({
+    select: () => ({
+      eq: () => {
+        if (table === 'streak_freezes') {
+          return {
+            single: () => Promise.resolve({ data: overrides?.freezes ?? { available: 2, used: 1 } }),
+          }
+        }
+        // streak_milestones
+        return Promise.resolve({ data: overrides?.milestones ?? mockMilestones })
+      },
+    }),
+  }))
+}
+
+describe('StreakTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setupMocks()
+  })
+
+  it('shows loading skeleton initially', () => {
+    // Make RPC hang
+    mockRpc.mockReturnValue(new Promise(() => {}))
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () => new Promise(() => {}),
+        }),
+      }),
+    })
+
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    const skeletons = document.querySelectorAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('renders active streak count summary', async () => {
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      // 3 active: active_day (5), perfect_day (3), Make Bed (7) — Brush Teeth is 0
+      expect(screen.getByText(/active streaks/)).toBeInTheDocument()
+    })
+  })
+
+  it('renders Active Day streak card', async () => {
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Day')).toBeInTheDocument()
+      expect(screen.getByTestId('streak-count-active_day')).toHaveTextContent('5')
+    })
+  })
+
+  it('renders Perfect Day streak card', async () => {
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Perfect Day')).toBeInTheDocument()
+      expect(screen.getByTestId('streak-count-perfect_day')).toHaveTextContent('3')
+    })
+  })
+
+  it('renders task streak cards', async () => {
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Make Bed')).toBeInTheDocument()
+      expect(screen.getByText('Brush Teeth')).toBeInTheDocument()
+    })
+  })
+
+  it('renders freeze section', async () => {
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Streak Freezes')).toBeInTheDocument()
+      expect(screen.getByTestId('freeze-count')).toHaveTextContent('1')
+    })
+  })
+
+  it('shows singular "streak" when only 1 active', async () => {
+    setupMocks({
+      streaks: {
+        active_day_streak: 1,
+        perfect_day_streak: 0,
+        task_streaks: [],
+      },
+    })
+
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/active streak$/)).toBeInTheDocument()
+    })
+  })
+
+  it('handles null streaks data', async () => {
+    setupMocks({ streaks: null })
+
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+  })
+
+  it('handles null freezes data gracefully', async () => {
+    setupMocks({ freezes: null })
+
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      // When freeze data is null, defaults to { available: 0, used: 0 }
+      expect(screen.getByText('Streak Freezes')).toBeInTheDocument()
+      expect(screen.getByTestId('freeze-count')).toBeInTheDocument()
+    })
+  })
+
+  it('handles null milestones data', async () => {
+    setupMocks({ milestones: null })
+
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Day')).toBeInTheDocument()
+    })
+  })
+
+  it('calls claim_streak_milestone RPC and shows toast on success', async () => {
+    setupMocks({
+      streaks: {
+        active_day_streak: 7,
+        perfect_day_streak: 0,
+        task_streaks: [],
+      },
+      milestones: [],
+    })
+
+    const user = userEvent.setup()
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Day')).toBeInTheDocument()
+    })
+
+    // Find the claimable 7-day milestone for Active Day
+    const claimableButton = screen.getAllByLabelText(/Week Warrior.*claimable/)[0]
+    await user.click(claimableButton)
+
+    expect(mockRpc).toHaveBeenCalledWith('claim_streak_milestone', {
+      p_user_id: 'user-1',
+      p_streak_type: 'active_day',
+      p_task_id: '00000000-0000-0000-0000-000000000000',
+      p_milestone_days: 7,
+      p_current_streak: 7,
+    })
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Week Warrior unlocked! +50 points')
+    })
+  })
+
+  it('calls buy_streak_freeze RPC and shows toast on success', async () => {
+    const user = userEvent.setup()
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Streak Freezes')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /Buy Freeze/i }))
+
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenCalledWith('buy_streak_freeze', { p_user_id: 'user-1' })
+      expect(toast.success).toHaveBeenCalledWith('Streak freeze purchased!')
+    })
+  })
+
+  it('handles failed claim (success: false)', async () => {
+    mockRpc.mockImplementation((fn: string) => {
+      if (fn === 'get_user_streaks') return Promise.resolve({ data: { ...mockStreaks, active_day_streak: 7 } })
+      if (fn === 'claim_streak_milestone') return Promise.resolve({ data: { success: false, error: 'Already claimed' } })
+      return Promise.resolve({ data: null })
+    })
+
+    const user = userEvent.setup()
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Day')).toBeInTheDocument()
+    })
+
+    const claimableButton = screen.getAllByLabelText(/Week Warrior.*claimable/)[0]
+    await user.click(claimableButton)
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Already claimed')
+    })
+  })
+
+  it('handles failed buy (success: false) with toast error', async () => {
+    mockRpc.mockImplementation((fn: string) => {
+      if (fn === 'get_user_streaks') return Promise.resolve({ data: mockStreaks })
+      if (fn === 'buy_streak_freeze') return Promise.resolve({ data: { success: false, error: 'Not enough points' } })
+      return Promise.resolve({ data: null })
+    })
+
+    const user = userEvent.setup()
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Streak Freezes')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /Buy Freeze/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Not enough points')
+    })
+  })
+
+  it('claims task-specific milestone with task_id', async () => {
+    setupMocks({
+      streaks: {
+        active_day_streak: 0,
+        perfect_day_streak: 0,
+        task_streaks: [
+          { task_id: 'task-1', title: 'Make Bed', current_streak: 7 },
+        ],
+      },
+      milestones: [],
+    })
+
+    const user = userEvent.setup()
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Make Bed')).toBeInTheDocument()
+    })
+
+    // The Make Bed card should have a claimable 7-day milestone
+    // There are multiple streak cards, find the one for Make Bed
+    const claimableButtons = screen.getAllByLabelText(/Week Warrior.*claimable/)
+    await user.click(claimableButtons[claimableButtons.length - 1])
+
+    expect(mockRpc).toHaveBeenCalledWith('claim_streak_milestone', {
+      p_user_id: 'user-1',
+      p_streak_type: 'task',
+      p_task_id: 'task-1',
+      p_milestone_days: 7,
+      p_current_streak: 7,
+    })
+  })
+
+  it('claims perfect day milestone', async () => {
+    setupMocks({
+      streaks: {
+        active_day_streak: 0,
+        perfect_day_streak: 7,
+        task_streaks: [],
+      },
+      milestones: [],
+    })
+
+    const user = userEvent.setup()
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Perfect Day')).toBeInTheDocument()
+    })
+
+    const claimableButtons = screen.getAllByLabelText(/Week Warrior.*claimable/)
+    await user.click(claimableButtons[0])
+
+    expect(mockRpc).toHaveBeenCalledWith('claim_streak_milestone', {
+      p_user_id: 'user-1',
+      p_streak_type: 'perfect_day',
+      p_task_id: '00000000-0000-0000-0000-000000000000',
+      p_milestone_days: 7,
+      p_current_streak: 7,
+    })
+  })
+
+  it('filters claimed milestones by streak type and task_id', async () => {
+    setupMocks({
+      streaks: {
+        active_day_streak: 7,
+        perfect_day_streak: 7,
+        task_streaks: [
+          { task_id: 'task-1', title: 'Make Bed', current_streak: 7 },
+        ],
+      },
+      milestones: [
+        { streak_type: 'active_day', task_id: null, milestone_days: 7, points_awarded: 50, badge_name: 'Week Warrior' },
+        { streak_type: 'task', task_id: 'task-1', milestone_days: 7, points_awarded: 50, badge_name: 'Week Warrior' },
+      ],
+    })
+
+    render(<StreakTab userId="user-1" userPoints={100} />)
+
+    await waitFor(() => {
+      // Active Day 7d should be claimed
+      // Perfect Day 7d should be claimable (not in milestones)
+      // Make Bed 7d should be claimed
+      const claimedBadges = screen.getAllByLabelText(/Week Warrior.*claimed/)
+      const claimableBadges = screen.getAllByLabelText(/Week Warrior.*claimable/)
+      expect(claimedBadges.length).toBe(2) // active_day + task
+      expect(claimableBadges.length).toBe(1) // perfect_day
+    })
+  })
+})

--- a/__tests__/lib/streaks.test.ts
+++ b/__tests__/lib/streaks.test.ts
@@ -1,0 +1,111 @@
+import {
+  STREAK_MILESTONES,
+  getNextMilestone,
+  getClaimableMilestones,
+  formatStreakCount,
+} from '@/lib/streaks'
+
+describe('STREAK_MILESTONES', () => {
+  it('has 5 milestones in ascending order', () => {
+    expect(STREAK_MILESTONES).toHaveLength(5)
+    for (let i = 1; i < STREAK_MILESTONES.length; i++) {
+      expect(STREAK_MILESTONES[i].days).toBeGreaterThan(STREAK_MILESTONES[i - 1].days)
+    }
+  })
+
+  it('has correct values', () => {
+    expect(STREAK_MILESTONES[0]).toEqual({ days: 7, bonus: 50, badge: 'Week Warrior' })
+    expect(STREAK_MILESTONES[1]).toEqual({ days: 14, bonus: 100, badge: 'Fortnight Fighter' })
+    expect(STREAK_MILESTONES[2]).toEqual({ days: 30, bonus: 250, badge: 'Monthly Master' })
+    expect(STREAK_MILESTONES[3]).toEqual({ days: 60, bonus: 500, badge: 'Sixty-Day Sage' })
+    expect(STREAK_MILESTONES[4]).toEqual({ days: 100, bonus: 1000, badge: 'Century Champion' })
+  })
+})
+
+describe('getNextMilestone', () => {
+  it('returns 7-day milestone when streak is 0 and nothing claimed', () => {
+    const result = getNextMilestone(0, [])
+    expect(result).toEqual({ days: 7, bonus: 50, badge: 'Week Warrior' })
+  })
+
+  it('returns 7-day milestone when streak is 5', () => {
+    const result = getNextMilestone(5, [])
+    expect(result).toEqual({ days: 7, bonus: 50, badge: 'Week Warrior' })
+  })
+
+  it('returns 14-day milestone when 7-day is claimed and streak is 10', () => {
+    const result = getNextMilestone(10, [7])
+    expect(result).toEqual({ days: 14, bonus: 100, badge: 'Fortnight Fighter' })
+  })
+
+  it('skips claimed milestones', () => {
+    const result = getNextMilestone(5, [7])
+    expect(result).toEqual({ days: 14, bonus: 100, badge: 'Fortnight Fighter' })
+  })
+
+  it('returns null when all milestones are claimed', () => {
+    const result = getNextMilestone(200, [7, 14, 30, 60, 100])
+    expect(result).toBeNull()
+  })
+
+  it('returns null when streak exceeds all unclaimed milestones', () => {
+    const result = getNextMilestone(200, [])
+    expect(result).toBeNull()
+  })
+
+  it('returns 30-day milestone when 7 and 14 are claimed', () => {
+    const result = getNextMilestone(20, [7, 14])
+    expect(result).toEqual({ days: 30, bonus: 250, badge: 'Monthly Master' })
+  })
+})
+
+describe('getClaimableMilestones', () => {
+  it('returns empty array when streak is 0', () => {
+    expect(getClaimableMilestones(0, [])).toEqual([])
+  })
+
+  it('returns 7-day milestone when streak is 7', () => {
+    const result = getClaimableMilestones(7, [])
+    expect(result).toEqual([{ days: 7, bonus: 50, badge: 'Week Warrior' }])
+  })
+
+  it('returns multiple milestones when streak is high', () => {
+    const result = getClaimableMilestones(30, [])
+    expect(result).toHaveLength(3)
+    expect(result.map((m) => m.days)).toEqual([7, 14, 30])
+  })
+
+  it('excludes already claimed milestones', () => {
+    const result = getClaimableMilestones(30, [7, 14])
+    expect(result).toHaveLength(1)
+    expect(result[0].days).toBe(30)
+  })
+
+  it('returns empty when all eligible are claimed', () => {
+    const result = getClaimableMilestones(30, [7, 14, 30])
+    expect(result).toEqual([])
+  })
+
+  it('returns all milestones at 100 days with none claimed', () => {
+    const result = getClaimableMilestones(100, [])
+    expect(result).toHaveLength(5)
+  })
+})
+
+describe('formatStreakCount', () => {
+  it('returns "1 day" for 1', () => {
+    expect(formatStreakCount(1)).toBe('1 day')
+  })
+
+  it('returns "0 days" for 0', () => {
+    expect(formatStreakCount(0)).toBe('0 days')
+  })
+
+  it('returns "7 days" for 7', () => {
+    expect(formatStreakCount(7)).toBe('7 days')
+  })
+
+  it('returns "100 days" for 100', () => {
+    expect(formatStreakCount(100)).toBe('100 days')
+  })
+})

--- a/app/(dashboard)/me/page.tsx
+++ b/app/(dashboard)/me/page.tsx
@@ -9,7 +9,10 @@ import { Modal } from '@/components/ui/modal'
 import { RoleSelector, type Role } from '@/components/ui/role-selector'
 import { UnderlineInput } from '@/components/ui/underline-input'
 import { Button } from '@/components/ui/button'
+import { StreakTab } from '@/components/streaks/streak-tab'
 import { AVATAR_OPTIONS, type Profile } from '@/lib/types'
+
+type MeTab = 'profile' | 'streaks'
 
 export default function MePage() {
   const [profile, setProfile] = useState<Profile | null>(null)
@@ -22,6 +25,7 @@ export default function MePage() {
   const [saving, setSaving] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
   const [isAvatarOpen, setIsAvatarOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState<MeTab>('profile')
   const [isPasswordOpen, setIsPasswordOpen] = useState(false)
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -182,8 +186,31 @@ export default function MePage() {
         </button>
       </header>
 
+      {/* Tab Switcher */}
+      <div className="px-6 pb-2">
+        <div className="flex gap-1 bg-gray-100 rounded-lg p-1 max-w-md mx-auto">
+          {(['profile', 'streaks'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 py-2 text-sm font-medium rounded-md transition ${
+                activeTab === tab
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {tab === 'profile' ? 'Profile' : 'Streaks'}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <main className="flex-1 px-6 pt-4 pb-24">
         <div className="max-w-md mx-auto">
+          {activeTab === 'streaks' ? (
+            <StreakTab userId={profile.id} userPoints={profile.points} />
+          ) : (
+          <>
           {/* Avatar Section */}
           <section className="flex flex-col items-center mb-10">
             <button
@@ -281,6 +308,8 @@ export default function MePage() {
               Save Changes
             </Button>
           </form>
+          </>
+          )}
         </div>
       </main>
 

--- a/components/streaks/freeze-section.tsx
+++ b/components/streaks/freeze-section.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+interface FreezeSectionProps {
+  available: number
+  used: number
+  userPoints: number
+  onBuy: () => Promise<void>
+}
+
+export function FreezeSection({ available, used, userPoints, onBuy }: FreezeSectionProps) {
+  const [buying, setBuying] = useState(false)
+  const remaining = available - used
+
+  async function handleBuy() {
+    setBuying(true)
+    try {
+      await onBuy()
+    } finally {
+      setBuying(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2">
+          <span aria-hidden="true">❄️</span>
+          <span>Streak Freezes</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <p className="text-sm text-gray-600">
+              Available: <span className="font-bold text-gray-900" data-testid="freeze-count">{remaining}</span>
+            </p>
+            <p className="text-xs text-gray-400">Protect your streak when you miss a day</p>
+          </div>
+        </div>
+        <Button
+          onClick={handleBuy}
+          loading={buying}
+          disabled={userPoints < 50}
+          size="sm"
+          className="w-full"
+        >
+          Buy Freeze (50 pts)
+        </Button>
+        {userPoints < 50 && (
+          <p className="text-xs text-amber-600 mt-1 text-center">
+            Need {50 - userPoints} more points
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/streaks/milestone-badge.tsx
+++ b/components/streaks/milestone-badge.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import type { StreakMilestone } from '@/lib/types'
+
+type MilestoneStatus = 'claimed' | 'claimable' | 'locked'
+
+interface MilestoneBadgeProps {
+  milestone: StreakMilestone
+  status: MilestoneStatus
+  onClaim?: () => void
+}
+
+const statusStyles: Record<MilestoneStatus, string> = {
+  claimed: 'bg-yellow-100 border-yellow-400 text-yellow-700',
+  claimable: 'bg-purple-100 border-purple-400 text-purple-700 animate-pulse cursor-pointer',
+  locked: 'bg-gray-100 border-gray-300 text-gray-400',
+}
+
+export function MilestoneBadge({ milestone, status, onClaim }: MilestoneBadgeProps) {
+  const handleClick = () => {
+    if (status === 'claimable' && onClaim) {
+      onClaim()
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={status !== 'claimable'}
+      className={`flex flex-col items-center p-2 rounded-full border-2 w-16 h-16 justify-center transition ${statusStyles[status]}`}
+      aria-label={`${milestone.badge} - ${milestone.days} days - ${status}`}
+    >
+      <span className="text-xs font-bold">{milestone.days}d</span>
+      <span className="text-[10px] leading-tight">+{milestone.bonus}</span>
+    </button>
+  )
+}

--- a/components/streaks/streak-card.tsx
+++ b/components/streaks/streak-card.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { MilestoneBadge } from './milestone-badge'
+import { STREAK_MILESTONES, getNextMilestone } from '@/lib/streaks'
+
+interface StreakCardProps {
+  type: string
+  label: string
+  streak: number
+  claimedMilestones: number[]
+  onClaimMilestone: (days: number) => void
+}
+
+export function StreakCard({ type, label, streak, claimedMilestones, onClaimMilestone }: StreakCardProps) {
+  const nextMilestone = getNextMilestone(streak, claimedMilestones)
+  const progressPercent = nextMilestone
+    ? Math.min(100, Math.round((streak / nextMilestone.days) * 100))
+    : 100
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <span aria-hidden="true">🔥</span>
+            <span>{label}</span>
+          </CardTitle>
+          <span className="text-2xl font-bold text-purple-600" data-testid={`streak-count-${type}`}>
+            {streak}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {/* Progress bar */}
+        <div className="mb-3">
+          <div className="flex justify-between text-xs text-gray-500 mb-1">
+            <span>{streak} day{streak !== 1 ? 's' : ''}</span>
+            {nextMilestone && <span>Next: {nextMilestone.days} days</span>}
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-purple-600 h-2 rounded-full transition-all"
+              style={{ width: `${progressPercent}%` }}
+              role="progressbar"
+              aria-valuenow={streak}
+              aria-valuemin={0}
+              aria-valuemax={nextMilestone?.days ?? streak}
+              aria-label={`${label} streak progress`}
+            />
+          </div>
+        </div>
+
+        {/* Milestone badges */}
+        <div className="flex gap-2 justify-center flex-wrap">
+          {STREAK_MILESTONES.map((milestone) => {
+            const isClaimed = claimedMilestones.includes(milestone.days)
+            const isClaimable = !isClaimed && streak >= milestone.days
+            const status = isClaimed ? 'claimed' : isClaimable ? 'claimable' : 'locked'
+
+            return (
+              <MilestoneBadge
+                key={milestone.days}
+                milestone={milestone}
+                status={status}
+                onClaim={() => onClaimMilestone(milestone.days)}
+              />
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/streaks/streak-tab.tsx
+++ b/components/streaks/streak-tab.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { toast } from 'sonner'
+import { createClient } from '@/lib/supabase/client'
+import { StreakCard } from './streak-card'
+import { FreezeSection } from './freeze-section'
+import type { UserStreaks, StreakFreezes, ClaimedMilestone } from '@/lib/types'
+
+interface StreakTabProps {
+  userId: string
+  userPoints: number
+}
+
+type RpcResult = { success: boolean; error?: string; bonus?: number; badge?: string }
+
+export function StreakTab({ userId, userPoints }: StreakTabProps) {
+  const [streaks, setStreaks] = useState<UserStreaks | null>(null)
+  const [freezes, setFreezes] = useState<StreakFreezes>({ available: 0, used: 0 })
+  const [claimedMilestones, setClaimedMilestones] = useState<ClaimedMilestone[]>([])
+  const [loading, setLoading] = useState(true)
+  const [points, setPoints] = useState(userPoints)
+  const supabase = createClient()
+
+  const fetchData = useCallback(async () => {
+    const [streakResult, freezeResult, milestoneResult] = await Promise.all([
+      supabase.rpc('get_user_streaks', { p_user_id: userId }),
+      supabase.from('streak_freezes').select('available, used').eq('user_id', userId).single(),
+      supabase.from('streak_milestones').select('streak_type, task_id, milestone_days, points_awarded, badge_name').eq('user_id', userId),
+    ])
+
+    if (streakResult.data) {
+      setStreaks(streakResult.data as UserStreaks)
+    }
+
+    if (freezeResult.data) {
+      setFreezes(freezeResult.data)
+    }
+
+    if (milestoneResult.data) {
+      setClaimedMilestones(milestoneResult.data)
+    }
+
+    setLoading(false)
+    // createClient() returns a singleton — supabase reference is stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data fetch on mount
+    fetchData()
+  }, [fetchData])
+
+  async function handleClaimMilestone(streakType: string, taskId: string | null, days: number, currentStreak: number) {
+    const { data } = await supabase.rpc('claim_streak_milestone', {
+      p_user_id: userId,
+      p_streak_type: streakType,
+      p_task_id: taskId ?? '00000000-0000-0000-0000-000000000000',
+      p_milestone_days: days,
+      p_current_streak: currentStreak,
+    })
+
+    const result = data as RpcResult | null
+    if (result?.success) {
+      toast.success(`${result.badge} unlocked! +${result.bonus} points`)
+      setPoints((prev) => prev + (result.bonus ?? 0))
+      fetchData()
+    } else if (result?.error) {
+      toast.error(result.error)
+    }
+  }
+
+  async function handleBuyFreeze() {
+    const { data } = await supabase.rpc('buy_streak_freeze', { p_user_id: userId })
+
+    const result = data as RpcResult | null
+    if (result?.success) {
+      toast.success('Streak freeze purchased!')
+      setPoints((prev) => prev - 50)
+      fetchData()
+    } else if (result?.error) {
+      toast.error(result.error)
+    }
+  }
+
+  function getClaimedDaysForStreak(streakType: string, taskId?: string): number[] {
+    return claimedMilestones
+      .filter((m) => {
+        if (m.streak_type !== streakType) return false
+        if (streakType === 'task') return m.task_id === taskId
+        return true
+      })
+      .map((m) => m.milestone_days)
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-32 bg-gray-100 rounded-xl animate-pulse" />
+        ))}
+      </div>
+    )
+  }
+
+  const activeStreakCount = [
+    streaks?.active_day_streak ?? 0,
+    streaks?.perfect_day_streak ?? 0,
+    ...(streaks?.task_streaks?.map((t) => t.current_streak) ?? []),
+  ].filter((s) => s > 0).length
+
+  return (
+    <div className="space-y-4">
+      {/* Summary */}
+      <div className="text-center py-2">
+        <p className="text-sm text-gray-500">
+          <span className="font-bold text-purple-600 text-lg">{activeStreakCount}</span>{' '}
+          active streak{activeStreakCount !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      {/* Active Day Streak */}
+      <StreakCard
+        type="active_day"
+        label="Active Day"
+        streak={streaks?.active_day_streak ?? 0}
+        claimedMilestones={getClaimedDaysForStreak('active_day')}
+        onClaimMilestone={(days) =>
+          handleClaimMilestone('active_day', null, days, streaks?.active_day_streak ?? 0)
+        }
+      />
+
+      {/* Perfect Day Streak */}
+      <StreakCard
+        type="perfect_day"
+        label="Perfect Day"
+        streak={streaks?.perfect_day_streak ?? 0}
+        claimedMilestones={getClaimedDaysForStreak('perfect_day')}
+        onClaimMilestone={(days) =>
+          handleClaimMilestone('perfect_day', null, days, streaks?.perfect_day_streak ?? 0)
+        }
+      />
+
+      {/* Task Streaks */}
+      {streaks?.task_streaks?.map((task) => (
+        <StreakCard
+          key={task.task_id}
+          type={`task_${task.task_id}`}
+          label={task.title}
+          streak={task.current_streak}
+          claimedMilestones={getClaimedDaysForStreak('task', task.task_id)}
+          onClaimMilestone={(days) =>
+            handleClaimMilestone('task', task.task_id, days, task.current_streak)
+          }
+        />
+      ))}
+
+      {/* Freeze Section */}
+      <FreezeSection
+        available={freezes.available}
+        used={freezes.used}
+        userPoints={points}
+        onBuy={handleBuyFreeze}
+      />
+    </div>
+  )
+}

--- a/docs/adr/013-streaks.md
+++ b/docs/adr/013-streaks.md
@@ -1,0 +1,61 @@
+# ADR 013: Streaks — Track Consecutive Days of Task Completion
+
+## Status
+Accepted
+
+## Context
+Users complete quests daily but have no way to see their consistency. Adding streaks creates a motivation loop: users see their streak grow, earn milestone badges with bonus points, and can buy streak freezes to protect their progress.
+
+## Decision
+
+### Three Streak Types
+- **Task streaks**: per daily recurring task, consecutive days completed
+- **Perfect Day**: all assigned daily tasks completed
+- **Active Day**: at least 1 task completed
+
+### On-Demand RPC Computation
+`get_user_streaks` RPC computes streaks from `task_completions` data on each page load. No denormalized streak columns that could go stale.
+
+### Streak Freezes
+- Purchasable for 50 points
+- Free freezes awarded at 30-day and 100-day milestones
+- NOT auto-applied — user chooses when to use them
+
+### Milestone Badges & Bonus Points
+| Days | Bonus | Badge |
+|------|-------|-------|
+| 7 | +50 | Week Warrior |
+| 14 | +100 | Fortnight Fighter |
+| 30 | +250 | Monthly Master |
+| 60 | +500 | Sixty-Day Sage |
+| 100 | +1000 | Century Champion |
+
+### UI Placement
+Tab switcher (Profile | Streaks) on `/me` page keeps nav clean at 4 items.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[Me Page] -->|Tab Switch| B[StreakTab Component]
+    B -->|RPC| C[get_user_streaks]
+    B -->|Query| D[streak_milestones]
+    B -->|Query| E[streak_freezes]
+    C -->|Reads| F[task_completions]
+    C -->|Reads| G[streak_freeze_usage]
+    B -->|RPC| H[claim_streak_milestone]
+    B -->|RPC| I[buy_streak_freeze]
+    H -->|Updates| J[profiles.points]
+    I -->|Updates| J
+```
+
+## Database Tables
+- `streak_freezes` — available/used freeze counts per user
+- `streak_milestones` — claimed milestone records (prevents double-awarding)
+- `streak_freeze_usage` — log of dates where freezes were applied
+
+## Consequences
+- Streaks are computed on-demand, so no stale data issues
+- Only daily recurring tasks participate (weekly/one-off too sparse)
+- RPC approach means streak computation cost scales with history length
+- Milestone claims are idempotent via unique indexes

--- a/e2e/streaks.spec.ts
+++ b/e2e/streaks.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Streaks Tab', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/me')
+    await expect(page.getByText('My Profile')).toBeVisible()
+  })
+
+  test('displays Profile and Streaks tab buttons', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Profile' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Streaks' })).toBeVisible()
+  })
+
+  test('shows profile content by default', async ({ page }) => {
+    await expect(page.getByText('Personal Info')).toBeVisible()
+  })
+
+  test('switches to streaks tab', async ({ page }) => {
+    await page.getByRole('button', { name: 'Streaks' }).click()
+
+    // Should show streak-related content
+    await expect(page.getByText('Active Day')).toBeVisible()
+    await expect(page.getByText('Streak Freezes')).toBeVisible()
+  })
+
+  test('switches back to profile tab', async ({ page }) => {
+    await page.getByRole('button', { name: 'Streaks' }).click()
+    await expect(page.getByText('Active Day')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Profile' }).click()
+    await expect(page.getByText('Personal Info')).toBeVisible()
+  })
+
+  test('streaks tab shows streak cards', async ({ page }) => {
+    await page.getByRole('button', { name: 'Streaks' }).click()
+
+    // Should show Active Day and Perfect Day cards
+    await expect(page.getByText('Active Day')).toBeVisible()
+    await expect(page.getByText('Perfect Day')).toBeVisible()
+  })
+
+  test('streaks tab shows freeze section with buy button', async ({ page }) => {
+    await page.getByRole('button', { name: 'Streaks' }).click()
+
+    await expect(page.getByText('Streak Freezes')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Buy Freeze/i })).toBeVisible()
+  })
+
+  test('milestone badges are visible in streak cards', async ({ page }) => {
+    await page.getByRole('button', { name: 'Streaks' }).click()
+
+    // Should show milestone badges (7d, 14d, etc.)
+    const badges = page.getByText('7d')
+    await expect(badges.first()).toBeVisible()
+  })
+
+  test('active streak count summary is shown', async ({ page }) => {
+    await page.getByRole('button', { name: 'Streaks' }).click()
+
+    await expect(page.getByText(/active streak/)).toBeVisible()
+  })
+})

--- a/lib/streaks.ts
+++ b/lib/streaks.ts
@@ -1,0 +1,35 @@
+import type { StreakMilestone } from './types'
+
+// Keep in sync with claim_streak_milestone() in supabase/migrations/012_streaks.sql
+export const STREAK_MILESTONES: StreakMilestone[] = [
+  { days: 7, bonus: 50, badge: 'Week Warrior' },
+  { days: 14, bonus: 100, badge: 'Fortnight Fighter' },
+  { days: 30, bonus: 250, badge: 'Monthly Master' },
+  { days: 60, bonus: 500, badge: 'Sixty-Day Sage' },
+  { days: 100, bonus: 1000, badge: 'Century Champion' },
+]
+
+export function getNextMilestone(
+  currentStreak: number,
+  claimedDays: number[]
+): StreakMilestone | null {
+  for (const milestone of STREAK_MILESTONES) {
+    if (!claimedDays.includes(milestone.days) && currentStreak < milestone.days) {
+      return milestone
+    }
+  }
+  return null
+}
+
+export function getClaimableMilestones(
+  currentStreak: number,
+  claimedDays: number[]
+): StreakMilestone[] {
+  return STREAK_MILESTONES.filter(
+    (m) => currentStreak >= m.days && !claimedDays.includes(m.days)
+  )
+}
+
+export function formatStreakCount(n: number): string {
+  return n === 1 ? '1 day' : `${n} days`
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,6 +171,22 @@ export type Database = {
         Args: { invite_id: string }
         Returns: undefined
       }
+      get_user_streaks: {
+        Args: { p_user_id: string }
+        Returns: UserStreaks
+      }
+      buy_streak_freeze: {
+        Args: { p_user_id: string }
+        Returns: { success: boolean; error?: string }
+      }
+      use_streak_freeze: {
+        Args: { p_user_id: string; p_freeze_date: string; p_streak_type: string; p_task_id?: string }
+        Returns: { success: boolean; error?: string }
+      }
+      claim_streak_milestone: {
+        Args: { p_user_id: string; p_streak_type: string; p_task_id: string; p_milestone_days: number; p_current_streak: number }
+        Returns: { success: boolean; error?: string; bonus?: number; badge?: string }
+      }
     }
   }
 }
@@ -205,6 +221,38 @@ export const TIME_OF_DAY_OPTIONS = [
   { value: 'afternoon', label: 'Afternoon' },
   { value: 'night', label: 'Night' },
 ] as const
+
+// Streak types
+export type StreakMilestone = {
+  days: number
+  bonus: number
+  badge: string
+}
+
+export type TaskStreak = {
+  task_id: string
+  title: string
+  current_streak: number
+}
+
+export type UserStreaks = {
+  active_day_streak: number
+  perfect_day_streak: number
+  task_streaks: TaskStreak[]
+}
+
+export type StreakFreezes = {
+  available: number
+  used: number
+}
+
+export type ClaimedMilestone = {
+  streak_type: string
+  task_id: string | null
+  milestone_days: number
+  points_awarded: number
+  badge_name: string
+}
 
 // Avatar options
 export const AVATAR_OPTIONS = [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         storageState: '.auth/parent.json',
       },
       dependencies: ['setup'],
-      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts/,
+      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts|streaks\.spec\.ts/,
     },
     // Destructive parent tests (sign-out) that invalidate the session - run last
     {

--- a/supabase/migrations/012_streaks.sql
+++ b/supabase/migrations/012_streaks.sql
@@ -1,0 +1,353 @@
+-- Streak tracking tables and RPC functions
+-- Supports: task streaks, perfect day streaks, active day streaks
+
+-- Streak freezes: available freeze count per user
+CREATE TABLE streak_freezes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  available int NOT NULL DEFAULT 0,
+  used int NOT NULL DEFAULT 0,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_streak_freezes_user ON streak_freezes(user_id);
+
+ALTER TABLE streak_freezes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own freezes" ON streak_freezes
+  FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users can insert own freezes" ON streak_freezes
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users can update own freezes" ON streak_freezes
+  FOR UPDATE USING (user_id = auth.uid());
+
+-- Streak milestones: claimed milestone records (prevents double-awarding)
+CREATE TABLE streak_milestones (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  streak_type text NOT NULL CHECK (streak_type IN ('task', 'perfect_day', 'active_day')),
+  task_id uuid REFERENCES tasks(id) ON DELETE CASCADE,
+  milestone_days int NOT NULL CHECK (milestone_days IN (7, 14, 30, 60, 100)),
+  points_awarded int NOT NULL,
+  badge_name text NOT NULL,
+  claimed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_streak_milestones_unique ON streak_milestones(
+  user_id, streak_type, COALESCE(task_id, '00000000-0000-0000-0000-000000000000'::uuid), milestone_days
+);
+
+ALTER TABLE streak_milestones ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own milestones" ON streak_milestones
+  FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users can insert own milestones" ON streak_milestones
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+-- Streak freeze usage: log of which dates freezes were applied
+CREATE TABLE streak_freeze_usage (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  freeze_date date NOT NULL,
+  streak_type text NOT NULL CHECK (streak_type IN ('task', 'perfect_day', 'active_day')),
+  task_id uuid REFERENCES tasks(id) ON DELETE CASCADE,
+  used_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_streak_freeze_usage_unique ON streak_freeze_usage(
+  user_id, freeze_date, streak_type, COALESCE(task_id, '00000000-0000-0000-0000-000000000000'::uuid)
+);
+
+ALTER TABLE streak_freeze_usage ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own freeze usage" ON streak_freeze_usage
+  FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users can insert own freeze usage" ON streak_freeze_usage
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+-- RPC: get_user_streaks
+-- Computes current streaks from task_completions data.
+-- [7] Uses set-based queries: fetches all completion dates and freeze dates upfront,
+-- then iterates in memory instead of running per-day queries.
+-- [4] Note: perfect day streak uses current task assignments. If tasks were added/removed
+-- historically, past perfect day counts may not reflect what was assigned on that date.
+CREATE OR REPLACE FUNCTION get_user_streaks(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_active_day_streak int := 0;
+  v_perfect_day_streak int := 0;
+  v_task_streaks jsonb := '[]'::jsonb;
+  v_check_date date;
+  v_daily_task_count int;
+  v_task record;
+  v_task_streak int;
+  -- Pre-fetched date sets
+  v_completion_dates date[];
+  v_active_freeze_dates date[];
+  v_perfect_freeze_dates date[];
+  v_task_completion_dates date[];
+  v_task_freeze_dates date[];
+BEGIN
+  -- [2] Auth check
+  IF p_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  -- Pre-fetch all completion dates for this user (set-based)
+  SELECT ARRAY_AGG(DISTINCT tc.completion_date::date)
+  INTO v_completion_dates
+  FROM task_completions tc
+  WHERE tc.completed_by = p_user_id;
+
+  -- Pre-fetch freeze dates by type
+  SELECT ARRAY_AGG(DISTINCT freeze_date)
+  INTO v_active_freeze_dates
+  FROM streak_freeze_usage
+  WHERE user_id = p_user_id AND streak_type = 'active_day';
+
+  SELECT ARRAY_AGG(DISTINCT freeze_date)
+  INTO v_perfect_freeze_dates
+  FROM streak_freeze_usage
+  WHERE user_id = p_user_id AND streak_type = 'perfect_day';
+
+  -- Coalesce NULLs to empty arrays
+  v_completion_dates := COALESCE(v_completion_dates, '{}');
+  v_active_freeze_dates := COALESCE(v_active_freeze_dates, '{}');
+  v_perfect_freeze_dates := COALESCE(v_perfect_freeze_dates, '{}');
+
+  -- Active Day Streak: at least 1 completion per day
+  v_check_date := CURRENT_DATE;
+  LOOP
+    IF v_check_date = ANY(v_completion_dates) OR v_check_date = ANY(v_active_freeze_dates) THEN
+      v_active_day_streak := v_active_day_streak + 1;
+      v_check_date := v_check_date - 1;
+    ELSE
+      EXIT;
+    END IF;
+  END LOOP;
+
+  -- Perfect Day Streak: all assigned daily tasks completed
+  -- Count daily tasks assigned to user (current assignment state)
+  SELECT COUNT(*) INTO v_daily_task_count
+  FROM tasks
+  WHERE assigned_to = p_user_id
+    AND recurring = 'daily';
+
+  IF v_daily_task_count > 0 THEN
+    v_check_date := CURRENT_DATE;
+    LOOP
+      DECLARE
+        v_completed_count int;
+      BEGIN
+        SELECT COUNT(DISTINCT tc.task_id) INTO v_completed_count
+        FROM task_completions tc
+        JOIN tasks t ON tc.task_id = t.id
+        WHERE tc.completed_by = p_user_id
+          AND tc.completion_date = v_check_date::text
+          AND t.recurring = 'daily'
+          AND t.assigned_to = p_user_id;
+
+        IF v_completed_count >= v_daily_task_count OR v_check_date = ANY(v_perfect_freeze_dates) THEN
+          v_perfect_day_streak := v_perfect_day_streak + 1;
+          v_check_date := v_check_date - 1;
+        ELSE
+          EXIT;
+        END IF;
+      END;
+    END LOOP;
+  END IF;
+
+  -- Task Streaks: per daily recurring task
+  FOR v_task IN
+    SELECT t.id, t.title
+    FROM tasks t
+    WHERE t.assigned_to = p_user_id
+      AND t.recurring = 'daily'
+    ORDER BY t.title
+  LOOP
+    v_task_streak := 0;
+    v_check_date := CURRENT_DATE;
+
+    -- Pre-fetch completion dates for this specific task
+    SELECT ARRAY_AGG(DISTINCT tc.completion_date::date)
+    INTO v_task_completion_dates
+    FROM task_completions tc
+    WHERE tc.task_id = v_task.id
+      AND tc.completed_by = p_user_id;
+
+    SELECT ARRAY_AGG(DISTINCT freeze_date)
+    INTO v_task_freeze_dates
+    FROM streak_freeze_usage
+    WHERE user_id = p_user_id
+      AND streak_type = 'task'
+      AND task_id = v_task.id;
+
+    v_task_completion_dates := COALESCE(v_task_completion_dates, '{}');
+    v_task_freeze_dates := COALESCE(v_task_freeze_dates, '{}');
+
+    LOOP
+      IF v_check_date = ANY(v_task_completion_dates) OR v_check_date = ANY(v_task_freeze_dates) THEN
+        v_task_streak := v_task_streak + 1;
+        v_check_date := v_check_date - 1;
+      ELSE
+        EXIT;
+      END IF;
+    END LOOP;
+
+    v_task_streaks := v_task_streaks || jsonb_build_object(
+      'task_id', v_task.id,
+      'title', v_task.title,
+      'current_streak', v_task_streak
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'active_day_streak', v_active_day_streak,
+    'perfect_day_streak', v_perfect_day_streak,
+    'task_streaks', v_task_streaks
+  );
+END;
+$$;
+
+-- RPC: buy_streak_freeze
+-- [1] Uses atomic UPDATE...WHERE points >= 50 to prevent TOCTOU race
+-- [2] Verifies p_user_id = auth.uid()
+CREATE OR REPLACE FUNCTION buy_streak_freeze(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_rows_affected int;
+BEGIN
+  -- [2] Auth check
+  IF p_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- [1] Atomic deduct: only succeeds if points >= 50
+  UPDATE profiles SET points = points - 50
+  WHERE id = p_user_id AND points >= 50;
+
+  GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+  IF v_rows_affected = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Not enough points (need 50)');
+  END IF;
+
+  -- Increment available freezes
+  INSERT INTO streak_freezes (user_id, available, used)
+  VALUES (p_user_id, 1, 0)
+  ON CONFLICT (user_id)
+  DO UPDATE SET available = streak_freezes.available + 1, updated_at = now();
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- RPC: use_streak_freeze
+-- [3] Uses atomic UPDATE...WHERE available > used to prevent TOCTOU race
+-- [2] Verifies p_user_id = auth.uid()
+CREATE OR REPLACE FUNCTION use_streak_freeze(p_user_id uuid, p_freeze_date date, p_streak_type text, p_task_id uuid DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_rows_affected int;
+BEGIN
+  -- [2] Auth check
+  IF p_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- [3] Atomic: only increments used if available > used
+  UPDATE streak_freezes
+  SET used = used + 1, updated_at = now()
+  WHERE user_id = p_user_id AND available > used;
+
+  GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+  IF v_rows_affected = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No freezes available');
+  END IF;
+
+  -- Insert freeze usage record
+  INSERT INTO streak_freeze_usage (user_id, freeze_date, streak_type, task_id)
+  VALUES (p_user_id, p_freeze_date, p_streak_type, p_task_id);
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- RPC: claim_streak_milestone
+-- [2] Verifies p_user_id = auth.uid()
+-- [8] Note: bonus/badge values are duplicated in lib/streaks.ts STREAK_MILESTONES.
+--     If milestone values change, update both this function and the TypeScript constant.
+CREATE OR REPLACE FUNCTION claim_streak_milestone(
+  p_user_id uuid,
+  p_streak_type text,
+  p_task_id uuid,
+  p_milestone_days int,
+  p_current_streak int
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_bonus int;
+  v_badge text;
+BEGIN
+  -- [2] Auth check
+  IF p_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- Validate streak meets milestone
+  IF p_current_streak < p_milestone_days THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Streak not long enough');
+  END IF;
+
+  -- Determine bonus and badge
+  v_bonus := CASE p_milestone_days
+    WHEN 7 THEN 50
+    WHEN 14 THEN 100
+    WHEN 30 THEN 250
+    WHEN 60 THEN 500
+    WHEN 100 THEN 1000
+    ELSE 0
+  END;
+
+  v_badge := CASE p_milestone_days
+    WHEN 7 THEN 'Week Warrior'
+    WHEN 14 THEN 'Fortnight Fighter'
+    WHEN 30 THEN 'Monthly Master'
+    WHEN 60 THEN 'Sixty-Day Sage'
+    WHEN 100 THEN 'Century Champion'
+    ELSE 'Unknown'
+  END;
+
+  -- Insert milestone (unique index prevents dupes)
+  BEGIN
+    INSERT INTO streak_milestones (user_id, streak_type, task_id, milestone_days, points_awarded, badge_name)
+    VALUES (p_user_id, p_streak_type, NULLIF(p_task_id, '00000000-0000-0000-0000-000000000000'::uuid), p_milestone_days, v_bonus, v_badge);
+  EXCEPTION WHEN unique_violation THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Milestone already claimed');
+  END;
+
+  -- Award bonus points
+  UPDATE profiles SET points = points + v_bonus WHERE id = p_user_id;
+
+  -- Award free freeze at 30-day and 100-day milestones
+  IF p_milestone_days IN (30, 100) THEN
+    INSERT INTO streak_freezes (user_id, available, used)
+    VALUES (p_user_id, 1, 0)
+    ON CONFLICT (user_id)
+    DO UPDATE SET available = streak_freezes.available + 1, updated_at = now();
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'bonus', v_bonus, 'badge', v_badge);
+END;
+$$;


### PR DESCRIPTION
## Summary
- **Three streak types**: Task streaks (per daily recurring task), Perfect Day (all assigned daily tasks done), Active Day (at least 1 task done) — computed on-demand via `get_user_streaks` RPC
- **Milestone badges with bonus points**: 7d (+50), 14d (+100), 30d (+250), 60d (+500), 100d (+1000) — claimable once per streak type, tracked in `streak_milestones` table
- **Streak freezes**: Purchasable for 50 points + free at 30/100-day milestones — protect streaks when missing a day
- **New Streaks tab** on `/me` page with Profile/Streaks tab switcher

### Security
- All 4 SECURITY DEFINER RPCs verify `p_user_id = auth.uid()`
- Atomic operations prevent TOCTOU races on point deduction and freeze usage
- RLS policies on all 3 new tables

### Files changed (17)
- `supabase/migrations/012_streaks.sql` — 3 tables, 4 RPCs
- `lib/types.ts` — Streak types + RPC function types in Database
- `lib/streaks.ts` — STREAK_MILESTONES constant, utility functions
- `components/streaks/` — milestone-badge, streak-card, freeze-section, streak-tab
- `app/(dashboard)/me/page.tsx` — Tab switcher (Profile | Streaks)
- `e2e/streaks.spec.ts` + `playwright.config.ts` — 8 E2E tests
- `docs/adr/013-streaks.md` — Architecture Decision Record

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 769 tests passing (100% line coverage on new code)
- [x] `npm run test:e2e` — 147 tests passing (8 new streaks tests)
- [ ] Manual: navigate to /me, switch to Streaks tab, verify cards render
- [ ] Manual: complete daily tasks, verify streak counts update
- [ ] Manual: buy a freeze, verify points deducted and freeze count increments

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)