### PR TITLE
feat: rewards store with custom rewards and redemption flow

### DIFF
--- a/__tests__/app/dashboard/rewards.test.tsx
+++ b/__tests__/app/dashboard/rewards.test.tsx
@@ -148,11 +148,19 @@ jest.mock('@/lib/supabase/client', () => ({
       }
       if (table === 'rewards') {
         return {
-          select: () => ({
-            eq: () => ({
-              order: () => Promise.resolve({ data: mockState.rewards }),
-            }),
-          }),
+          select: (_cols: string, opts?: { count?: string; head?: boolean }) => {
+            // Seed check: select('*', { count: 'exact', head: true })
+            if (opts?.head) {
+              return {
+                eq: () => Promise.resolve({ count: (mockState.rewards ?? []).length }),
+              }
+            }
+            return {
+              eq: () => ({
+                order: () => Promise.resolve({ data: mockState.rewards }),
+              }),
+            }
+          },
           insert: (data: unknown) => mockInsert(data),
           update: (data: unknown) => ({
             eq: (...args: unknown[]) => mockUpdate(data, ...args),
@@ -668,6 +676,37 @@ describe('RewardsPage', () => {
       const modal = screen.getByText('Reject Reward?').closest('div')!
       await userEvent.click(within(modal).getByRole('button', { name: /^Reject$/ }))
       await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    })
+  })
+
+  describe('Default reward seeding', () => {
+    it('seeds default rewards when parent loads page with no rewards', async () => {
+      mockState.rewards = []
+      render(<RewardsPage />)
+      await waitFor(() => {
+        expect(mockInsert).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ title: '30 Min Screen Time', family_id: 'family-1', created_by: 'user-parent' }),
+          ])
+        )
+      })
+    })
+
+    it('does not seed when rewards already exist', async () => {
+      mockState.rewards = mockRewards
+      render(<RewardsPage />)
+      await waitFor(() => expect(screen.getByText('Movie Night')).toBeInTheDocument())
+      expect(mockInsert).not.toHaveBeenCalled()
+    })
+
+    it('does not seed for child users', async () => {
+      mockState.rewards = []
+      mockState.user = mockChildUser
+      mockState.profile = mockChildProfile
+      mockGetUser.mockResolvedValue({ data: { user: mockChildUser } })
+      render(<RewardsPage />)
+      await waitFor(() => expect(screen.getByText('No rewards available yet.')).toBeInTheDocument())
+      expect(mockInsert).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/app/dashboard/rewards.test.tsx
+++ b/__tests__/app/dashboard/rewards.test.tsx
@@ -1,5 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import RewardsPage from '@/app/(dashboard)/rewards/page'
+
+// Mock next/navigation
+const mockPush = jest.fn()
+const mockGet = jest.fn().mockReturnValue(null)
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: mockGet }),
+  useRouter: () => ({ push: mockPush }),
+}))
 
 // Mock next/image
 jest.mock('next/image', () => ({
@@ -7,31 +16,41 @@ jest.mock('next/image', () => ({
   default: (props: { alt: string; src: string }) => <img alt={props.alt} src={props.src} />,
 }))
 
+// Mock sonner
+jest.mock('sonner', () => ({
+  toast: { error: jest.fn(), success: jest.fn() },
+  Toaster: () => null,
+}))
+
 // Mock data
-const mockUser = { id: 'user-1', email: 'test@example.com' }
-const mockProfile = {
-  id: 'user-1',
+const mockUser = { id: 'user-parent', email: 'parent@example.com' }
+const mockChildUser = { id: 'user-child', email: 'child@example.com' }
+
+const mockParentProfile = {
+  id: 'user-parent',
   family_id: 'family-1',
-  display_name: 'Test User',
+  display_name: 'Test Parent',
   avatar_url: null,
   nickname: null,
   role: 'parent',
-  points: 150,
+  points: 200,
+  created_at: '2024-01-01T00:00:00Z',
+}
+
+const mockChildProfile = {
+  id: 'user-child',
+  family_id: 'family-1',
+  display_name: 'Timmy Jones',
+  avatar_url: null,
+  nickname: 'Little T',
+  role: 'child',
+  points: 100,
   created_at: '2024-01-01T00:00:00Z',
 }
 
 const mockMembers = [
-  { ...mockProfile, points: 150 },
-  {
-    id: 'child-1',
-    family_id: 'family-1',
-    display_name: 'Timmy',
-    avatar_url: null,
-    nickname: 'Little T',
-    role: 'child',
-    points: 100,
-    created_at: '2024-01-01T00:00:00Z',
-  },
+  mockParentProfile,
+  mockChildProfile,
   {
     id: 'child-2',
     family_id: 'family-1',
@@ -44,39 +63,196 @@ const mockMembers = [
   },
 ]
 
-// Supabase mock
+const mockRewards = [
+  {
+    id: 'reward-1',
+    family_id: 'family-1',
+    title: 'Movie Night',
+    description: null,
+    points_cost: 50,
+    icon_id: 'movie',
+    category: 'activities',
+    stock: null,
+    active: true,
+    created_by: 'user-parent',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+const mockRedemptions = [
+  {
+    id: 'redemption-1',
+    reward_id: 'reward-1',
+    redeemed_by: 'user-child',
+    points_cost: 50,
+    status: 'pending',
+    redeemed_at: new Date().toISOString(),
+    resolved_at: null,
+    resolved_by: null,
+    rewards: { title: 'Movie Night', icon_id: 'movie' },
+  },
+]
+
+const mockPendingApprovals = [
+  {
+    id: 'redemption-1',
+    reward_id: 'reward-1',
+    redeemed_by: 'user-child',
+    points_cost: 50,
+    status: 'pending',
+    redeemed_at: new Date().toISOString(),
+    resolved_at: null,
+    resolved_by: null,
+    rewards: { title: 'Movie Night', icon_id: 'movie', family_id: 'family-1' },
+    profiles: { display_name: 'Timmy', nickname: 'Little T', avatar_url: null },
+  },
+]
+
+// Mutable state containers
+const mockState = {
+  user: mockUser as typeof mockUser | null,
+  profile: mockParentProfile as unknown,
+  members: mockMembers as unknown[],
+  rewards: mockRewards as unknown[],
+  myRedemptions: [] as unknown[],
+  myRedemptionsCount: 0,
+  pendingApprovals: [] as unknown[],
+  pendingPoints: [] as unknown[],
+}
+
 const mockGetUser = jest.fn()
-const mockProfileData = { current: mockProfile as unknown }
-const mockMembersData = { current: mockMembers as unknown[] }
+const mockRpc = jest.fn()
+const mockInsert = jest.fn()
+const mockUpdate = jest.fn()
 
 jest.mock('@/lib/supabase/client', () => ({
   createClient: () => ({
     auth: {
       getUser: () => mockGetUser(),
     },
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          single: () => Promise.resolve({ data: mockProfileData.current }),
-          order: () => Promise.resolve({ data: mockMembersData.current }),
+    rpc: (name: string, args: unknown) => mockRpc(name, args),
+    from: (table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => {
+              const membersPromise = Promise.resolve({ data: mockState.members })
+              return Object.assign(membersPromise, {
+                single: () => Promise.resolve({ data: mockState.profile }),
+                order: () => Promise.resolve({ data: mockState.members }),
+              })
+            },
+          }),
+        }
+      }
+      if (table === 'rewards') {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => Promise.resolve({ data: mockState.rewards }),
+            }),
+          }),
+          insert: (data: unknown) => mockInsert(data),
+          update: (data: unknown) => ({
+            eq: (...args: unknown[]) => mockUpdate(data, ...args),
+          }),
+        }
+      }
+      if (table === 'reward_redemptions') {
+        return {
+          select: (cols: string) => {
+            // Pending points query
+            if (cols === 'points_cost') {
+              return {
+                eq: () => ({
+                  eq: () => Promise.resolve({ data: mockState.pendingPoints }),
+                }),
+              }
+            }
+            // Pending approvals query (parent)
+            if (cols.includes('profiles!')) {
+              return {
+                eq: () => ({
+                  eq: () => ({
+                    order: () => Promise.resolve({ data: mockState.pendingApprovals }),
+                  }),
+                }),
+              }
+            }
+            // My redemptions query (with count)
+            return {
+              eq: () => ({
+                order: () => ({
+                  range: () =>
+                    Promise.resolve({
+                      data: mockState.myRedemptions,
+                      count: mockState.myRedemptionsCount,
+                    }),
+                }),
+              }),
+            }
+          },
+        }
+      }
+      return {
+        select: () => ({
+          eq: () => ({ single: () => Promise.resolve({ data: null }) }),
         }),
-      }),
-    }),
+      }
+    },
   }),
 }))
 
 describe('RewardsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGet.mockReturnValue(null) // default tab = store
+    mockState.user = mockUser
+    mockState.profile = mockParentProfile
+    mockState.members = mockMembers
+    mockState.rewards = mockRewards
+    mockState.myRedemptions = []
+    mockState.myRedemptionsCount = 0
+    mockState.pendingApprovals = []
+    mockState.pendingPoints = []
     mockGetUser.mockResolvedValue({ data: { user: mockUser } })
-    mockProfileData.current = mockProfile
-    mockMembersData.current = mockMembers
+    mockInsert.mockResolvedValue({ error: null })
+    mockUpdate.mockResolvedValue({ error: null })
+    mockRpc.mockResolvedValue({ data: { success: true } })
   })
 
   it('shows loading state initially', () => {
     mockGetUser.mockReturnValue(new Promise(() => {}))
     render(<RewardsPage />)
     expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('stops loading when user not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    render(<RewardsPage />)
+    await waitFor(() => expect(document.querySelector('.animate-spin')).not.toBeInTheDocument())
+  })
+
+  it('stops loading when profile not found', async () => {
+    mockState.profile = null
+    render(<RewardsPage />)
+    await waitFor(() => expect(document.querySelector('.animate-spin')).not.toBeInTheDocument())
+  })
+
+  it('shows no-family state when user has no family', async () => {
+    mockState.profile = { ...mockParentProfile, family_id: null }
+    render(<RewardsPage />)
+    await waitFor(() => expect(screen.getByText('No Family Yet')).toBeInTheDocument())
+    expect(screen.getByText(/join a family to see the leaderboard/i)).toBeInTheDocument()
+  })
+
+  it('shows Set Up Family link in no-family state', async () => {
+    mockState.profile = { ...mockParentProfile, family_id: null }
+    render(<RewardsPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'Set Up Family' })).toBeInTheDocument()
+    )
   })
 
   it('renders page header', async () => {
@@ -87,176 +263,411 @@ describe('RewardsPage', () => {
     })
   })
 
-  it('renders podium with top 3 members', async () => {
+  it('renders leaderboard podium', async () => {
     render(<RewardsPage />)
     await waitFor(() => {
-      expect(screen.getByText('150 pts')).toBeInTheDocument()
-      expect(screen.getByText('100 pts')).toBeInTheDocument()
-      expect(screen.getByText('75 pts')).toBeInTheDocument()
+      expect(screen.getByText('200 pts')).toBeInTheDocument()
+      expect(screen.getByText('🏆')).toBeInTheDocument()
+      expect(screen.getByText('👑')).toBeInTheDocument()
     })
   })
 
-  it('renders member names on podium', async () => {
+  it('renders member names on podium (uses first name when no nickname)', async () => {
     render(<RewardsPage />)
     await waitFor(() => {
-      expect(screen.getByText('Test')).toBeInTheDocument()   // First name of "Test User"
+      // topThree[0] = Parent (no nickname) → "Test"
+      expect(screen.getByText('Test')).toBeInTheDocument()
+      // topThree[1] = Timmy (has nickname "Little T")
       expect(screen.getByText('Little T')).toBeInTheDocument()
+      // topThree[2] = Sally (no nickname) → "Sally"
       expect(screen.getByText('Sally')).toBeInTheDocument()
     })
   })
 
-  it('renders Available Rewards section', async () => {
-    render(<RewardsPage />)
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Available Rewards' })).toBeInTheDocument()
-      expect(screen.getByText('Coming Soon!')).toBeInTheDocument()
-    })
-  })
-
-  it('shows no-family state when user has no family', async () => {
-    mockProfileData.current = { ...mockProfile, family_id: null }
-
-    render(<RewardsPage />)
-    await waitFor(() => {
-      expect(screen.getByText('No Family Yet')).toBeInTheDocument()
-      expect(screen.getByText(/join a family to see the leaderboard/i)).toBeInTheDocument()
-    })
-  })
-
-  it('shows Set Up Family link in no-family state', async () => {
-    mockProfileData.current = { ...mockProfile, family_id: null }
-
-    render(<RewardsPage />)
-    await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'Set Up Family' })).toBeInTheDocument()
-    })
-  })
-
-  describe('fetchData edge cases', () => {
-    it('stops loading when user is not authenticated', async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } })
-      render(<RewardsPage />)
-      await waitFor(() => {
-        expect(document.querySelector('.animate-spin')).not.toBeInTheDocument()
-      })
-    })
-
-    it('stops loading when profile is not found', async () => {
-      mockProfileData.current = null
-      render(<RewardsPage />)
-      await waitFor(() => {
-        expect(document.querySelector('.animate-spin')).not.toBeInTheDocument()
-      })
-    })
-  })
-
-  it('renders 4th+ members in a list below podium', async () => {
-    const fourMembers = [
+  it('renders 4th+ members in list below podium', async () => {
+    mockState.members = [
       ...mockMembers,
-      {
-        id: 'child-3',
-        family_id: 'family-1',
-        display_name: 'Bob',
-        avatar_url: null,
-        nickname: null,
-        role: 'child',
-        points: 25,
-        created_at: '2024-01-01T00:00:00Z',
-      },
+      { id: 'child-3', family_id: 'family-1', display_name: 'Bob', avatar_url: null, nickname: null, role: 'child', points: 25, created_at: '2024-01-01T00:00:00Z' },
     ]
-    mockMembersData.current = fourMembers
-
     render(<RewardsPage />)
     await waitFor(() => {
       expect(screen.getByText('Bob')).toBeInTheDocument()
-      expect(screen.getByText('25 pts')).toBeInTheDocument()
-      // 4th place indicator
       expect(screen.getByText('4')).toBeInTheDocument()
     })
   })
 
-  describe('podium with fewer than 3 members', () => {
-    it('renders podium with only 1 member (no 2nd/3rd place)', async () => {
-      mockMembersData.current = [
-        { ...mockProfile, points: 150 },
-      ]
+  it('renders with only 1 member (no 2nd/3rd place)', async () => {
+    mockState.members = [mockParentProfile]
+    render(<RewardsPage />)
+    await waitFor(() => expect(screen.getByText('200 pts')).toBeInTheDocument())
+    expect(screen.queryByText('🥈')).not.toBeInTheDocument()
+  })
 
+  it('renders with 2 members (no 3rd place)', async () => {
+    mockState.members = [mockParentProfile, mockChildProfile]
+    render(<RewardsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('200 pts')).toBeInTheDocument()
+      expect(screen.getByText('100 pts')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('🥉')).not.toBeInTheDocument()
+  })
+
+  it('handles null membersData', async () => {
+    mockState.members = null as unknown as unknown[]
+    render(<RewardsPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Rewards' })).toBeInTheDocument()
+    )
+  })
+
+  it('handles null data from all queries', async () => {
+    mockState.rewards = null as unknown as typeof mockState.rewards
+    mockState.myRedemptions = null as unknown as typeof mockState.myRedemptions
+    mockState.myRedemptionsCount = null as unknown as number
+    mockState.pendingApprovals = null as unknown as typeof mockState.pendingApprovals
+    mockState.pendingPoints = null as unknown as typeof mockState.pendingPoints
+    render(<RewardsPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Rewards' })).toBeInTheDocument()
+    )
+  })
+
+  it('renders 2nd place member display name when no nickname', async () => {
+    mockState.members = [
+      mockParentProfile,
+      { ...mockChildProfile, nickname: null },
+      { id: 'child-2', family_id: 'family-1', display_name: 'Sally Jones', avatar_url: null, nickname: null, role: 'child', points: 75, created_at: '2024-01-01T00:00:00Z' },
+    ]
+    render(<RewardsPage />)
+    await waitFor(() => expect(screen.getByText('Timmy')).toBeInTheDocument())
+  })
+
+  describe('parent view', () => {
+    it('shows Store, My Rewards, Manage, Approvals tabs', async () => {
       render(<RewardsPage />)
       await waitFor(() => {
-        expect(screen.getByText('150 pts')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Store' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'My Rewards' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Manage' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Approvals' })).toBeInTheDocument()
       })
-      // Only 1st place should render, no 2nd or 3rd
-      expect(screen.queryByText('100 pts')).not.toBeInTheDocument()
-      expect(screen.queryByText('75 pts')).not.toBeInTheDocument()
     })
 
-    it('renders podium with only 2 members (no 3rd place)', async () => {
-      mockMembersData.current = [
-        { ...mockProfile, points: 150 },
-        {
-          id: 'child-1',
-          family_id: 'family-1',
-          display_name: 'Timmy',
-          avatar_url: null,
-          nickname: 'Little T',
-          role: 'child',
-          points: 100,
-          created_at: '2024-01-01T00:00:00Z',
-        },
-      ]
-
+    it('shows points balance', async () => {
       render(<RewardsPage />)
-      await waitFor(() => {
-        expect(screen.getByText('150 pts')).toBeInTheDocument()
-        expect(screen.getByText('100 pts')).toBeInTheDocument()
-      })
-      // No 3rd place
-      expect(screen.queryByText('75 pts')).not.toBeInTheDocument()
+      await waitFor(() =>
+        expect(screen.getByText('200 pts available')).toBeInTheDocument()
+      )
     })
 
-    it('renders 2nd place member with null nickname (line 98/102 || falsy branch)', async () => {
-      mockMembersData.current = [
-        { ...mockProfile, points: 150 },
-        {
-          id: 'child-1',
-          family_id: 'family-1',
-          display_name: 'Timmy Jones',
-          avatar_url: null,
-          nickname: null,
-          role: 'child',
-          points: 100,
-          created_at: '2024-01-01T00:00:00Z',
-        },
-        {
-          id: 'child-2',
-          family_id: 'family-1',
-          display_name: 'Sally Smith',
-          avatar_url: null,
-          nickname: null,
-          role: 'child',
-          points: 75,
-          created_at: '2024-01-01T00:00:00Z',
-        },
-      ]
-
+    it('shows pending points when there are pending redemptions', async () => {
+      mockState.pendingPoints = [{ points_cost: 50 }]
       render(<RewardsPage />)
-      await waitFor(() => {
-        // 2nd place should show first name from display_name since nickname is null
-        expect(screen.getByText('Timmy')).toBeInTheDocument()
-        // 3rd place similarly
-        expect(screen.getByText('Sally')).toBeInTheDocument()
-      })
+      await waitFor(() =>
+        expect(screen.getByText('(50 pending approval)')).toBeInTheDocument()
+      )
+    })
+
+    it('shows approval badge count when approvals pending', async () => {
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Approvals (1)' })).toBeInTheDocument()
+      )
+    })
+
+    it('shows store tab content by default', async () => {
+      render(<RewardsPage />)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
+      )
+    })
+
+    it('shows reward cards in store', async () => {
+      render(<RewardsPage />)
+      await waitFor(() => expect(screen.getByText('Movie Night')).toBeInTheDocument())
+    })
+
+    it('switches to my-rewards tab', async () => {
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'My Rewards' }))
+      await userEvent.click(screen.getByRole('button', { name: 'My Rewards' }))
+      expect(mockPush).toHaveBeenCalledWith('?tab=my-rewards')
+    })
+
+    it('shows my-rewards tab content when tab=my-rewards', async () => {
+      mockGet.mockReturnValue('my-rewards')
+      mockState.myRedemptions = mockRedemptions
+      mockState.myRedemptionsCount = 1
+      render(<RewardsPage />)
+      await waitFor(() => expect(screen.getByText('Waiting for approval')).toBeInTheDocument())
+    })
+
+    it('shows manage tab content when tab=manage', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Add Reward/i })).toBeInTheDocument()
+      )
+    })
+
+    it('shows approvals tab content when tab=approvals', async () => {
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+      )
+    })
+
+    it('opens form when Add Reward clicked in manage tab', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: /Add Reward/i }))
+      await userEvent.click(screen.getByRole('button', { name: /Add Reward/i }))
+      expect(screen.getByText('New Reward')).toBeInTheDocument()
+    })
+
+    it('opens edit form when Edit clicked in manage tab', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Edit' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+      expect(screen.getByText('Edit Reward')).toBeInTheDocument()
+    })
+
+    it('creates reward via form submit', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: /Add Reward/i }))
+      await userEvent.click(screen.getByRole('button', { name: /Add Reward/i }))
+      await userEvent.type(screen.getByLabelText(/Title/i), 'New Reward')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() => expect(mockInsert).toHaveBeenCalled())
+    })
+
+    it('updates reward via form submit', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Edit' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+      await waitFor(() => screen.getByLabelText(/Title/i))
+      // Clear and retype
+      await userEvent.clear(screen.getByLabelText(/Title/i))
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Updated')
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+    })
+
+    it('shows error when update reward fails', async () => {
+      mockUpdate.mockResolvedValue({ error: { message: 'Update failed' } })
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Edit' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+      await waitFor(() => screen.getByLabelText(/Title/i))
+      await userEvent.clear(screen.getByLabelText(/Title/i))
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Updated')
+      await userEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+      await waitFor(() =>
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      )
+    })
+
+    it('shows error toast when insert fails', async () => {
+      mockInsert.mockResolvedValue({ error: { message: 'DB error' } })
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: /Add Reward/i }))
+      await userEvent.click(screen.getByRole('button', { name: /Add Reward/i }))
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() =>
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      )
+    })
+
+    it('toggles reward active state', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Deactivate' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+    })
+
+    it('shows toast error when toggle update fails', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockUpdate.mockResolvedValue({ error: { message: 'Toggle failed' } })
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Deactivate' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Toggle failed'))
+    })
+
+    it('deletes reward (soft-delete via deactivate)', async () => {
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Delete' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      const modal = screen.getByText('Delete Reward?').closest('div')!
+      await userEvent.click(within(modal).getByRole('button', { name: /^Delete$/ }))
+      await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+    })
+
+    it('throws error from delete when update fails', async () => {
+      mockUpdate.mockResolvedValue({ error: { message: 'Cannot delete' } })
+      mockGet.mockReturnValue('manage')
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Delete' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      const modal = screen.getByText('Delete Reward?').closest('div')!
+      await userEvent.click(within(modal).getByRole('button', { name: /^Delete$/ }))
+      await waitFor(() =>
+        expect(screen.getByText('Cannot delete')).toBeInTheDocument()
+      )
+    })
+
+    it('approves redemption in approvals tab', async () => {
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Approve' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+      await waitFor(() =>
+        expect(mockRpc).toHaveBeenCalledWith('resolve_redemption', expect.objectContaining({ p_action: 'approved' }))
+      )
+    })
+
+    it('shows toast error when approve RPC fails', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockRpc.mockResolvedValue({ data: { success: false, error: 'Already approved' } })
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Approve' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    })
+
+    it('rejects redemption in approvals tab', async () => {
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Reject' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+      const modal = screen.getByText('Reject Reward?').closest('div')!
+      await userEvent.click(within(modal).getByRole('button', { name: /^Reject$/ }))
+      await waitFor(() =>
+        expect(mockRpc).toHaveBeenCalledWith('resolve_redemption', expect.objectContaining({ p_action: 'rejected' }))
+      )
+    })
+
+    it('shows toast error when reject RPC fails', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockRpc.mockResolvedValue({ data: { success: false, error: 'Already resolved' } })
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Reject' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+      const modal = screen.getByText('Reject Reward?').closest('div')!
+      await userEvent.click(within(modal).getByRole('button', { name: /^Reject$/ }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    })
+
+    it('loads more redemptions', async () => {
+      mockGet.mockReturnValue('my-rewards')
+      mockState.myRedemptions = mockRedemptions
+      mockState.myRedemptionsCount = 25 // > PAGE_SIZE=20, triggers hasMore
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: /Load more/i }))
+      await userEvent.click(screen.getByRole('button', { name: /Load more/i }))
+      // Second fetch called (for offset=20)
+      await waitFor(() => expect(screen.getByRole('button', { name: /Load more/i })).toBeInTheDocument())
     })
   })
 
-  describe('membersData null branch', () => {
-    it('handles null membersData (line 42 falsy branch)', async () => {
-      mockMembersData.current = null as unknown as unknown[]
+  describe('child view', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: mockChildUser } })
+      mockState.profile = mockChildProfile
+    })
 
+    it('shows Store and My Rewards tabs but not Manage/Approvals', async () => {
       render(<RewardsPage />)
       await waitFor(() => {
-        expect(screen.getByRole('heading', { name: 'Rewards' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Store' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'My Rewards' })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Approvals' })).not.toBeInTheDocument()
       })
+    })
+
+    it('shows child points balance', async () => {
+      render(<RewardsPage />)
+      await waitFor(() => expect(screen.getByText('100 pts available')).toBeInTheDocument())
+    })
+
+    it('can redeem a reward (calls RPC)', async () => {
+      render(<RewardsPage />)
+      await waitFor(() => screen.getAllByRole('button', { name: 'Redeem' }))
+      await userEvent.click(screen.getAllByRole('button', { name: 'Redeem' })[0])
+      // Confirm modal opens
+      expect(screen.getByText('Redeem Reward')).toBeInTheDocument()
+      await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+      await waitFor(() =>
+        expect(mockRpc).toHaveBeenCalledWith('redeem_reward', expect.any(Object))
+      )
+    })
+
+    it('throws error when redeem RPC fails', async () => {
+      mockRpc.mockResolvedValue({ data: { success: false, error: 'Not enough points' } })
+      render(<RewardsPage />)
+      await waitFor(() => screen.getAllByRole('button', { name: 'Redeem' }))
+      await userEvent.click(screen.getAllByRole('button', { name: 'Redeem' })[0])
+      await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+      await waitFor(() =>
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      )
+    })
+
+    it('handles redeem RPC returning null data', async () => {
+      mockRpc.mockResolvedValue({ data: null })
+      render(<RewardsPage />)
+      await waitFor(() => screen.getAllByRole('button', { name: 'Redeem' }))
+      await userEvent.click(screen.getAllByRole('button', { name: 'Redeem' })[0])
+      await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+      await waitFor(() =>
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      )
+    })
+  })
+
+  describe('approve/reject RPC with null data', () => {
+    it('shows toast error when approve RPC returns null', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockRpc.mockResolvedValue({ data: null })
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Approve' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    })
+
+    it('shows toast error when reject RPC returns null', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockRpc.mockResolvedValue({ data: null })
+      mockGet.mockReturnValue('approvals')
+      mockState.pendingApprovals = mockPendingApprovals
+      render(<RewardsPage />)
+      await waitFor(() => screen.getByRole('button', { name: 'Reject' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+      const modal = screen.getByText('Reject Reward?').closest('div')!
+      await userEvent.click(within(modal).getByRole('button', { name: /^Reject$/ }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalled())
     })
   })
 })

--- a/__tests__/components/rewards/approval-queue.test.tsx
+++ b/__tests__/components/rewards/approval-queue.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ApprovalQueue } from '@/components/rewards/approval-queue'
+import type { RewardRedemptionWithDetails } from '@/lib/types'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => <img alt={props.alt} src={props.src} />,
+}))
+
+const makeRedemption = (id: string, minutesAgo = 5): RewardRedemptionWithDetails => ({
+  id,
+  reward_id: 'reward-1',
+  redeemed_by: 'child-1',
+  points_cost: 50,
+  status: 'pending',
+  redeemed_at: new Date(Date.now() - minutesAgo * 60000).toISOString(),
+  resolved_at: null,
+  resolved_by: null,
+  rewards: { title: 'Movie Night', icon_id: 'movie' },
+  profiles: {
+    display_name: 'Timmy',
+    nickname: 'Little T',
+    avatar_url: null,
+  },
+})
+
+const defaultProps = {
+  redemptions: [],
+  onApprove: jest.fn().mockResolvedValue(undefined),
+  onReject: jest.fn().mockResolvedValue(undefined),
+}
+
+describe('ApprovalQueue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows empty state when no pending redemptions', () => {
+    render(<ApprovalQueue {...defaultProps} />)
+    expect(screen.getByText(/No pending approvals/i)).toBeInTheDocument()
+    expect(screen.getByText(/All caught up/i)).toBeInTheDocument()
+  })
+
+  it('renders redemption items', () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    expect(screen.getByText('Movie Night')).toBeInTheDocument()
+    expect(screen.getByText('50 pts')).toBeInTheDocument()
+  })
+
+  it('shows child nickname when available', () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    expect(screen.getByText('Little T')).toBeInTheDocument()
+  })
+
+  it('shows child display_name when no nickname', () => {
+    const redemption = makeRedemption('r1')
+    redemption.profiles = { display_name: 'Timmy Jones', nickname: null, avatar_url: null }
+    render(<ApprovalQueue {...defaultProps} redemptions={[redemption]} />)
+    expect(screen.getByText('Timmy Jones')).toBeInTheDocument()
+  })
+
+  it('shows fallback name when no profile', () => {
+    const redemption = makeRedemption('r1')
+    redemption.profiles = undefined
+    render(<ApprovalQueue {...defaultProps} redemptions={[redemption]} />)
+    expect(screen.getByText('A child')).toBeInTheDocument()
+  })
+
+  it('shows relative time for recent redemption', () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1', 5)]} />)
+    expect(screen.getByText(/5m ago/)).toBeInTheDocument()
+  })
+
+  it('shows hours ago for older redemption', () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1', 90)]} />)
+    expect(screen.getByText(/1h ago/)).toBeInTheDocument()
+  })
+
+  it('shows days ago for old redemption', () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1', 60 * 25)]} />)
+    expect(screen.getByText(/1d ago/)).toBeInTheDocument()
+  })
+
+  it('calls onApprove when Approve clicked', async () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    await waitFor(() => expect(defaultProps.onApprove).toHaveBeenCalledWith('r1'))
+  })
+
+  it('shows Reject confirmation when Reject clicked', async () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    expect(screen.getByText('Reject Reward?')).toBeInTheDocument()
+    expect(screen.getByText(/50 points/)).toBeInTheDocument()
+  })
+
+  it('calls onReject after confirmation', async () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    const modal = screen.getByText('Reject Reward?').closest('div')!
+    await userEvent.click(within(modal).getByRole('button', { name: /^Reject$/ }))
+    await waitFor(() => expect(defaultProps.onReject).toHaveBeenCalledWith('r1'))
+  })
+
+  it('closes reject modal when Cancel clicked', async () => {
+    render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByText('Reject Reward?')).not.toBeInTheDocument()
+  })
+
+  it('closes reject modal when backdrop clicked', async () => {
+    const { container } = render(<ApprovalQueue {...defaultProps} redemptions={[makeRedemption('r1')]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    expect(screen.getByText('Reject Reward?')).toBeInTheDocument()
+    const backdrop = container.querySelector('.fixed.z-40') as Element
+    await userEvent.click(backdrop)
+    expect(screen.queryByText('Reject Reward?')).not.toBeInTheDocument()
+  })
+
+  it('uses fallback emoji for unknown icon', () => {
+    const redemption = makeRedemption('r1')
+    redemption.rewards = { title: 'Mystery', icon_id: 'unknown_icon' }
+    render(<ApprovalQueue {...defaultProps} redemptions={[redemption]} />)
+    expect(screen.getByRole('img', { name: 'unknown_icon' })).toHaveTextContent('🎁')
+  })
+
+  it('disables Approve button while approve loading', async () => {
+    let resolve: () => void
+    const promise = new Promise<void>((r) => { resolve = r })
+    const onApprove = jest.fn().mockReturnValue(promise)
+    render(<ApprovalQueue {...defaultProps} onApprove={onApprove} redemptions={[makeRedemption('r1')]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    // While loading, the loading state shows 'Saving...' and reject button should be disabled
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeDisabled()
+    resolve!()
+    await waitFor(() => expect(screen.queryByText('Saving...')).not.toBeInTheDocument())
+  })
+})

--- a/__tests__/components/rewards/manage-rewards.test.tsx
+++ b/__tests__/components/rewards/manage-rewards.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ManageRewards } from '@/components/rewards/manage-rewards'
+import type { Reward } from '@/lib/types'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => <img alt={props.alt} src={props.src} />,
+}))
+
+const makeReward = (overrides: Partial<Reward> = {}): Reward => ({
+  id: 'reward-1',
+  family_id: 'family-1',
+  title: 'Movie Night',
+  description: null,
+  points_cost: 50,
+  icon_id: 'movie',
+  category: 'activities',
+  stock: null,
+  active: true,
+  created_by: 'parent-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+const defaultProps = {
+  rewards: [],
+  onAdd: jest.fn(),
+  onEdit: jest.fn(),
+  onToggle: jest.fn().mockResolvedValue(undefined),
+  onDelete: jest.fn().mockResolvedValue(undefined),
+}
+
+describe('ManageRewards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows empty state when no rewards', () => {
+    render(<ManageRewards {...defaultProps} />)
+    expect(screen.getByText(/No rewards yet/i)).toBeInTheDocument()
+  })
+
+  it('shows Add Reward button', () => {
+    render(<ManageRewards {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /Add Reward/i })).toBeInTheDocument()
+  })
+
+  it('calls onAdd when Add Reward clicked', async () => {
+    render(<ManageRewards {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /Add Reward/i }))
+    expect(defaultProps.onAdd).toHaveBeenCalled()
+  })
+
+  it('renders reward cards', () => {
+    render(<ManageRewards {...defaultProps} rewards={[makeReward()]} />)
+    expect(screen.getByText('Movie Night')).toBeInTheDocument()
+  })
+
+  it('sorts active rewards before inactive', () => {
+    const rewards = [
+      makeReward({ id: 'r1', title: 'Inactive Reward', active: false }),
+      makeReward({ id: 'r2', title: 'Active Reward', active: true }),
+    ]
+    render(<ManageRewards {...defaultProps} rewards={rewards} />)
+    const cards = screen.getAllByRole('heading', { level: 3 })
+    expect(cards[0]).toHaveTextContent('Active Reward')
+    expect(cards[1]).toHaveTextContent('Inactive Reward')
+  })
+
+  it('preserves relative order of rewards with equal active status', () => {
+    const rewards = [
+      makeReward({ id: 'r1', title: 'First Active', active: true }),
+      makeReward({ id: 'r2', title: 'Second Active', active: true }),
+      makeReward({ id: 'r3', title: 'Inactive', active: false }),
+    ]
+    render(<ManageRewards {...defaultProps} rewards={rewards} />)
+    const cards = screen.getAllByRole('heading', { level: 3 })
+    expect(cards[0]).toHaveTextContent('First Active')
+    expect(cards[1]).toHaveTextContent('Second Active')
+    expect(cards[2]).toHaveTextContent('Inactive')
+  })
+
+  it('calls onEdit when Edit button clicked', async () => {
+    const reward = makeReward()
+    render(<ManageRewards {...defaultProps} rewards={[reward]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(defaultProps.onEdit).toHaveBeenCalledWith(reward)
+  })
+
+  it('calls onToggle when toggle button clicked', async () => {
+    const reward = makeReward()
+    render(<ManageRewards {...defaultProps} rewards={[reward]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+    await waitFor(() => expect(defaultProps.onToggle).toHaveBeenCalledWith(reward))
+  })
+
+  it('shows delete confirmation modal when Delete clicked', async () => {
+    render(<ManageRewards {...defaultProps} rewards={[makeReward()]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(screen.getByText('Delete Reward?')).toBeInTheDocument()
+    expect(screen.getByText(/"Movie Night"/)).toBeInTheDocument()
+  })
+
+  it('closes delete modal when Cancel clicked', async () => {
+    render(<ManageRewards {...defaultProps} rewards={[makeReward()]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByText('Delete Reward?')).not.toBeInTheDocument()
+  })
+
+  it('closes delete modal when backdrop clicked', async () => {
+    const { container } = render(<ManageRewards {...defaultProps} rewards={[makeReward()]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(screen.getByText('Delete Reward?')).toBeInTheDocument()
+    const backdrop = container.querySelector('.fixed.z-40') as Element
+    await userEvent.click(backdrop)
+    expect(screen.queryByText('Delete Reward?')).not.toBeInTheDocument()
+  })
+
+  it('calls onDelete when delete confirmed', async () => {
+    const reward = makeReward()
+    render(<ManageRewards {...defaultProps} rewards={[reward]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    const modal = screen.getByText('Delete Reward?').closest('div')!
+    await userEvent.click(within(modal).getByRole('button', { name: /^Delete$/ }))
+    await waitFor(() => expect(defaultProps.onDelete).toHaveBeenCalledWith(reward))
+  })
+
+  it('shows error when onDelete rejects', async () => {
+    const onDelete = jest.fn().mockRejectedValue(new Error('Cannot delete'))
+    render(<ManageRewards {...defaultProps} rewards={[makeReward()]} onDelete={onDelete} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    const modal = screen.getByText('Delete Reward?').closest('div')!
+    await userEvent.click(within(modal).getByRole('button', { name: /^Delete$/ }))
+    await waitFor(() => expect(screen.getByText('Cannot delete')).toBeInTheDocument())
+  })
+
+  it('shows fallback error message when onDelete rejects with non-Error', async () => {
+    const onDelete = jest.fn().mockRejectedValue('string error')
+    render(<ManageRewards {...defaultProps} rewards={[makeReward()]} onDelete={onDelete} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    const modal = screen.getByText('Delete Reward?').closest('div')!
+    await userEvent.click(within(modal).getByRole('button', { name: /^Delete$/ }))
+    await waitFor(() =>
+      expect(screen.getByText('Cannot delete. Deactivate it instead.')).toBeInTheDocument()
+    )
+  })
+})

--- a/__tests__/components/rewards/redeem-confirm-modal.test.tsx
+++ b/__tests__/components/rewards/redeem-confirm-modal.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RedeemConfirmModal } from '@/components/rewards/redeem-confirm-modal'
+import type { Reward } from '@/lib/types'
+
+const mockReward: Reward = {
+  id: 'reward-1',
+  family_id: 'family-1',
+  title: 'Movie Night',
+  description: null,
+  points_cost: 50,
+  icon_id: 'movie',
+  category: 'activities',
+  stock: null,
+  active: true,
+  created_by: 'parent-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onConfirm: jest.fn().mockResolvedValue(undefined),
+  reward: mockReward,
+  userPoints: 100,
+}
+
+describe('RedeemConfirmModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders nothing when reward is null', () => {
+    render(<RedeemConfirmModal {...defaultProps} reward={null} />)
+    expect(screen.queryByText('Redeem Reward')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when isOpen is false', () => {
+    render(<RedeemConfirmModal {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText('Redeem Reward')).not.toBeInTheDocument()
+  })
+
+  it('shows reward title and cost', () => {
+    render(<RedeemConfirmModal {...defaultProps} />)
+    expect(screen.getByText('Movie Night')).toBeInTheDocument()
+    expect(screen.getByText(/50 points/i)).toBeInTheDocument()
+  })
+
+  it('shows current balance', () => {
+    render(<RedeemConfirmModal {...defaultProps} />)
+    expect(screen.getByText('100 pts')).toBeInTheDocument()
+  })
+
+  it('shows balance after redemption', () => {
+    render(<RedeemConfirmModal {...defaultProps} />)
+    // 100 - 50 = 50 pts after
+    expect(screen.getByText('50 pts')).toBeInTheDocument()
+  })
+
+  it('shows reward emoji', () => {
+    render(<RedeemConfirmModal {...defaultProps} />)
+    expect(screen.getByRole('img', { name: 'movie' })).toBeInTheDocument()
+  })
+
+  it('uses fallback emoji for unknown icon', () => {
+    const unknown = { ...mockReward, icon_id: 'unknown_icon' }
+    render(<RedeemConfirmModal {...defaultProps} reward={unknown} />)
+    expect(screen.getByRole('img', { name: 'unknown_icon' })).toHaveTextContent('🎁')
+  })
+
+  it('calls onConfirm and onClose when confirmed', async () => {
+    render(<RedeemConfirmModal {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+    await waitFor(() => {
+      expect(defaultProps.onConfirm).toHaveBeenCalled()
+      expect(defaultProps.onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('shows loading state during confirmation', async () => {
+    let resolve: () => void
+    const promise = new Promise<void>((r) => { resolve = r })
+    const onConfirm = jest.fn().mockReturnValue(promise)
+    render(<RedeemConfirmModal {...defaultProps} onConfirm={onConfirm} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+    resolve!()
+    await waitFor(() => expect(screen.queryByText('Saving...')).not.toBeInTheDocument())
+  })
+
+  it('shows error when confirmation fails', async () => {
+    const onConfirm = jest.fn().mockRejectedValue(new Error('fail'))
+    render(<RedeemConfirmModal {...defaultProps} onConfirm={onConfirm} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+    await waitFor(() =>
+      expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+    )
+  })
+
+  it('calls onClose when Cancel clicked', async () => {
+    render(<RedeemConfirmModal {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/rewards/redemption-history.test.tsx
+++ b/__tests__/components/rewards/redemption-history.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RedemptionHistory } from '@/components/rewards/redemption-history'
+import type { RewardRedemptionWithDetails } from '@/lib/types'
+
+const now = new Date()
+const makeRedemption = (
+  id: string,
+  status: 'pending' | 'approved' | 'rejected',
+  daysAgo = 0
+): RewardRedemptionWithDetails => ({
+  id,
+  reward_id: 'reward-1',
+  redeemed_by: 'child-1',
+  points_cost: 50,
+  status,
+  redeemed_at: new Date(now.getTime() - daysAgo * 86400000).toISOString(),
+  resolved_at: null,
+  resolved_by: null,
+  rewards: { title: 'Movie Night', icon_id: 'movie' },
+})
+
+const defaultProps = {
+  redemptions: [],
+  hasMore: false,
+  onLoadMore: jest.fn(),
+  loadingMore: false,
+}
+
+describe('RedemptionHistory', () => {
+  it('shows empty state when no redemptions', () => {
+    render(<RedemptionHistory {...defaultProps} />)
+    expect(screen.getByText(/No rewards redeemed yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/Browse the store to get started/i)).toBeInTheDocument()
+  })
+
+  it('renders list of redemptions', () => {
+    const redemptions = [makeRedemption('r1', 'pending')]
+    render(<RedemptionHistory {...defaultProps} redemptions={redemptions} />)
+    expect(screen.getByText('Movie Night')).toBeInTheDocument()
+    expect(screen.getByText(/50 pts/)).toBeInTheDocument()
+  })
+
+  it('shows "Waiting for approval" badge for pending', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'pending')]} />)
+    expect(screen.getByText('Waiting for approval')).toBeInTheDocument()
+  })
+
+  it('shows "Approved" badge for approved', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'approved')]} />)
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+  })
+
+  it('shows "Rejected — points refunded" badge for rejected', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'rejected')]} />)
+    expect(screen.getByText('Rejected — points refunded')).toBeInTheDocument()
+  })
+
+  it('shows "Today" for redemptions from today', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'pending', 0)]} />)
+    expect(screen.getByText(/Today/)).toBeInTheDocument()
+  })
+
+  it('shows "Yesterday" for redemptions from 1 day ago', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'pending', 1)]} />)
+    expect(screen.getByText(/Yesterday/)).toBeInTheDocument()
+  })
+
+  it('shows "X days ago" for recent redemptions', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'pending', 3)]} />)
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument()
+  })
+
+  it('shows "X weeks ago" for older redemptions', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'pending', 10)]} />)
+    expect(screen.getByText(/weeks ago/)).toBeInTheDocument()
+  })
+
+  it('shows "X months ago" for old redemptions', () => {
+    render(<RedemptionHistory {...defaultProps} redemptions={[makeRedemption('r1', 'pending', 40)]} />)
+    expect(screen.getByText(/months ago/)).toBeInTheDocument()
+  })
+
+  it('shows Load more button when hasMore is true', () => {
+    render(
+      <RedemptionHistory
+        {...defaultProps}
+        redemptions={[makeRedemption('r1', 'pending')]}
+        hasMore
+      />
+    )
+    expect(screen.getByRole('button', { name: /Load more/i })).toBeInTheDocument()
+  })
+
+  it('does not show Load more when hasMore is false', () => {
+    render(
+      <RedemptionHistory
+        {...defaultProps}
+        redemptions={[makeRedemption('r1', 'pending')]}
+        hasMore={false}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /Load more/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onLoadMore when Load more clicked', async () => {
+    const onLoadMore = jest.fn()
+    render(
+      <RedemptionHistory
+        {...defaultProps}
+        redemptions={[makeRedemption('r1', 'pending')]}
+        hasMore
+        onLoadMore={onLoadMore}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /Load more/i }))
+    expect(onLoadMore).toHaveBeenCalled()
+  })
+
+  it('shows loading state on Load more when loadingMore is true', () => {
+    render(
+      <RedemptionHistory
+        {...defaultProps}
+        redemptions={[makeRedemption('r1', 'pending')]}
+        hasMore
+        loadingMore
+      />
+    )
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+  })
+
+  it('uses fallback emoji for unknown icon', () => {
+    const redemption = makeRedemption('r1', 'pending')
+    redemption.rewards = { title: 'Unknown', icon_id: 'unknown_icon' }
+    render(<RedemptionHistory {...defaultProps} redemptions={[redemption]} />)
+    expect(screen.getByRole('img', { name: 'unknown_icon' })).toHaveTextContent('🎁')
+  })
+})

--- a/__tests__/components/rewards/reward-card.test.tsx
+++ b/__tests__/components/rewards/reward-card.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RewardCard } from '@/components/rewards/reward-card'
+import type { Reward } from '@/lib/types'
+
+const mockReward: Reward = {
+  id: 'reward-1',
+  family_id: 'family-1',
+  title: 'Movie Night',
+  description: 'Pick any movie to watch',
+  points_cost: 50,
+  icon_id: 'movie',
+  category: 'activities',
+  stock: null,
+  active: true,
+  created_by: 'parent-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+describe('RewardCard', () => {
+  describe('store view — child', () => {
+    it('renders title, cost, and emoji', () => {
+      render(
+        <RewardCard reward={mockReward} userPoints={100} userRole="child" />
+      )
+      expect(screen.getByText('Movie Night')).toBeInTheDocument()
+      expect(screen.getByText('50 pts')).toBeInTheDocument()
+      expect(screen.getByRole('img', { name: 'movie' })).toBeInTheDocument()
+    })
+
+    it('renders description when provided', () => {
+      render(<RewardCard reward={mockReward} userPoints={100} userRole="child" />)
+      expect(screen.getByText('Pick any movie to watch')).toBeInTheDocument()
+    })
+
+    it('does not render description when absent', () => {
+      const noDesc = { ...mockReward, description: null }
+      render(<RewardCard reward={noDesc} userPoints={100} userRole="child" />)
+      expect(screen.queryByText('Pick any movie to watch')).not.toBeInTheDocument()
+    })
+
+    it('shows Redeem button when child can afford', () => {
+      render(<RewardCard reward={mockReward} userPoints={100} userRole="child" />)
+      expect(screen.getByRole('button', { name: 'Redeem' })).toBeInTheDocument()
+    })
+
+    it('shows "Need X more pts" when child cannot afford', () => {
+      render(<RewardCard reward={mockReward} userPoints={20} userRole="child" />)
+      expect(screen.getByRole('button', { name: /Need 30 more pts/i })).toBeInTheDocument()
+    })
+
+    it('disables button when child cannot afford', () => {
+      render(<RewardCard reward={mockReward} userPoints={20} userRole="child" />)
+      expect(screen.getByRole('button', { name: /Need 30 more pts/i })).toBeDisabled()
+    })
+
+    it('shows "Out of stock" when stock is 0', () => {
+      const outOfStock = { ...mockReward, stock: 0 }
+      render(<RewardCard reward={outOfStock} userPoints={100} userRole="child" />)
+      expect(screen.getByRole('button', { name: 'Out of stock' })).toBeInTheDocument()
+    })
+
+    it('disables button when out of stock', () => {
+      const outOfStock = { ...mockReward, stock: 0 }
+      render(<RewardCard reward={outOfStock} userPoints={100} userRole="child" />)
+      expect(screen.getByRole('button', { name: 'Out of stock' })).toBeDisabled()
+    })
+
+    it('shows stock remaining badge when stock > 0', () => {
+      const limited = { ...mockReward, stock: 3 }
+      render(<RewardCard reward={limited} userPoints={100} userRole="child" />)
+      expect(screen.getByText('3 left')).toBeInTheDocument()
+    })
+
+    it('shows out of stock badge when stock is 0', () => {
+      const oos = { ...mockReward, stock: 0 }
+      render(<RewardCard reward={oos} userPoints={100} userRole="child" />)
+      // Badge in stock indicator (not the button)
+      const badges = screen.getAllByText('Out of stock')
+      expect(badges.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('does not show stock badge when unlimited (null)', () => {
+      render(<RewardCard reward={mockReward} userPoints={100} userRole="child" />)
+      expect(screen.queryByText(/left/)).not.toBeInTheDocument()
+    })
+
+    it('calls onRedeem with reward id when Redeem clicked', async () => {
+      const onRedeem = jest.fn().mockResolvedValue(undefined)
+      render(
+        <RewardCard reward={mockReward} userPoints={100} userRole="child" onRedeem={onRedeem} />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Redeem' }))
+      expect(onRedeem).toHaveBeenCalledWith('reward-1')
+    })
+
+    it('shows loading state while redeeming', async () => {
+      let resolve: () => void
+      const promise = new Promise<void>((r) => { resolve = r })
+      const onRedeem = jest.fn().mockReturnValue(promise)
+      render(
+        <RewardCard reward={mockReward} userPoints={100} userRole="child" onRedeem={onRedeem} />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Redeem' }))
+      expect(screen.getByText('Saving...')).toBeInTheDocument()
+      resolve!()
+      await waitFor(() => expect(screen.queryByText('Saving...')).not.toBeInTheDocument())
+    })
+
+    it('uses fallback emoji for unknown icon_id', () => {
+      const unknown = { ...mockReward, icon_id: 'nonexistent' }
+      render(<RewardCard reward={unknown} userPoints={100} userRole="child" />)
+      expect(screen.getByRole('img', { name: 'nonexistent' })).toHaveTextContent('🎁')
+    })
+
+    it('does nothing when Redeem clicked without onRedeem handler', async () => {
+      render(<RewardCard reward={mockReward} userPoints={100} userRole="child" />)
+      await userEvent.click(screen.getByRole('button', { name: 'Redeem' }))
+      // No error thrown and no loading state
+      expect(screen.queryByText('Saving...')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('store view — parent', () => {
+    it('does not show Redeem button for parent', () => {
+      render(<RewardCard reward={mockReward} userPoints={0} userRole="parent" />)
+      expect(screen.queryByRole('button', { name: 'Redeem' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('manage view', () => {
+    it('shows Edit, Deactivate, Delete buttons for active reward', () => {
+      render(
+        <RewardCard
+          reward={mockReward}
+          userPoints={0}
+          userRole="parent"
+          isManageView
+          onEdit={jest.fn()}
+          onToggle={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Deactivate' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+    })
+
+    it('shows Activate button for inactive reward', () => {
+      const inactive = { ...mockReward, active: false }
+      render(
+        <RewardCard reward={inactive} userPoints={0} userRole="parent" isManageView onToggle={jest.fn()} />
+      )
+      expect(screen.getByRole('button', { name: 'Activate' })).toBeInTheDocument()
+    })
+
+    it('shows Inactive badge for inactive reward', () => {
+      const inactive = { ...mockReward, active: false }
+      render(<RewardCard reward={inactive} userPoints={0} userRole="parent" isManageView />)
+      expect(screen.getByText('Inactive')).toBeInTheDocument()
+    })
+
+    it('applies opacity class for inactive reward in manage view', () => {
+      const inactive = { ...mockReward, active: false }
+      const { container } = render(
+        <RewardCard reward={inactive} userPoints={0} userRole="parent" isManageView />
+      )
+      expect(container.firstChild).toHaveClass('opacity-50')
+    })
+
+    it('does not apply opacity for active reward', () => {
+      const { container } = render(
+        <RewardCard reward={mockReward} userPoints={0} userRole="parent" isManageView />
+      )
+      expect(container.firstChild).not.toHaveClass('opacity-50')
+    })
+
+    it('calls onEdit when Edit clicked', async () => {
+      const onEdit = jest.fn()
+      render(
+        <RewardCard reward={mockReward} userPoints={0} userRole="parent" isManageView onEdit={onEdit} />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+      expect(onEdit).toHaveBeenCalledWith(mockReward)
+    })
+
+    it('calls onDelete when Delete clicked', async () => {
+      const onDelete = jest.fn()
+      render(
+        <RewardCard reward={mockReward} userPoints={0} userRole="parent" isManageView onDelete={onDelete} />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      expect(onDelete).toHaveBeenCalledWith(mockReward)
+    })
+
+    it('calls onToggle when toggle button clicked', async () => {
+      const onToggle = jest.fn().mockResolvedValue(undefined)
+      render(
+        <RewardCard reward={mockReward} userPoints={0} userRole="parent" isManageView onToggle={onToggle} />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+      expect(onToggle).toHaveBeenCalledWith(mockReward)
+    })
+
+    it('shows loading state while toggling', async () => {
+      let resolve: () => void
+      const promise = new Promise<void>((r) => { resolve = r })
+      const onToggle = jest.fn().mockReturnValue(promise)
+      render(
+        <RewardCard reward={mockReward} userPoints={0} userRole="parent" isManageView onToggle={onToggle} />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+      expect(screen.getByText('Saving...')).toBeInTheDocument()
+      resolve!()
+      await waitFor(() => expect(screen.queryByText('Saving...')).not.toBeInTheDocument())
+    })
+
+    it('does nothing when toggle clicked without onToggle handler', async () => {
+      render(
+        <RewardCard reward={mockReward} userPoints={0} userRole="parent" isManageView />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Deactivate' }))
+      expect(screen.queryByText('Saving...')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/components/rewards/reward-form.test.tsx
+++ b/__tests__/components/rewards/reward-form.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RewardForm } from '@/components/rewards/reward-form'
+import type { Reward } from '@/lib/types'
+
+const mockReward: Reward = {
+  id: 'reward-1',
+  family_id: 'family-1',
+  title: 'Movie Night',
+  description: 'Pick any movie',
+  points_cost: 50,
+  icon_id: 'movie',
+  category: 'activities',
+  stock: 5,
+  active: true,
+  created_by: 'parent-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onSubmit: jest.fn().mockResolvedValue(undefined),
+}
+
+describe('RewardForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('create mode', () => {
+    it('shows "New Reward" title', () => {
+      render(<RewardForm {...defaultProps} />)
+      expect(screen.getByText('New Reward')).toBeInTheDocument()
+    })
+
+    it('shows "Create Reward" submit button', () => {
+      render(<RewardForm {...defaultProps} />)
+      expect(screen.getByRole('button', { name: 'Create Reward' })).toBeInTheDocument()
+    })
+
+    it('starts with empty title', () => {
+      render(<RewardForm {...defaultProps} />)
+      expect(screen.getByLabelText(/Title/i)).toHaveValue('')
+    })
+
+    it('starts with default points cost of 10', () => {
+      render(<RewardForm {...defaultProps} />)
+      expect(screen.getByLabelText(/Points Cost/i)).toHaveValue('10')
+    })
+  })
+
+  describe('edit mode', () => {
+    it('shows "Edit Reward" title', () => {
+      render(<RewardForm {...defaultProps} reward={mockReward} />)
+      expect(screen.getByText('Edit Reward')).toBeInTheDocument()
+    })
+
+    it('shows "Save Changes" submit button', () => {
+      render(<RewardForm {...defaultProps} reward={mockReward} />)
+      expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument()
+    })
+
+    it('pre-populates title from reward', () => {
+      render(<RewardForm {...defaultProps} reward={mockReward} />)
+      expect(screen.getByLabelText(/Title/i)).toHaveValue('Movie Night')
+    })
+
+    it('pre-populates points cost from reward', () => {
+      render(<RewardForm {...defaultProps} reward={mockReward} />)
+      expect(screen.getByLabelText(/Points Cost/i)).toHaveValue('50')
+    })
+
+    it('pre-populates stock from reward', () => {
+      render(<RewardForm {...defaultProps} reward={mockReward} />)
+      expect(screen.getByLabelText(/Stock Limit/i)).toHaveValue('5')
+    })
+
+    it('resets to empty when switching to create mode', () => {
+      const { rerender } = render(<RewardForm {...defaultProps} reward={mockReward} />)
+      rerender(<RewardForm {...defaultProps} reward={undefined} />)
+      expect(screen.getByLabelText(/Title/i)).toHaveValue('')
+    })
+
+    it('populates description (null becomes empty string)', () => {
+      const noDesc = { ...mockReward, description: null }
+      render(<RewardForm {...defaultProps} reward={noDesc} />)
+      expect(screen.getByLabelText(/Description/i)).toHaveValue('')
+    })
+
+    it('shows stock as empty when reward.stock is null', () => {
+      const unlimited = { ...mockReward, stock: null }
+      render(<RewardForm {...defaultProps} reward={unlimited} />)
+      expect(screen.getByLabelText(/Stock Limit/i)).toHaveValue('')
+    })
+  })
+
+  describe('validation', () => {
+    it('shows error when title is empty on submit', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      expect(screen.getByText('Title is required')).toBeInTheDocument()
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled()
+    })
+
+    it('shows error when points cost is 0', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.clear(screen.getByLabelText(/Points Cost/i))
+      await userEvent.type(screen.getByLabelText(/Points Cost/i), '0')
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() =>
+        expect(screen.getByText('Points cost must be at least 1')).toBeInTheDocument()
+      )
+    })
+
+    it('shows error when stock is -1', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.type(screen.getByLabelText(/Stock Limit/i), '-1')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() =>
+        expect(screen.getByText('Stock must be at least 1 if provided')).toBeInTheDocument()
+      )
+    })
+  })
+
+  describe('successful submission', () => {
+    it('calls onSubmit with form data', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Ice Cream')
+      // Submit with default points cost (10), no stock limit
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() => {
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Ice Cream',
+            points_cost: 10,
+            stock: null,
+          })
+        )
+      })
+    })
+
+    it('includes description in submitted data', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.type(screen.getByLabelText(/Description/i), 'A fun reward')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() => {
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ description: 'A fun reward' })
+        )
+      })
+    })
+
+    it('includes selected category in submitted data', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.selectOptions(screen.getByLabelText(/Category/i), 'treats')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() => {
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ category: 'treats' })
+        )
+      })
+    })
+
+    it('passes stock as number when provided', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Limited Reward')
+      await userEvent.type(screen.getByLabelText(/Stock Limit/i), '3')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() => {
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ stock: 3 })
+        )
+      })
+    })
+
+    it('calls onClose after successful submit', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() => expect(defaultProps.onClose).toHaveBeenCalled())
+    })
+  })
+
+  describe('error handling', () => {
+    it('shows error message when submit throws', async () => {
+      const onSubmit = jest.fn().mockRejectedValue(new Error('DB error'))
+      render(<RewardForm {...defaultProps} onSubmit={onSubmit} />)
+      await userEvent.type(screen.getByLabelText(/Title/i), 'Test')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Reward' }))
+      await waitFor(() =>
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument()
+      )
+    })
+  })
+
+  describe('cancel', () => {
+    it('calls onClose when Cancel clicked', async () => {
+      render(<RewardForm {...defaultProps} />)
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(defaultProps.onClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('icon selection', () => {
+    it('renders icon grid buttons', () => {
+      render(<RewardForm {...defaultProps} />)
+      expect(screen.getByRole('button', { name: 'Star' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Movie' })).toBeInTheDocument()
+    })
+
+    it('selects clicked icon', async () => {
+      render(<RewardForm {...defaultProps} />)
+      const gameBtn = screen.getByRole('button', { name: 'Game' })
+      await userEvent.click(gameBtn)
+      expect(gameBtn).toHaveClass('ring-2')
+    })
+  })
+
+  describe('not open', () => {
+    it('renders nothing when isOpen is false', () => {
+      render(<RewardForm {...defaultProps} isOpen={false} />)
+      expect(screen.queryByText('New Reward')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/components/rewards/reward-store.test.tsx
+++ b/__tests__/components/rewards/reward-store.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RewardStore } from '@/components/rewards/reward-store'
+import type { Reward } from '@/lib/types'
+
+const makeReward = (overrides: Partial<Reward> = {}): Reward => ({
+  id: 'reward-1',
+  family_id: 'family-1',
+  title: 'Movie Night',
+  description: null,
+  points_cost: 50,
+  icon_id: 'movie',
+  category: 'activities',
+  stock: null,
+  active: true,
+  created_by: 'parent-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  ...overrides,
+})
+
+const mockRewards: Reward[] = [
+  makeReward({ id: 'r1', title: 'Movie Night', category: 'activities' }),
+  makeReward({ id: 'r2', title: 'Ice Cream', category: 'treats', icon_id: 'ice_cream' }),
+  makeReward({ id: 'r3', title: 'Screen Time', category: 'screen_time', icon_id: 'game', points_cost: 30 }),
+]
+
+const defaultProps = {
+  rewards: mockRewards,
+  userPoints: 100,
+  userRole: 'child' as const,
+  onRedeem: jest.fn().mockResolvedValue(undefined),
+}
+
+describe('RewardStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows empty state when no rewards', () => {
+    render(<RewardStore {...defaultProps} rewards={[]} />)
+    expect(screen.getByText(/No rewards available yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/Ask your parents to add some/i)).toBeInTheDocument()
+  })
+
+  it('renders all rewards by default', () => {
+    render(<RewardStore {...defaultProps} />)
+    expect(screen.getByText('Movie Night')).toBeInTheDocument()
+    expect(screen.getByText('Ice Cream')).toBeInTheDocument()
+    expect(screen.getByText('Screen Time')).toBeInTheDocument()
+  })
+
+  it('shows All filter chip as active by default', () => {
+    render(<RewardStore {...defaultProps} />)
+    const allButton = screen.getByRole('button', { name: 'All' })
+    expect(allButton).toHaveClass('bg-purple-100')
+  })
+
+  it('shows category filter chips', () => {
+    render(<RewardStore {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /Activities/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Treats/i })).toBeInTheDocument()
+  })
+
+  it('filters rewards by category', async () => {
+    render(<RewardStore {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /Treats/i }))
+    expect(screen.queryByText('Movie Night')).not.toBeInTheDocument()
+    expect(screen.getByText('Ice Cream')).toBeInTheDocument()
+  })
+
+  it('shows all rewards again when All is clicked', async () => {
+    render(<RewardStore {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /Treats/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'All' }))
+    expect(screen.getByText('Movie Night')).toBeInTheDocument()
+    expect(screen.getByText('Ice Cream')).toBeInTheDocument()
+  })
+
+  it('shows empty state when category has no rewards', async () => {
+    render(<RewardStore {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /Privileges/i }))
+    expect(screen.getByText(/No rewards available yet/i)).toBeInTheDocument()
+  })
+
+  it('opens confirm modal when child clicks Redeem', async () => {
+    render(<RewardStore {...defaultProps} />)
+    const redeemBtns = screen.getAllByRole('button', { name: 'Redeem' })
+    await userEvent.click(redeemBtns[0])
+    expect(screen.getByText('Redeem Reward')).toBeInTheDocument()
+  })
+
+  it('calls onRedeem when confirm modal confirmed', async () => {
+    render(<RewardStore {...defaultProps} />)
+    const redeemBtns = screen.getAllByRole('button', { name: 'Redeem' })
+    await userEvent.click(redeemBtns[0])
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm Redemption' }))
+    await waitFor(() => expect(defaultProps.onRedeem).toHaveBeenCalled())
+  })
+
+  it('closes modal without calling onRedeem when Cancel clicked', async () => {
+    render(<RewardStore {...defaultProps} />)
+    const redeemBtns = screen.getAllByRole('button', { name: 'Redeem' })
+    await userEvent.click(redeemBtns[0])
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByText('Redeem Reward')).not.toBeInTheDocument()
+    expect(defaultProps.onRedeem).not.toHaveBeenCalled()
+  })
+
+  it('does not show Redeem buttons for parent role', () => {
+    render(<RewardStore {...defaultProps} userRole="parent" />)
+    expect(screen.queryByRole('button', { name: 'Redeem' })).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/db/rewards.test.ts
+++ b/__tests__/db/rewards.test.ts
@@ -1,0 +1,322 @@
+jest.retryTimes(1, { logErrorsBeforeRetry: true })
+
+import {
+  callRpcAsUser,
+  ensureDbTestUser,
+  runSQLWithRetry,
+} from './helpers/db-test-helpers'
+
+let userId: string
+let familyId: string
+
+// A second "child" user for family-isolation tests
+let childUserId: string
+
+async function ensureChildUser(): Promise<string> {
+  const email = 'db-test-child@chore-champions-test.local'
+  const existing = await runSQLWithRetry(
+    `SELECT id FROM auth.users WHERE email = '${email}' LIMIT 1`
+  ) as Array<{ id: string }>
+  if (existing.length > 0) return existing[0].id
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing env vars')
+
+  const res = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${serviceRoleKey}`,
+      'apikey': serviceRoleKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password: 'TestPassword123!',
+      email_confirm: true,
+      user_metadata: { display_name: 'DB Test Child' },
+    }),
+  })
+  const data = (await res.json()) as { id: string }
+  return data.id
+}
+
+async function joinFamily(childId: string, targetFamilyId: string): Promise<void> {
+  // Upsert child profile into the family
+  await runSQLWithRetry(`
+    INSERT INTO profiles (id, family_id, display_name, role)
+    VALUES ('${childId}', '${targetFamilyId}', 'DB Test Child', 'child')
+    ON CONFLICT (id) DO UPDATE SET family_id = '${targetFamilyId}', role = 'child'
+  `)
+}
+
+async function createReward(overrides: {
+  familyId: string
+  createdBy: string
+  pointsCost?: number
+  stock?: number | null
+  active?: boolean
+}): Promise<string> {
+  const { familyId: fid, createdBy, pointsCost = 50, stock, active = true } = overrides
+  const stockSql = stock === undefined || stock === null ? 'NULL' : stock.toString()
+  const rows = await runSQLWithRetry(`
+    INSERT INTO rewards (family_id, title, points_cost, stock, active, created_by)
+    VALUES ('${fid}', 'Test Reward', ${pointsCost}, ${stockSql}, ${active}, '${createdBy}')
+    RETURNING id
+  `) as Array<{ id: string }>
+  return rows[0].id
+}
+
+async function setPoints(uid: string, points: number): Promise<void> {
+  await runSQLWithRetry(`UPDATE profiles SET points = ${points} WHERE id = '${uid}'`)
+}
+
+async function cleanupRewards(): Promise<void> {
+  await runSQLWithRetry(`
+    DELETE FROM reward_redemptions WHERE redeemed_by IN ('${userId}', '${childUserId ?? userId}');
+    DELETE FROM rewards WHERE family_id = '${familyId}';
+  `)
+}
+
+beforeAll(async () => {
+  const user = await ensureDbTestUser()
+  userId = user.userId
+  familyId = user.familyId
+
+  childUserId = await ensureChildUser()
+  await joinFamily(childUserId, familyId)
+
+  await cleanupRewards()
+})
+
+afterAll(async () => {
+  await cleanupRewards()
+})
+
+afterEach(async () => {
+  await cleanupRewards()
+})
+
+// ─── redeem_reward ──────────────────────────────────────────────────────────
+
+describe('redeem_reward', () => {
+  it('happy path: child redeems reward, points deducted, redemption created', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId, pointsCost: 30 })
+    await setPoints(childUserId, 100)
+
+    const result = await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = result as Array<{ redeem_reward: { success: boolean; points_spent: number } }>
+    const data = rows[0].redeem_reward
+    expect(data.success).toBe(true)
+    expect(data.points_spent).toBe(30)
+
+    // Points should be deducted
+    const pts = await runSQLWithRetry(
+      `SELECT points FROM profiles WHERE id = '${childUserId}'`
+    ) as Array<{ points: number }>
+    expect(pts[0].points).toBe(70)
+
+    // Redemption record created
+    const redemptions = await runSQLWithRetry(
+      `SELECT * FROM reward_redemptions WHERE redeemed_by = '${childUserId}'`
+    ) as Array<{ status: string; points_cost: number }>
+    expect(redemptions).toHaveLength(1)
+    expect(redemptions[0].status).toBe('pending')
+    expect(redemptions[0].points_cost).toBe(30)
+  })
+
+  it('returns error when child has insufficient points', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId, pointsCost: 100 })
+    await setPoints(childUserId, 50)
+
+    const result = await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = result as Array<{ redeem_reward: { success: boolean; error: string } }>
+    expect(rows[0].redeem_reward.success).toBe(false)
+    expect(rows[0].redeem_reward.error).toMatch(/not enough points/i)
+  })
+
+  it('returns error for out-of-stock reward', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId, pointsCost: 10, stock: 0 })
+    await setPoints(childUserId, 100)
+
+    const result = await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = result as Array<{ redeem_reward: { success: boolean; error: string } }>
+    // stock check: stock=0 inserted directly; RPC checks active, then stock > 0
+    expect(rows[0].redeem_reward.success).toBe(false)
+  })
+
+  it('returns error for inactive reward', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId, active: false })
+    await setPoints(childUserId, 100)
+
+    const result = await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = result as Array<{ redeem_reward: { success: boolean; error: string } }>
+    expect(rows[0].redeem_reward.success).toBe(false)
+    expect(rows[0].redeem_reward.error).toMatch(/no longer available/i)
+  })
+
+  it('returns error when parent tries to redeem', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId })
+    await setPoints(userId, 100)
+
+    const result = await callRpcAsUser(
+      userId,
+      `redeem_reward('${userId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = result as Array<{ redeem_reward: { success: boolean; error: string } }>
+    expect(rows[0].redeem_reward.success).toBe(false)
+    expect(rows[0].redeem_reward.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error for non-existent reward', async () => {
+    const fakeId = '00000000-0000-0000-0000-000000000000'
+    const result = await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${fakeId}'::uuid)`
+    )
+    const rows = result as Array<{ redeem_reward: { success: boolean; error: string } }>
+    expect(rows[0].redeem_reward.success).toBe(false)
+    expect(rows[0].redeem_reward.error).toMatch(/not found/i)
+  })
+
+  it('decrements stock for limited rewards', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId, pointsCost: 10, stock: 3 })
+    await setPoints(childUserId, 100)
+
+    await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+
+    const rows = await runSQLWithRetry(
+      `SELECT stock FROM rewards WHERE id = '${rewardId}'`
+    ) as Array<{ stock: number }>
+    expect(rows[0].stock).toBe(2)
+  })
+})
+
+// ─── resolve_redemption ──────────────────────────────────────────────────────
+
+describe('resolve_redemption', () => {
+  async function createPendingRedemption(): Promise<{ redemptionId: string; rewardId: string }> {
+    const rewardId = await createReward({ familyId, createdBy: userId, pointsCost: 20 })
+    await setPoints(childUserId, 100)
+    await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = await runSQLWithRetry(
+      `SELECT id FROM reward_redemptions WHERE redeemed_by = '${childUserId}' LIMIT 1`
+    ) as Array<{ id: string }>
+    return { redemptionId: rows[0].id, rewardId }
+  }
+
+  it('approve: sets status to approved', async () => {
+    const { redemptionId } = await createPendingRedemption()
+
+    const result = await callRpcAsUser(
+      userId,
+      `resolve_redemption('${userId}'::uuid, '${redemptionId}'::uuid, 'approved')`
+    )
+    const rows = result as Array<{ resolve_redemption: { success: boolean } }>
+    expect(rows[0].resolve_redemption.success).toBe(true)
+
+    const redemption = await runSQLWithRetry(
+      `SELECT status FROM reward_redemptions WHERE id = '${redemptionId}'`
+    ) as Array<{ status: string }>
+    expect(redemption[0].status).toBe('approved')
+  })
+
+  it('reject: refunds points and restores stock', async () => {
+    const rewardId = await createReward({ familyId, createdBy: userId, pointsCost: 20, stock: 5 })
+    await setPoints(childUserId, 100)
+    await callRpcAsUser(
+      childUserId,
+      `redeem_reward('${childUserId}'::uuid, '${rewardId}'::uuid)`
+    )
+    const rows = await runSQLWithRetry(
+      `SELECT id FROM reward_redemptions WHERE redeemed_by = '${childUserId}' LIMIT 1`
+    ) as Array<{ id: string }>
+    const redemptionId = rows[0].id
+
+    const result = await callRpcAsUser(
+      userId,
+      `resolve_redemption('${userId}'::uuid, '${redemptionId}'::uuid, 'rejected')`
+    )
+    const rpcRows = result as Array<{ resolve_redemption: { success: boolean } }>
+    expect(rpcRows[0].resolve_redemption.success).toBe(true)
+
+    // Points refunded
+    const pts = await runSQLWithRetry(
+      `SELECT points FROM profiles WHERE id = '${childUserId}'`
+    ) as Array<{ points: number }>
+    expect(pts[0].points).toBe(100) // back to original
+
+    // Stock restored
+    const stock = await runSQLWithRetry(
+      `SELECT stock FROM rewards WHERE id = '${rewardId}'`
+    ) as Array<{ stock: number }>
+    expect(stock[0].stock).toBe(5) // back to original
+  })
+
+  it('returns error when trying to resolve already-resolved redemption', async () => {
+    const { redemptionId } = await createPendingRedemption()
+    await callRpcAsUser(
+      userId,
+      `resolve_redemption('${userId}'::uuid, '${redemptionId}'::uuid, 'approved')`
+    )
+    // Try to approve again
+    const result = await callRpcAsUser(
+      userId,
+      `resolve_redemption('${userId}'::uuid, '${redemptionId}'::uuid, 'approved')`
+    )
+    const rows = result as Array<{ resolve_redemption: { success: boolean; error: string } }>
+    expect(rows[0].resolve_redemption.success).toBe(false)
+    expect(rows[0].resolve_redemption.error).toMatch(/already resolved/i)
+  })
+
+  it('returns error for invalid action', async () => {
+    const { redemptionId } = await createPendingRedemption()
+    const result = await callRpcAsUser(
+      userId,
+      `resolve_redemption('${userId}'::uuid, '${redemptionId}'::uuid, 'invalid')`
+    )
+    const rows = result as Array<{ resolve_redemption: { success: boolean; error: string } }>
+    expect(rows[0].resolve_redemption.success).toBe(false)
+    expect(rows[0].resolve_redemption.error).toMatch(/invalid action/i)
+  })
+
+  it('returns error when child tries to resolve', async () => {
+    const { redemptionId } = await createPendingRedemption()
+    const result = await callRpcAsUser(
+      childUserId,
+      `resolve_redemption('${childUserId}'::uuid, '${redemptionId}'::uuid, 'approved')`
+    )
+    const rows = result as Array<{ resolve_redemption: { success: boolean; error: string } }>
+    expect(rows[0].resolve_redemption.success).toBe(false)
+    expect(rows[0].resolve_redemption.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error for non-existent redemption', async () => {
+    const fakeId = '00000000-0000-0000-0000-000000000000'
+    const result = await callRpcAsUser(
+      userId,
+      `resolve_redemption('${userId}'::uuid, '${fakeId}'::uuid, 'approved')`
+    )
+    const rows = result as Array<{ resolve_redemption: { success: boolean; error: string } }>
+    expect(rows[0].resolve_redemption.success).toBe(false)
+    expect(rows[0].resolve_redemption.error).toMatch(/not found/i)
+  })
+})

--- a/app/(dashboard)/rewards/page.tsx
+++ b/app/(dashboard)/rewards/page.tsx
@@ -1,54 +1,296 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, Suspense } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { toast } from 'sonner'
 import { createClient } from '@/lib/supabase/client'
 import { Card, CardContent } from '@/components/ui/card'
 import { Avatar } from '@/components/ui/avatar'
-import type { Profile } from '@/lib/types'
+import { RewardStore } from '@/components/rewards/reward-store'
+import { RedemptionHistory } from '@/components/rewards/redemption-history'
+import { ManageRewards } from '@/components/rewards/manage-rewards'
+import { ApprovalQueue } from '@/components/rewards/approval-queue'
+import { RewardForm } from '@/components/rewards/reward-form'
+import type { RewardFormData } from '@/components/rewards/reward-form'
+import type {
+  Profile,
+  Reward,
+  RewardRedemptionWithDetails,
+} from '@/lib/types'
 
-export default function RewardsPage() {
-  const [members, setMembers] = useState<Profile[]>([])
-  const [currentUser, setCurrentUser] = useState<Profile | null>(null)
+type Tab = 'store' | 'my-rewards' | 'manage' | 'approvals'
+
+const PAGE_SIZE = 20
+
+function RewardsPageContent() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const activeTab = (searchParams.get('tab') as Tab) || 'store'
+
   const [loading, setLoading] = useState(true)
+  const [currentUser, setCurrentUser] = useState<Profile | null>(null)
+  const [members, setMembers] = useState<Profile[]>([])
+  const [rewards, setRewards] = useState<Reward[]>([])
+  const [myRedemptions, setMyRedemptions] = useState<RewardRedemptionWithDetails[]>([])
+  const [pendingApprovals, setPendingApprovals] = useState<RewardRedemptionWithDetails[]>([])
+  const [hasMoreRedemptions, setHasMoreRedemptions] = useState(false)
+  const [redemptionOffset, setRedemptionOffset] = useState(0)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [pendingPointsCost, setPendingPointsCost] = useState(0)
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [editingReward, setEditingReward] = useState<Reward | null>(null)
 
   const supabase = createClient()
 
-  const fetchData = useCallback(async () => {
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) {
-      setLoading(false)
-      return
-    }
-
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('id', user.id)
-      .single()
-
-    if (!profile) {
-      setLoading(false)
-      return
-    }
-    setCurrentUser(profile)
-
-    if (profile.family_id) {
-      const { data: membersData } = await supabase
+  const fetchMembers = useCallback(
+    async (familyId: string) => {
+      const { data } = await supabase
         .from('profiles')
         .select('*')
-        .eq('family_id', profile.family_id)
+        .eq('family_id', familyId)
         .order('points', { ascending: false })
+      setMembers(data ?? [])
+    },
+    [supabase]
+  )
 
-      setMembers(membersData || [])
-    }
+  const fetchRewards = useCallback(
+    async (familyId: string) => {
+      const { data } = await supabase
+        .from('rewards')
+        .select('*')
+        .eq('family_id', familyId)
+        .order('points_cost')
+      setRewards(data ?? [])
+    },
+    [supabase]
+  )
 
-    setLoading(false)
-  }, [supabase])
+  const fetchMyRedemptions = useCallback(
+    async (userId: string, offset: number) => {
+      const { data, count } = await supabase
+        .from('reward_redemptions')
+        .select('*, rewards(title, icon_id)', { count: 'exact' })
+        .eq('redeemed_by', userId)
+        .order('redeemed_at', { ascending: false })
+        .range(offset, offset + PAGE_SIZE - 1)
+      return { data: (data ?? []) as RewardRedemptionWithDetails[], count: count ?? 0 }
+    },
+    [supabase]
+  )
+
+  const fetchPendingApprovals = useCallback(
+    async (familyId: string) => {
+      const { data } = await supabase
+        .from('reward_redemptions')
+        .select(
+          '*, rewards!inner(title, icon_id, family_id), profiles!reward_redemptions_redeemed_by_fkey(display_name, nickname, avatar_url)'
+        )
+        .eq('rewards.family_id', familyId)
+        .eq('status', 'pending')
+        .order('redeemed_at')
+      setPendingApprovals((data ?? []) as RewardRedemptionWithDetails[])
+    },
+    [supabase]
+  )
+
+  const fetchPendingPointsCost = useCallback(
+    async (userId: string) => {
+      const { data } = await supabase
+        .from('reward_redemptions')
+        .select('points_cost')
+        .eq('redeemed_by', userId)
+        .eq('status', 'pending')
+      const total = (data ?? []).reduce((sum, r) => sum + r.points_cost, 0)
+      setPendingPointsCost(total)
+    },
+    [supabase]
+  )
+
+  const fetchProfile = useCallback(
+    async (userId: string) => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', userId)
+        .single()
+      if (data) setCurrentUser(data)
+      return data
+    },
+    [supabase]
+  )
 
   useEffect(() => {
+    const load = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) {
+        setLoading(false)
+        return
+      }
+
+      const profile = await fetchProfile(user.id)
+      if (!profile) {
+        setLoading(false)
+        return
+      }
+
+      if (profile.family_id) {
+        const isParent = profile.role === 'parent'
+        const [redemptionsResult] = await Promise.all([
+          fetchMyRedemptions(user.id, 0),
+          fetchMembers(profile.family_id),
+          fetchRewards(profile.family_id),
+          fetchPendingPointsCost(user.id),
+          isParent ? fetchPendingApprovals(profile.family_id) : Promise.resolve(undefined),
+        ])
+        const { data: redemptions, count } = redemptionsResult
+        setMyRedemptions(redemptions)
+        setHasMoreRedemptions(count > PAGE_SIZE)
+        setRedemptionOffset(PAGE_SIZE)
+      }
+
+      setLoading(false)
+    }
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data fetch on mount
-    fetchData()
-  }, [fetchData])
+    load()
+  }, [fetchMembers, fetchMyRedemptions, fetchPendingApprovals, fetchPendingPointsCost, fetchProfile, fetchRewards, supabase])
+
+  const refreshAll = useCallback(
+    async (userId: string, familyId: string, isParent: boolean) => {
+      const [redemptionsResult] = await Promise.all([
+        fetchMyRedemptions(userId, 0),
+        fetchProfile(userId),
+        fetchRewards(familyId),
+        fetchPendingPointsCost(userId),
+        isParent ? fetchPendingApprovals(familyId) : Promise.resolve(undefined),
+      ])
+      const { data: redemptions, count } = redemptionsResult
+      setMyRedemptions(redemptions)
+      setHasMoreRedemptions(count > PAGE_SIZE)
+      setRedemptionOffset(PAGE_SIZE)
+    },
+    [fetchMyRedemptions, fetchPendingApprovals, fetchPendingPointsCost, fetchProfile, fetchRewards]
+  )
+
+  const handleRedeem = async (rewardId: string) => {
+    const result = await supabase.rpc('redeem_reward', {
+      p_user_id: currentUser!.id,
+      p_reward_id: rewardId,
+    })
+    const data = result.data as { success: boolean; error?: string } | null
+    if (!data?.success) {
+      throw new Error(data?.error ?? 'Something went wrong')
+    }
+    await refreshAll(currentUser!.id, currentUser!.family_id!, false)
+  }
+
+  const handleApprove = async (redemptionId: string) => {
+    const result = await supabase.rpc('resolve_redemption', {
+      p_user_id: currentUser!.id,
+      p_redemption_id: redemptionId,
+      p_action: 'approved',
+    })
+    const data = result.data as { success: boolean; error?: string } | null
+    if (!data?.success) {
+      toast.error(data?.error ?? 'Something went wrong')
+      return
+    }
+    await refreshAll(currentUser!.id, currentUser!.family_id!, true)
+  }
+
+  const handleReject = async (redemptionId: string) => {
+    const result = await supabase.rpc('resolve_redemption', {
+      p_user_id: currentUser!.id,
+      p_redemption_id: redemptionId,
+      p_action: 'rejected',
+    })
+    const data = result.data as { success: boolean; error?: string } | null
+    if (!data?.success) {
+      toast.error(data?.error ?? 'Something went wrong')
+      return
+    }
+    await refreshAll(currentUser!.id, currentUser!.family_id!, true)
+  }
+
+  const handleCreateReward = async (formData: RewardFormData) => {
+    const { error } = await supabase.from('rewards').insert({
+      family_id: currentUser!.family_id!,
+      title: formData.title,
+      description: formData.description || null,
+      points_cost: formData.points_cost,
+      icon_id: formData.icon_id,
+      category: formData.category,
+      stock: formData.stock,
+      created_by: currentUser!.id,
+    })
+    if (error) throw new Error(error.message)
+    await fetchRewards(currentUser!.family_id!)
+  }
+
+  const handleUpdateReward = async (formData: RewardFormData) => {
+    const { error } = await supabase
+      .from('rewards')
+      .update({
+        title: formData.title,
+        description: formData.description || null,
+        points_cost: formData.points_cost,
+        icon_id: formData.icon_id,
+        category: formData.category,
+        stock: formData.stock,
+      })
+      .eq('id', editingReward!.id)
+    if (error) throw new Error(error.message)
+    await fetchRewards(currentUser!.family_id!)
+  }
+
+  const handleToggleActive = async (reward: Reward) => {
+    const { error } = await supabase
+      .from('rewards')
+      .update({ active: !reward.active })
+      .eq('id', reward.id)
+    if (error) {
+      toast.error(error.message)
+      return
+    }
+    await fetchRewards(currentUser!.family_id!)
+  }
+
+  const handleDeleteReward = async (reward: Reward) => {
+    const { error } = await supabase
+      .from('rewards')
+      .update({ active: false })
+      .eq('id', reward.id)
+    if (error) throw new Error(error.message)
+    await fetchRewards(currentUser!.family_id!)
+  }
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true)
+    const { data, count } = await fetchMyRedemptions(currentUser!.id, redemptionOffset)
+    setMyRedemptions((prev) => [...prev, ...data])
+    setHasMoreRedemptions(count > redemptionOffset + PAGE_SIZE)
+    setRedemptionOffset((prev) => prev + PAGE_SIZE)
+    setLoadingMore(false)
+  }
+
+  const handleOpenForm = (reward?: Reward) => {
+    setEditingReward(reward ?? null)
+    setIsFormOpen(true)
+  }
+
+  const handleFormSubmit = async (formData: RewardFormData) => {
+    if (editingReward) {
+      await handleUpdateReward(formData)
+    } else {
+      await handleCreateReward(formData)
+    }
+  }
+
+  const setTab = (tab: Tab) => {
+    router.push(`?tab=${tab}`)
+  }
 
   if (loading) {
     return (
@@ -77,8 +319,18 @@ export default function RewardsPage() {
     )
   }
 
+  const isParent = currentUser.role === 'parent'
   const topThree = members.slice(0, 3)
   const rest = members.slice(3)
+  const activeRewards = rewards.filter((r) => r.active)
+  const pendingCount = pendingApprovals.length
+
+  const tabs: { id: Tab; label: string; show: boolean }[] = [
+    { id: 'store', label: 'Store', show: true },
+    { id: 'my-rewards', label: 'My Rewards', show: true },
+    { id: 'manage', label: 'Manage', show: isParent },
+    { id: 'approvals', label: `Approvals${pendingCount > 0 ? ` (${pendingCount})` : ''}`, show: isParent },
+  ]
 
   return (
     <div className="p-4 space-y-6">
@@ -175,23 +427,96 @@ export default function RewardsPage() {
         </div>
       )}
 
-      {/* Rewards Section (Stub) */}
-      <section className="pt-4">
-        <h2 className="text-lg font-semibold text-gray-900 mb-3">Available Rewards</h2>
-        <Card>
-          <CardContent className="p-6 text-center">
-            <div className="w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" />
-              </svg>
-            </div>
-            <h3 className="font-semibold text-gray-900 mb-2">Coming Soon!</h3>
-            <p className="text-gray-600 text-sm">
-              Redeem your points for real rewards like screen time, treats, or special activities.
-            </p>
-          </CardContent>
-        </Card>
+      {/* Rewards section */}
+      <section className="pt-2">
+        {/* Points display */}
+        <div className="flex items-center gap-2 mb-4">
+          <span className="text-lg font-bold text-purple-600">{currentUser.points} pts available</span>
+          {pendingPointsCost > 0 && (
+            <span className="text-sm text-yellow-600">
+              ({pendingPointsCost} pending approval)
+            </span>
+          )}
+        </div>
+
+        {/* Tab bar */}
+        <div className="flex gap-1 border-b border-gray-200 mb-4 overflow-x-auto">
+          {tabs
+            .filter((t) => t.show)
+            .map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setTab(tab.id)}
+                className={`flex-shrink-0 px-4 py-2 text-sm font-medium transition border-b-2 -mb-px ${
+                  activeTab === tab.id
+                    ? 'border-purple-600 text-purple-600'
+                    : 'border-transparent text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+        </div>
+
+        {/* Tab content */}
+        {activeTab === 'store' && (
+          <RewardStore
+            rewards={activeRewards}
+            userPoints={currentUser.points}
+            userRole={currentUser.role}
+            onRedeem={handleRedeem}
+          />
+        )}
+
+        {activeTab === 'my-rewards' && (
+          <RedemptionHistory
+            redemptions={myRedemptions}
+            hasMore={hasMoreRedemptions}
+            onLoadMore={handleLoadMore}
+            loadingMore={loadingMore}
+          />
+        )}
+
+        {activeTab === 'manage' && isParent && (
+          <ManageRewards
+            rewards={rewards}
+            onAdd={() => handleOpenForm()}
+            onEdit={(r) => handleOpenForm(r)}
+            onToggle={handleToggleActive}
+            onDelete={handleDeleteReward}
+          />
+        )}
+
+        {activeTab === 'approvals' && isParent && (
+          <ApprovalQueue
+            redemptions={pendingApprovals}
+            onApprove={handleApprove}
+            onReject={handleReject}
+          />
+        )}
       </section>
+
+      {/* Reward form modal */}
+      <RewardForm
+        isOpen={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        onSubmit={handleFormSubmit}
+        reward={editingReward ?? undefined}
+      />
     </div>
+  )
+}
+
+export default function RewardsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600" />
+        </div>
+      }
+    >
+      <RewardsPageContent />
+    </Suspense>
   )
 }

--- a/app/(dashboard)/rewards/page.tsx
+++ b/app/(dashboard)/rewards/page.tsx
@@ -12,6 +12,9 @@ import { ManageRewards } from '@/components/rewards/manage-rewards'
 import { ApprovalQueue } from '@/components/rewards/approval-queue'
 import { RewardForm } from '@/components/rewards/reward-form'
 import type { RewardFormData } from '@/components/rewards/reward-form'
+import {
+  DEFAULT_REWARDS,
+} from '@/lib/types'
 import type {
   Profile,
   Reward,
@@ -149,6 +152,23 @@ function RewardsPageContent() {
         setMyRedemptions(redemptions)
         setHasMoreRedemptions(count > PAGE_SIZE)
         setRedemptionOffset(PAGE_SIZE)
+
+        // Seed default rewards for new families (parent only, one-time)
+        if (isParent) {
+          const { count: rewardCount } = await supabase
+            .from('rewards')
+            .select('*', { count: 'exact', head: true })
+            .eq('family_id', profile.family_id)
+          if (rewardCount === 0) {
+            const rows = DEFAULT_REWARDS.map((r) => ({
+              family_id: profile.family_id!,
+              created_by: user.id,
+              ...r,
+            }))
+            await supabase.from('rewards').insert(rows)
+            await fetchRewards(profile.family_id)
+          }
+        }
       }
 
       setLoading(false)

--- a/components/rewards/approval-queue.tsx
+++ b/components/rewards/approval-queue.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Avatar } from '@/components/ui/avatar'
+import { REWARD_ICON_OPTIONS } from '@/lib/types'
+import type { RewardRedemptionWithDetails } from '@/lib/types'
+
+export interface ApprovalQueueProps {
+  redemptions: RewardRedemptionWithDetails[]
+  onApprove: (redemptionId: string) => Promise<void>
+  onReject: (redemptionId: string) => Promise<void>
+}
+
+function getRewardEmoji(iconId: string): string {
+  const option = REWARD_ICON_OPTIONS.find((o) => o.id === iconId)
+  return option?.emoji ?? '🎁'
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+
+  if (diffMins < 60) return `${diffMins}m ago`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+  return `${Math.floor(diffHours / 24)}d ago`
+}
+
+export function ApprovalQueue({ redemptions, onApprove, onReject }: ApprovalQueueProps) {
+  const [loadingId, setLoadingId] = useState<string | null>(null)
+  const [rejectingId, setRejectingId] = useState<string | null>(null)
+
+  const handleApprove = async (redemptionId: string) => {
+    setLoadingId(`${redemptionId}-approve`)
+    try {
+      await onApprove(redemptionId)
+    } finally {
+      setLoadingId(null)
+    }
+  }
+
+  const handleRejectClick = (redemptionId: string) => {
+    setRejectingId(redemptionId)
+  }
+
+  const handleRejectConfirm = async () => {
+    setLoadingId(`${rejectingId!}-reject`)
+    try {
+      await onReject(rejectingId!)
+      setRejectingId(null)
+    } finally {
+      setLoadingId(null)
+    }
+  }
+
+  const rejectingRedemption = redemptions.find((r) => r.id === rejectingId)
+
+  if (redemptions.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        <p className="text-lg">No pending approvals.</p>
+        <p className="text-sm mt-1">All caught up!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {redemptions.map((redemption) => {
+        const childName =
+          redemption.profiles?.nickname ??
+          redemption.profiles?.display_name ??
+          'A child'
+        const isApprovingThis = loadingId === `${redemption.id}-approve`
+        const isRejectingThis = loadingId === `${redemption.id}-reject`
+
+        return (
+          <div
+            key={redemption.id}
+            className="bg-white rounded-xl border border-gray-100 shadow-sm p-4"
+          >
+            <div className="flex items-center gap-3 mb-3">
+              <Avatar
+                src={redemption.profiles?.avatar_url ?? null}
+                fallback={childName}
+                size="md"
+              />
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-gray-900">{childName}</p>
+                <p className="text-sm text-gray-500">{formatRelativeTime(redemption.redeemed_at)}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xl" role="img" aria-label={redemption.rewards.icon_id}>
+                  {getRewardEmoji(redemption.rewards.icon_id)}
+                </span>
+                <div>
+                  <p className="text-sm font-medium text-gray-900">{redemption.rewards.title}</p>
+                  <p className="text-xs text-purple-600 font-semibold">{redemption.points_cost} pts</p>
+                </div>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                className="flex-1"
+                onClick={() => handleApprove(redemption.id)}
+                loading={isApprovingThis}
+                disabled={isRejectingThis || loadingId !== null && !isApprovingThis}
+              >
+                Approve
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                className="flex-1"
+                onClick={() => handleRejectClick(redemption.id)}
+                disabled={isApprovingThis || isRejectingThis}
+              >
+                Reject
+              </Button>
+            </div>
+          </div>
+        )
+      })}
+
+      {/* Reject confirmation */}
+      {rejectingRedemption && (
+        <>
+          <div className="fixed inset-0 bg-black/50 z-40" onClick={() => setRejectingId(null)} />
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <div
+              className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Reject Reward?</h3>
+              <p className="text-gray-600 text-sm mb-4">
+                Reject{' '}
+                <span className="font-semibold">&quot;{rejectingRedemption.rewards.title}&quot;</span>?{' '}
+                <span className="text-purple-600 font-semibold">
+                  {rejectingRedemption.points_cost} points
+                </span>{' '}
+                will be refunded.
+              </p>
+              <div className="flex gap-3">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => setRejectingId(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  className="flex-1"
+                  onClick={handleRejectConfirm}
+                  loading={loadingId === `${rejectingId}-reject`}
+                >
+                  Reject
+                </Button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/rewards/manage-rewards.tsx
+++ b/components/rewards/manage-rewards.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+import { RewardCard } from '@/components/rewards/reward-card'
+import { Button } from '@/components/ui/button'
+import type { Reward } from '@/lib/types'
+
+export interface ManageRewardsProps {
+  rewards: Reward[]
+  onAdd: () => void
+  onEdit: (reward: Reward) => void
+  onToggle: (reward: Reward) => Promise<void>
+  onDelete: (reward: Reward) => Promise<void>
+}
+
+export function ManageRewards({ rewards, onAdd, onEdit, onToggle, onDelete }: ManageRewardsProps) {
+  const [deletingReward, setDeletingReward] = useState<Reward | null>(null)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const handleDeleteClick = (reward: Reward) => {
+    setDeletingReward(reward)
+    setDeleteError(null)
+  }
+
+  const handleDeleteConfirm = async () => {
+    setDeleteLoading(true)
+    setDeleteError(null)
+    try {
+      await onDelete(deletingReward!)
+      setDeletingReward(null)
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : 'Cannot delete. Deactivate it instead.'
+      )
+    } finally {
+      setDeleteLoading(false)
+    }
+  }
+
+  // Active rewards first, then inactive
+  const sorted = [...rewards].sort((a, b) => {
+    if (a.active === b.active) return 0
+    return a.active ? -1 : 1
+  })
+
+  return (
+    <div>
+      <div className="flex justify-end mb-4">
+        <Button variant="primary" size="sm" onClick={onAdd}>
+          + Add Reward
+        </Button>
+      </div>
+
+      {rewards.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <p className="text-lg">No rewards yet.</p>
+          <p className="text-sm mt-1">Create your first reward for your family!</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {sorted.map((reward) => (
+            <RewardCard
+              key={reward.id}
+              reward={reward}
+              userPoints={0}
+              userRole="parent"
+              isManageView
+              onEdit={onEdit}
+              onToggle={onToggle}
+              onDelete={handleDeleteClick}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
+      {deletingReward && (
+        <>
+          <div className="fixed inset-0 bg-black/50 z-40" onClick={() => setDeletingReward(null)} />
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6" onClick={(e) => e.stopPropagation()}>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Delete Reward?</h3>
+              <p className="text-gray-600 text-sm mb-4">
+                Delete <span className="font-semibold">&quot;{deletingReward.title}&quot;</span>? This cannot be undone.
+              </p>
+              {deleteError && (
+                <p className="text-sm text-red-600 bg-red-50 p-2 rounded-lg mb-3">{deleteError}</p>
+              )}
+              <div className="flex gap-3">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => setDeletingReward(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  className="flex-1"
+                  onClick={handleDeleteConfirm}
+                  loading={deleteLoading}
+                >
+                  Delete
+                </Button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/rewards/redeem-confirm-modal.tsx
+++ b/components/rewards/redeem-confirm-modal.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState } from 'react'
+import { Modal } from '@/components/ui/modal'
+import { Button } from '@/components/ui/button'
+import { REWARD_ICON_OPTIONS } from '@/lib/types'
+import type { Reward } from '@/lib/types'
+
+export interface RedeemConfirmModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => Promise<void>
+  reward: Reward | null
+  userPoints: number
+}
+
+function getRewardEmoji(iconId: string): string {
+  const option = REWARD_ICON_OPTIONS.find((o) => o.id === iconId)
+  return option?.emoji ?? '🎁'
+}
+
+export function RedeemConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  reward,
+  userPoints,
+}: RedeemConfirmModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!reward) return null
+
+  const emoji = getRewardEmoji(reward.icon_id)
+  const balanceAfter = userPoints - reward.points_cost
+
+  const handleConfirm = async () => {
+    setError(null)
+    setLoading(true)
+    try {
+      await onConfirm()
+      onClose()
+    } catch {
+      setError('Something went wrong. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Redeem Reward">
+      <div className="space-y-4">
+        <div className="text-center">
+          <span className="text-5xl" role="img" aria-label={reward.icon_id}>
+            {emoji}
+          </span>
+          <h3 className="mt-3 text-lg font-semibold text-gray-900">{reward.title}</h3>
+          <p className="mt-1 text-gray-600">
+            Spend <span className="font-bold text-purple-600">{reward.points_cost} points</span> on this reward?
+          </p>
+        </div>
+
+        <div className="bg-gray-50 rounded-lg p-3 space-y-1 text-sm">
+          <div className="flex justify-between">
+            <span className="text-gray-600">Current balance</span>
+            <span className="font-semibold">{userPoints} pts</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Cost</span>
+            <span className="font-semibold text-red-600">−{reward.points_cost} pts</span>
+          </div>
+          <div className="flex justify-between border-t border-gray-200 pt-1 mt-1">
+            <span className="text-gray-700 font-medium">Balance after</span>
+            <span className="font-bold text-purple-600">{balanceAfter} pts</span>
+          </div>
+        </div>
+
+        <p className="text-xs text-gray-500 text-center">
+          Your parent will need to approve this redemption.
+        </p>
+
+        {error && (
+          <p className="text-sm text-red-600 bg-red-50 p-2 rounded-lg text-center">{error}</p>
+        )}
+
+        <div className="flex gap-3">
+          <Button variant="secondary" size="sm" onClick={onClose} className="flex-1">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleConfirm}
+            loading={loading}
+            className="flex-1"
+          >
+            Confirm Redemption
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/components/rewards/redemption-history.tsx
+++ b/components/rewards/redemption-history.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { REWARD_ICON_OPTIONS } from '@/lib/types'
+import type { RewardRedemptionWithDetails } from '@/lib/types'
+
+export interface RedemptionHistoryProps {
+  redemptions: RewardRedemptionWithDetails[]
+  hasMore: boolean
+  onLoadMore: () => void
+  loadingMore: boolean
+}
+
+function getRewardEmoji(iconId: string): string {
+  const option = REWARD_ICON_OPTIONS.find((o) => o.id === iconId)
+  return option?.emoji ?? '🎁'
+}
+
+function StatusBadge({ status }: { status: RewardRedemptionWithDetails['status'] }) {
+  if (status === 'approved') {
+    return (
+      <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full font-medium">
+        Approved
+      </span>
+    )
+  }
+  if (status === 'rejected') {
+    return (
+      <span className="text-xs bg-red-100 text-red-700 px-2 py-0.5 rounded-full font-medium">
+        Rejected — points refunded
+      </span>
+    )
+  }
+  return (
+    <span className="text-xs bg-yellow-100 text-yellow-700 px-2 py-0.5 rounded-full font-medium">
+      Waiting for approval
+    </span>
+  )
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
+  return `${Math.floor(diffDays / 30)} months ago`
+}
+
+export function RedemptionHistory({
+  redemptions,
+  hasMore,
+  onLoadMore,
+  loadingMore,
+}: RedemptionHistoryProps) {
+  if (redemptions.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        <p className="text-lg">No rewards redeemed yet.</p>
+        <p className="text-sm mt-1">Browse the store to get started!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {redemptions.map((redemption) => (
+        <div
+          key={redemption.id}
+          className="bg-white rounded-xl border border-gray-100 shadow-sm p-4 flex items-center gap-3"
+        >
+          <span className="text-2xl flex-shrink-0" role="img" aria-label={redemption.rewards.icon_id}>
+            {getRewardEmoji(redemption.rewards.icon_id)}
+          </span>
+          <div className="flex-1 min-w-0">
+            <p className="font-medium text-gray-900 truncate">{redemption.rewards.title}</p>
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
+              <span className="text-sm text-gray-500">
+                {redemption.points_cost} pts · {formatRelativeTime(redemption.redeemed_at)}
+              </span>
+              <StatusBadge status={redemption.status} />
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {hasMore && (
+        <div className="text-center pt-2">
+          <Button variant="secondary" size="sm" onClick={onLoadMore} loading={loadingMore}>
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/rewards/reward-card.tsx
+++ b/components/rewards/reward-card.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { REWARD_ICON_OPTIONS } from '@/lib/types'
+import type { Reward } from '@/lib/types'
+
+export interface RewardCardProps {
+  reward: Reward
+  userPoints: number
+  userRole: 'parent' | 'child'
+  isManageView?: boolean
+  onRedeem?: (rewardId: string) => Promise<void>
+  onEdit?: (reward: Reward) => void
+  onToggle?: (reward: Reward) => Promise<void>
+  onDelete?: (reward: Reward) => void
+}
+
+function getRewardEmoji(iconId: string): string {
+  const option = REWARD_ICON_OPTIONS.find((o) => o.id === iconId)
+  return option?.emoji ?? '🎁'
+}
+
+export function RewardCard({
+  reward,
+  userPoints,
+  userRole,
+  isManageView = false,
+  onRedeem,
+  onEdit,
+  onToggle,
+  onDelete,
+}: RewardCardProps) {
+  const [loadingAction, setLoadingAction] = useState<'redeem' | 'toggle' | null>(null)
+
+  const emoji = getRewardEmoji(reward.icon_id)
+  const canAfford = userPoints >= reward.points_cost
+  const inStock = reward.stock === null || reward.stock > 0
+
+  const handleRedeem = async () => {
+    if (!onRedeem) return
+    setLoadingAction('redeem')
+    try {
+      await onRedeem(reward.id)
+    } finally {
+      setLoadingAction(null)
+    }
+  }
+
+  const handleToggle = async () => {
+    if (!onToggle) return
+    setLoadingAction('toggle')
+    try {
+      await onToggle(reward)
+    } finally {
+      setLoadingAction(null)
+    }
+  }
+
+  const redeemLabel = !inStock
+    ? 'Out of stock'
+    : !canAfford
+      ? `Need ${reward.points_cost - userPoints} more pts`
+      : 'Redeem'
+
+  return (
+    <div
+      className={`rounded-xl bg-white shadow-sm border border-gray-100 p-4 ${
+        isManageView && !reward.active ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-3xl" role="img" aria-label={reward.icon_id}>
+          {emoji}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-semibold text-gray-900 truncate">{reward.title}</h3>
+            {isManageView && !reward.active && (
+              <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">
+                Inactive
+              </span>
+            )}
+          </div>
+          {reward.description && (
+            <p className="text-sm text-gray-600 mt-1 line-clamp-2">{reward.description}</p>
+          )}
+          <div className="flex items-center gap-2 mt-2 flex-wrap">
+            <span className="text-sm font-bold text-purple-600">{reward.points_cost} pts</span>
+            {reward.stock !== null && (
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full ${
+                  reward.stock === 0
+                    ? 'bg-red-100 text-red-600'
+                    : 'bg-green-100 text-green-600'
+                }`}
+              >
+                {reward.stock === 0 ? 'Out of stock' : `${reward.stock} left`}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {isManageView ? (
+        <div className="flex items-center gap-2 mt-3 pt-3 border-t border-gray-100">
+          <Button variant="ghost" size="sm" onClick={() => onEdit?.(reward)}>
+            Edit
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleToggle}
+            loading={loadingAction === 'toggle'}
+          >
+            {reward.active ? 'Deactivate' : 'Activate'}
+          </Button>
+          <Button variant="danger" size="sm" onClick={() => onDelete?.(reward)}>
+            Delete
+          </Button>
+        </div>
+      ) : (
+        userRole === 'child' && (
+          <div className="mt-3">
+            <Button
+              variant="primary"
+              size="sm"
+              className="w-full"
+              onClick={handleRedeem}
+              loading={loadingAction === 'redeem'}
+              disabled={!inStock || !canAfford}
+            >
+              {redeemLabel}
+            </Button>
+          </div>
+        )
+      )}
+    </div>
+  )
+}

--- a/components/rewards/reward-form.tsx
+++ b/components/rewards/reward-form.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Modal } from '@/components/ui/modal'
+import { Button } from '@/components/ui/button'
+import { REWARD_CATEGORIES, REWARD_ICON_OPTIONS } from '@/lib/types'
+import type { Reward, RewardCategory } from '@/lib/types'
+
+export interface RewardFormData {
+  title: string
+  description: string
+  points_cost: number
+  category: RewardCategory
+  icon_id: string
+  stock: number | null
+}
+
+export interface RewardFormProps {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (data: RewardFormData) => Promise<void>
+  reward?: Reward
+}
+
+export function RewardForm({ isOpen, onClose, onSubmit, reward }: RewardFormProps) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [pointsCost, setPointsCost] = useState('10')
+  const [category, setCategory] = useState<RewardCategory>('other')
+  const [iconId, setIconId] = useState('star')
+  const [stockInput, setStockInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Populate fields when editing
+  useEffect(() => {
+    if (reward) {
+      setTitle(reward.title)
+      setDescription(reward.description ?? '')
+      setPointsCost(String(reward.points_cost))
+      setCategory(reward.category as RewardCategory)
+      setIconId(reward.icon_id)
+      setStockInput(reward.stock !== null ? String(reward.stock) : '')
+    } else {
+      setTitle('')
+      setDescription('')
+      setPointsCost('10')
+      setCategory('other')
+      setIconId('star')
+      setStockInput('')
+    }
+    setError(null)
+  }, [reward, isOpen])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      setError('Title is required')
+      return
+    }
+
+    const cost = parseInt(pointsCost, 10)
+    if (isNaN(cost) || cost < 1) {
+      setError('Points cost must be at least 1')
+      return
+    }
+
+    let stock: number | null = null
+    if (stockInput.trim() !== '') {
+      const stockNum = parseInt(stockInput, 10)
+      if (isNaN(stockNum) || stockNum < 1) {
+        setError('Stock must be at least 1 if provided')
+        return
+      }
+      stock = stockNum
+    }
+
+    setLoading(true)
+    try {
+      await onSubmit({
+        title: trimmedTitle,
+        description: description.trim(),
+        points_cost: cost,
+        category,
+        icon_id: iconId,
+        stock,
+      })
+      onClose()
+    } catch {
+      setError('Something went wrong. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={reward ? 'Edit Reward' : 'New Reward'}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <p className="text-sm text-red-600 bg-red-50 p-2 rounded-lg">{error}</p>
+        )}
+
+        <div>
+          <label htmlFor="reward-title" className="block text-sm font-medium text-gray-700 mb-1">
+            Title <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="reward-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+            placeholder="e.g. Movie Night"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="reward-description" className="block text-sm font-medium text-gray-700 mb-1">
+            Description
+          </label>
+          <textarea
+            id="reward-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none"
+            placeholder="Optional details..."
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="reward-points" className="block text-sm font-medium text-gray-700 mb-1">
+              Points Cost <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="reward-points"
+              type="text"
+              inputMode="numeric"
+              value={pointsCost}
+              onChange={(e) => setPointsCost(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="reward-stock" className="block text-sm font-medium text-gray-700 mb-1">
+              Stock Limit
+            </label>
+            <input
+              id="reward-stock"
+              type="text"
+              inputMode="numeric"
+              value={stockInput}
+              onChange={(e) => setStockInput(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+              placeholder="Unlimited"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="reward-category" className="block text-sm font-medium text-gray-700 mb-1">
+            Category
+          </label>
+          <select
+            id="reward-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value as RewardCategory)}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+          >
+            {REWARD_CATEGORIES.map((cat) => (
+              <option key={cat.value} value={cat.value}>
+                {cat.emoji} {cat.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <p className="block text-sm font-medium text-gray-700 mb-2">Icon</p>
+          <div className="grid grid-cols-8 gap-1">
+            {REWARD_ICON_OPTIONS.map((icon) => (
+              <button
+                key={icon.id}
+                type="button"
+                onClick={() => setIconId(icon.id)}
+                aria-label={icon.label}
+                className={`text-xl p-1 rounded-lg transition ${
+                  iconId === icon.id
+                    ? 'ring-2 ring-purple-600 bg-purple-50'
+                    : 'hover:bg-gray-100'
+                }`}
+              >
+                {icon.emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <Button type="button" variant="secondary" size="sm" onClick={onClose} className="flex-1">
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="sm" loading={loading} className="flex-1">
+            {reward ? 'Save Changes' : 'Create Reward'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/components/rewards/reward-store.tsx
+++ b/components/rewards/reward-store.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import { RewardCard } from '@/components/rewards/reward-card'
+import { RedeemConfirmModal } from '@/components/rewards/redeem-confirm-modal'
+import { REWARD_CATEGORIES } from '@/lib/types'
+import type { Reward, RewardCategory } from '@/lib/types'
+
+export interface RewardStoreProps {
+  rewards: Reward[]
+  userPoints: number
+  userRole: 'parent' | 'child'
+  onRedeem: (rewardId: string) => Promise<void>
+}
+
+export function RewardStore({ rewards, userPoints, userRole, onRedeem }: RewardStoreProps) {
+  const [selectedCategory, setSelectedCategory] = useState<RewardCategory | 'all'>('all')
+  const [selectedReward, setSelectedReward] = useState<Reward | null>(null)
+
+  const filtered =
+    selectedCategory === 'all'
+      ? rewards
+      : rewards.filter((r) => r.category === selectedCategory)
+
+  const handleConfirmRedeem = async (): Promise<void> => {
+    await onRedeem(selectedReward!.id)
+    setSelectedReward(null)
+  }
+
+  return (
+    <div>
+      {/* Category filter chips */}
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-4">
+        <button
+          onClick={() => setSelectedCategory('all')}
+          className={`flex-shrink-0 text-sm px-3 py-1.5 rounded-full border font-medium transition ${
+            selectedCategory === 'all'
+              ? 'bg-purple-100 text-purple-700 border-purple-300'
+              : 'bg-gray-100 text-gray-600 border-gray-200 hover:bg-gray-200'
+          }`}
+        >
+          All
+        </button>
+        {REWARD_CATEGORIES.map((cat) => (
+          <button
+            key={cat.value}
+            onClick={() => setSelectedCategory(cat.value)}
+            className={`flex-shrink-0 text-sm px-3 py-1.5 rounded-full border font-medium transition ${
+              selectedCategory === cat.value
+                ? 'bg-purple-100 text-purple-700 border-purple-300'
+                : 'bg-gray-100 text-gray-600 border-gray-200 hover:bg-gray-200'
+            }`}
+          >
+            {cat.emoji} {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Reward grid */}
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <p className="text-lg">No rewards available yet.</p>
+          <p className="text-sm mt-1">Ask your parents to add some!</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {filtered.map((reward) => (
+            <RewardCard
+              key={reward.id}
+              reward={reward}
+              userPoints={userPoints}
+              userRole={userRole}
+              onRedeem={userRole === 'child' ? async () => { setSelectedReward(reward) } : undefined}
+            />
+          ))}
+        </div>
+      )}
+
+      <RedeemConfirmModal
+        isOpen={selectedReward !== null}
+        onClose={() => setSelectedReward(null)}
+        onConfirm={handleConfirmRedeem}
+        reward={selectedReward}
+        userPoints={userPoints}
+      />
+    </div>
+  )
+}

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -26,6 +26,8 @@ async function globalTeardown() {
         DELETE FROM task_completions WHERE task_id IN (SELECT id FROM tasks WHERE family_id = '${family_id}');
         DELETE FROM tasks WHERE family_id = '${family_id}';
         DELETE FROM family_invites WHERE family_id = '${family_id}';
+        DELETE FROM reward_redemptions WHERE reward_id IN (SELECT id FROM rewards WHERE family_id = '${family_id}');
+        DELETE FROM rewards WHERE family_id = '${family_id}';
       `)
     }
 

--- a/e2e/rewards-store.spec.ts
+++ b/e2e/rewards-store.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test'
+import { runSQL } from './supabase-admin'
+import { TEST_PARENT_EMAIL } from './test-constants'
+
+// Helper: get the test parent's family_id
+async function getTestFamilyId(): Promise<string | null> {
+  const rows = await runSQL(`
+    SELECT p.family_id FROM profiles p
+    JOIN auth.users u ON u.id = p.id
+    WHERE u.email = '${TEST_PARENT_EMAIL}'
+    LIMIT 1
+  `) as Array<{ family_id: string }>
+  return rows[0]?.family_id ?? null
+}
+
+// Helper: insert a test reward
+async function createTestReward(familyId: string, parentId: string, title: string, pointsCost: number): Promise<string> {
+  const rows = await runSQL(`
+    INSERT INTO rewards (family_id, title, points_cost, icon_id, category, created_by)
+    VALUES ('${familyId}', '${title}', ${pointsCost}, 'star', 'other', '${parentId}')
+    RETURNING id
+  `) as Array<{ id: string }>
+  return rows[0].id
+}
+
+// Helper: get parent profile id
+async function getParentId(): Promise<string | null> {
+  const rows = await runSQL(`
+    SELECT u.id FROM auth.users u WHERE u.email = '${TEST_PARENT_EMAIL}' LIMIT 1
+  `) as Array<{ id: string }>
+  return rows[0]?.id ?? null
+}
+
+test.describe('Rewards Store — Parent', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/rewards')
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
+  })
+
+  test('parent can navigate to Manage tab', async ({ page }) => {
+    await page.getByRole('button', { name: 'Manage' }).click()
+    await expect(page).toHaveURL(/tab=manage/)
+    await expect(page.getByRole('button', { name: /Add Reward/i })).toBeVisible()
+  })
+
+  test('parent can create a reward via form', async ({ page }) => {
+    await page.getByRole('button', { name: 'Manage' }).click()
+    await page.getByRole('button', { name: /Add Reward/i }).click()
+    await expect(page.getByText('New Reward')).toBeVisible()
+
+    await page.getByLabel(/Title/i).fill('E2E Test Reward')
+    await page.getByLabel(/Points Cost/i).fill('25')
+    await page.getByRole('button', { name: 'Create Reward' }).click()
+
+    // Reward should appear in the manage list
+    await expect(page.getByText('E2E Test Reward')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('created reward appears in store tab', async ({ page }) => {
+    // Navigate to store
+    await page.getByRole('button', { name: 'Store' }).click()
+    await expect(page).toHaveURL(/tab=store|rewards$/)
+    // The reward created in the previous test should appear (if tests run sequentially)
+    // This test just verifies the store tab is accessible and shows category filters
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
+  })
+
+  test('parent can toggle a reward inactive', async ({ page }) => {
+    // First create a reward via DB to ensure it exists
+    const familyId = await getTestFamilyId()
+    const parentId = await getParentId()
+    if (!familyId || !parentId) test.skip()
+
+    await createTestReward(familyId!, parentId!, 'Toggle Test Reward', 30)
+    await page.reload()
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
+
+    await page.getByRole('button', { name: 'Manage' }).click()
+    await page.getByRole('button', { name: 'Deactivate' }).first().click()
+
+    // After deactivation, should show Activate button
+    await expect(page.getByRole('button', { name: 'Activate' }).first()).toBeVisible({ timeout: 5000 })
+  })
+
+  test('parent can see approvals tab', async ({ page }) => {
+    await page.getByRole('button', { name: /Approvals/ }).click()
+    await expect(page).toHaveURL(/tab=approvals/)
+  })
+})
+
+test.describe('Rewards Store — Child', () => {
+  test.use({ storageState: '.auth/child.json' })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/rewards')
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
+  })
+
+  test('child sees Store and My Rewards tabs but not Manage/Approvals', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Store' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'My Rewards' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Manage' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: /Approvals/ })).not.toBeVisible()
+  })
+
+  test('child can browse the store with category filters', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Activities/i })).toBeVisible()
+  })
+
+  test('child can navigate to My Rewards tab', async ({ page }) => {
+    await page.getByRole('button', { name: 'My Rewards' }).click()
+    await expect(page).toHaveURL(/tab=my-rewards/)
+    // Either redemption history or empty state
+    const hasEmpty = await page.getByText(/No rewards redeemed yet/i).isVisible().catch(() => false)
+    const hasList = await page.locator('.bg-white.rounded-xl').first().isVisible().catch(() => false)
+    expect(hasEmpty || hasList).toBeTruthy()
+  })
+
+  test('child can redeem a reward and see pending status', async ({ page }) => {
+    // Ensure there is an active reward with enough points for the child
+    const familyId = await getTestFamilyId()
+    const parentId = await getParentId()
+    if (!familyId || !parentId) test.skip()
+
+    // Create a cheap reward
+    await createTestReward(familyId!, parentId!, 'Cheap E2E Reward', 1)
+    // Give child points
+    await runSQL(`
+      UPDATE profiles SET points = 999
+      WHERE id IN (SELECT id FROM auth.users WHERE email = 'e2e-child@chore-champions-test.local')
+    `)
+
+    await page.reload()
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
+
+    // Click Redeem on the cheap reward
+    const redeemBtn = page.getByRole('button', { name: 'Redeem' }).first()
+    await redeemBtn.click()
+
+    // Confirm redemption
+    await expect(page.getByText('Redeem Reward')).toBeVisible()
+    await page.getByRole('button', { name: 'Confirm Redemption' }).click()
+
+    // Navigate to my-rewards to see pending
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 5000 })
+    await page.getByRole('button', { name: 'My Rewards' }).click()
+    await expect(page.getByText('Waiting for approval')).toBeVisible({ timeout: 5000 })
+  })
+})
+
+test.describe('Rewards Store — Approval flow', () => {
+  test('parent can approve a pending redemption', async ({ page }) => {
+    // Ensure there's a pending redemption by checking the approvals tab
+    await page.goto('/rewards?tab=approvals')
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
+
+    // If there are pending approvals, approve the first one
+    const approveBtn = page.getByRole('button', { name: 'Approve' }).first()
+    const hasApproval = await approveBtn.isVisible().catch(() => false)
+    if (!hasApproval) {
+      // No pending approvals — empty state is fine
+      await expect(page.getByText(/No pending approvals/i)).toBeVisible()
+      return
+    }
+
+    await approveBtn.click()
+    // After approval, the item should disappear from queue
+    await expect(page.getByText('Approve')).not.toBeVisible({ timeout: 5000 })
+  })
+})

--- a/e2e/rewards.spec.ts
+++ b/e2e/rewards.spec.ts
@@ -16,80 +16,65 @@ test.describe('Rewards Page', () => {
   })
 
   test('displays podium section', async ({ page }) => {
-    // Podium should have trophy emoji for 1st place
     await expect(page.getByText('🏆')).toBeVisible()
   })
 
   test('displays 1st place with crown', async ({ page }) => {
-    // First place should have crown emoji
     await expect(page.getByText('👑')).toBeVisible()
   })
 
   test('displays medals for 2nd and 3rd place if members exist', async ({ page }) => {
-    // Check for silver medal (2nd place)
     const silverMedal = page.getByText('🥈')
     const bronzeMedal = page.getByText('🥉')
-
-    // At least one of these should be visible if there are 2+ members
     const hasSilver = await silverMedal.isVisible().catch(() => false)
     const hasBronze = await bronzeMedal.isVisible().catch(() => false)
-
-    // If family has multiple members, medals should show
-    // This is conditional based on family size
-    expect(hasSilver || hasBronze || true).toBeTruthy() // Pass if any medal or single member family
+    expect(hasSilver || hasBronze || true).toBeTruthy()
   })
 
   test('podium shows member names', async ({ page }) => {
-    // Names should be displayed under avatars
     const podiumSection = page.locator('.flex.items-end.justify-center')
     await expect(podiumSection).toBeVisible()
-
-    // Should have at least one name visible
     const names = podiumSection.locator('span.font-medium')
     await expect(names.first()).toBeVisible()
   })
 
   test('podium shows points for each member', async ({ page }) => {
-    // Points should be displayed for podium members
     await expect(page.getByText(/\d+ pts/).first()).toBeVisible()
   })
 
-  test('displays Available Rewards section', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Available Rewards' })).toBeVisible()
-  })
-
-  test('displays Coming Soon message', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Coming Soon!' })).toBeVisible()
-  })
-
-  test('displays rewards description', async ({ page }) => {
-    await expect(
-      page.getByText(/redeem your points for real rewards/i)
-    ).toBeVisible()
-  })
-
-  test('displays gift icon in rewards section', async ({ page }) => {
-    // The rewards section has a gift icon (svg)
-    const rewardsSection = page.locator('section').filter({ hasText: 'Available Rewards' })
-    const icon = rewardsSection.locator('svg')
-    await expect(icon).toBeVisible()
-  })
-
   test('first place has larger avatar', async ({ page }) => {
-    // First place avatar should be in xl size container
     const firstPlace = page.locator('.-mt-4').first()
     await expect(firstPlace).toBeVisible()
   })
 
   test('first place podium is tallest (gold background)', async ({ page }) => {
-    // First place podium has yellow/gold background
     const goldPodium = page.locator('.bg-yellow-400')
     await expect(goldPodium).toBeVisible()
   })
 
   test('page has proper spacing', async ({ page }) => {
-    // Main container should have spacing classes
     const container = page.locator('.p-4.space-y-6')
     await expect(container).toBeVisible()
+  })
+
+  test('displays points balance', async ({ page }) => {
+    await expect(page.getByText(/pts available/)).toBeVisible()
+  })
+
+  test('displays tab bar with Store tab', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Store' })).toBeVisible()
+  })
+
+  test('displays My Rewards tab', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'My Rewards' })).toBeVisible()
+  })
+
+  test('shows store content by default (category filters)', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
+  })
+
+  test('can navigate to My Rewards tab', async ({ page }) => {
+    await page.getByRole('button', { name: 'My Rewards' }).click()
+    await expect(page).toHaveURL(/tab=my-rewards/)
   })
 })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -548,6 +548,24 @@ export const REWARD_ICON_OPTIONS = [
   { id: 'rocket', label: 'Rocket', emoji: '🚀' },
 ] as const
 
+// Default rewards seeded for new families — parents can edit or delete these
+export const DEFAULT_REWARDS: readonly {
+  title: string
+  description: string
+  points_cost: number
+  icon_id: string
+  category: RewardCategory
+}[] = [
+  { title: '30 Min Screen Time', description: 'Enjoy 30 minutes of your favorite show or game', points_cost: 50, icon_id: 'game', category: 'screen_time' },
+  { title: 'Pick Dinner', description: 'You choose what the family eats tonight', points_cost: 100, icon_id: 'pizza', category: 'privileges' },
+  { title: 'Stay Up 30 Min Late', description: 'Push bedtime back by 30 minutes', points_cost: 75, icon_id: 'star', category: 'privileges' },
+  { title: 'Ice Cream Treat', description: 'A scoop of your favorite flavor', points_cost: 60, icon_id: 'ice_cream', category: 'treats' },
+  { title: 'Movie Night Pick', description: 'Pick the movie for family movie night', points_cost: 80, icon_id: 'movie', category: 'activities' },
+  { title: 'Park Trip', description: 'A trip to your favorite park', points_cost: 150, icon_id: 'park', category: 'activities' },
+  { title: 'New Book', description: 'Pick out a new book to read', points_cost: 200, icon_id: 'book', category: 'treats' },
+  { title: 'Sleepover with Friend', description: 'Have a friend over for the night', points_cost: 300, icon_id: 'sleepover', category: 'activities' },
+] as const
+
 // Avatar options
 export const AVATAR_OPTIONS = [
   { id: 'panther', name: 'Panther', url: '/avatars/panther.svg' },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -156,6 +156,82 @@ export type Database = {
           responded_at?: string | null
         }
       }
+      rewards: {
+        Row: {
+          id: string
+          family_id: string
+          title: string
+          description: string | null
+          points_cost: number
+          icon_id: string
+          category: string
+          stock: number | null
+          active: boolean
+          created_by: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          family_id: string
+          title: string
+          description?: string | null
+          points_cost: number
+          icon_id?: string
+          category?: string
+          stock?: number | null
+          active?: boolean
+          created_by: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          family_id?: string
+          title?: string
+          description?: string | null
+          points_cost?: number
+          icon_id?: string
+          category?: string
+          stock?: number | null
+          active?: boolean
+          created_by?: string
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      reward_redemptions: {
+        Row: {
+          id: string
+          reward_id: string
+          redeemed_by: string
+          points_cost: number
+          status: 'pending' | 'approved' | 'rejected'
+          redeemed_at: string
+          resolved_at: string | null
+          resolved_by: string | null
+        }
+        Insert: {
+          id?: string
+          reward_id: string
+          redeemed_by: string
+          points_cost: number
+          status?: string
+          redeemed_at?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+        }
+        Update: {
+          id?: string
+          reward_id?: string
+          redeemed_by?: string
+          points_cost?: number
+          status?: string
+          redeemed_at?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+        }
+      }
     }
     Functions: {
       find_user_by_email: {
@@ -198,6 +274,14 @@ export type Database = {
       get_family_analytics: {
         Args: { p_family_id: string; p_weeks?: number }
         Returns: FamilyAnalytics
+      }
+      redeem_reward: {
+        Args: { p_user_id: string; p_reward_id: string }
+        Returns: { success: boolean; error?: string; points_spent?: number }
+      }
+      resolve_redemption: {
+        Args: { p_user_id: string; p_redemption_id: string; p_action: string }
+        Returns: { success: boolean; error?: string }
       }
     }
   }
@@ -425,6 +509,44 @@ export type ErrorListResult = {
   page: number
   total_pages: number
 }
+
+// Reward types
+export type Reward = Database['public']['Tables']['rewards']['Row']
+export type RewardRedemption = Database['public']['Tables']['reward_redemptions']['Row']
+
+export type RewardRedemptionWithDetails = RewardRedemption & {
+  rewards: Pick<Reward, 'title' | 'icon_id'>
+  profiles?: Pick<Profile, 'display_name' | 'nickname' | 'avatar_url'>
+}
+
+export type RewardCategory = 'screen_time' | 'treats' | 'activities' | 'privileges' | 'other'
+
+export const REWARD_CATEGORIES: readonly { value: RewardCategory; label: string; emoji: string }[] = [
+  { value: 'activities', label: 'Activities', emoji: '🎯' },
+  { value: 'treats', label: 'Treats', emoji: '🍪' },
+  { value: 'screen_time', label: 'Screen Time', emoji: '📱' },
+  { value: 'privileges', label: 'Privileges', emoji: '⭐' },
+  { value: 'other', label: 'Other', emoji: '🎁' },
+] as const
+
+export const REWARD_ICON_OPTIONS = [
+  { id: 'star', label: 'Star', emoji: '⭐' },
+  { id: 'trophy', label: 'Trophy', emoji: '🏆' },
+  { id: 'game', label: 'Game', emoji: '🎮' },
+  { id: 'movie', label: 'Movie', emoji: '🎬' },
+  { id: 'ice_cream', label: 'Ice Cream', emoji: '🍦' },
+  { id: 'pizza', label: 'Pizza', emoji: '🍕' },
+  { id: 'cookie', label: 'Cookie', emoji: '🍪' },
+  { id: 'bike', label: 'Bike Ride', emoji: '🚲' },
+  { id: 'park', label: 'Park', emoji: '🏞️' },
+  { id: 'sleepover', label: 'Sleepover', emoji: '🛏️' },
+  { id: 'book', label: 'Book', emoji: '📚' },
+  { id: 'music', label: 'Music', emoji: '🎵' },
+  { id: 'art', label: 'Art', emoji: '🎨' },
+  { id: 'gift', label: 'Gift', emoji: '🎁' },
+  { id: 'crown', label: 'Crown', emoji: '👑' },
+  { id: 'rocket', label: 'Rocket', emoji: '🚀' },
+] as const
 
 // Avatar options
 export const AVATAR_OPTIONS = [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         storageState: '.auth/parent.json',
       },
       dependencies: ['setup'],
-      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts|streaks\.spec\.ts|analytics\.spec\.ts/,
+      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|rewards-store\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts|streaks\.spec\.ts|analytics\.spec\.ts/,
     },
     // Destructive parent tests (sign-out) that invalidate the session - run last
     {

--- a/supabase/migrations/015_add_rewards_tables.sql
+++ b/supabase/migrations/015_add_rewards_tables.sql
@@ -1,0 +1,244 @@
+-- ============================================================
+-- 015: Rewards Store Tables, RLS, RPCs
+-- ============================================================
+
+-- rewards table
+CREATE TABLE rewards (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_id uuid NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  title text NOT NULL CHECK (char_length(title) <= 200),
+  description text,
+  points_cost integer NOT NULL CHECK (points_cost >= 1),
+  icon_id text NOT NULL DEFAULT 'star',
+  category text NOT NULL DEFAULT 'other',
+  stock integer CHECK (stock IS NULL OR stock >= 1),
+  active boolean NOT NULL DEFAULT true,
+  created_by uuid NOT NULL REFERENCES profiles(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- reward_redemptions table
+CREATE TABLE reward_redemptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  reward_id uuid NOT NULL REFERENCES rewards(id) ON DELETE RESTRICT,
+  redeemed_by uuid NOT NULL REFERENCES profiles(id),
+  points_cost integer NOT NULL,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+  redeemed_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz,
+  resolved_by uuid REFERENCES profiles(id)
+);
+
+-- Indexes
+CREATE INDEX idx_rewards_family_active ON rewards(family_id, active) WHERE active = true;
+CREATE INDEX idx_rewards_family_id ON rewards(family_id);
+CREATE INDEX idx_redemptions_redeemed_by_status ON reward_redemptions(redeemed_by, status);
+CREATE INDEX idx_redemptions_status ON reward_redemptions(status) WHERE status = 'pending';
+CREATE INDEX idx_redemptions_reward_id ON reward_redemptions(reward_id);
+
+-- updated_at trigger for rewards
+CREATE OR REPLACE FUNCTION set_rewards_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER rewards_updated_at
+  BEFORE UPDATE ON rewards
+  FOR EACH ROW EXECUTE FUNCTION set_rewards_updated_at();
+
+-- ============================================================
+-- RLS: rewards
+-- ============================================================
+ALTER TABLE rewards ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "family_members_select_rewards" ON rewards FOR SELECT
+  USING (family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid()));
+
+CREATE POLICY "parents_insert_rewards" ON rewards FOR INSERT
+  WITH CHECK (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND (SELECT role FROM profiles WHERE id = auth.uid()) = 'parent'
+  );
+
+CREATE POLICY "parents_update_rewards" ON rewards FOR UPDATE
+  USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND (SELECT role FROM profiles WHERE id = auth.uid()) = 'parent'
+  );
+
+-- No DELETE: rewards are deactivated, not deleted. Preserves redemption history.
+-- Explicit deny makes intent clear (not a forgotten policy).
+CREATE POLICY "no_delete_rewards" ON rewards FOR DELETE USING (false);
+
+-- ============================================================
+-- RLS: reward_redemptions
+-- ============================================================
+ALTER TABLE reward_redemptions ENABLE ROW LEVEL SECURITY;
+
+-- Users see their own redemptions; parents see all family redemptions
+CREATE POLICY "own_or_family_parent_select_redemptions" ON reward_redemptions FOR SELECT
+  USING (
+    redeemed_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM profiles p
+      JOIN rewards r ON r.family_id = p.family_id
+      WHERE p.id = auth.uid() AND p.role = 'parent' AND r.id = reward_redemptions.reward_id
+    )
+  );
+
+-- No direct INSERT/UPDATE/DELETE — handled by SECURITY DEFINER RPCs
+CREATE POLICY "no_insert_redemptions" ON reward_redemptions FOR INSERT WITH CHECK (false);
+CREATE POLICY "no_update_redemptions" ON reward_redemptions FOR UPDATE USING (false);
+CREATE POLICY "no_delete_redemptions" ON reward_redemptions FOR DELETE USING (false);
+
+-- ============================================================
+-- RPC: redeem_reward
+-- ============================================================
+CREATE OR REPLACE FUNCTION redeem_reward(p_user_id uuid, p_reward_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_reward rewards%ROWTYPE;
+  v_rows_affected int;
+  v_cost int;
+BEGIN
+  -- Auth: caller must be the authenticated user
+  IF p_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- Fetch reward
+  SELECT * INTO v_reward FROM rewards WHERE id = p_reward_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Reward not found');
+  END IF;
+
+  IF NOT v_reward.active THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Reward is no longer available');
+  END IF;
+
+  -- Auth: must be a child in the same family as the reward
+  IF NOT EXISTS (
+    SELECT 1 FROM profiles
+    WHERE id = p_user_id AND family_id = v_reward.family_id AND role = 'child'
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  v_cost := v_reward.points_cost;
+
+  -- Check and decrement stock atomically (if limited)
+  IF v_reward.stock IS NOT NULL THEN
+    UPDATE rewards SET stock = stock - 1
+    WHERE id = p_reward_id AND stock > 0;
+
+    GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+    IF v_rows_affected = 0 THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Out of stock');
+    END IF;
+  END IF;
+
+  -- Atomic point deduction (only succeeds if user has enough)
+  UPDATE profiles SET points = points - v_cost
+  WHERE id = p_user_id AND points >= v_cost;
+
+  GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+  IF v_rows_affected = 0 THEN
+    -- Explicit rollback: undo stock decrement
+    -- NOTE: A normal RETURN does NOT rollback prior writes in PL/pgSQL.
+    -- Only RAISE EXCEPTION triggers automatic rollback. We must undo manually.
+    IF v_reward.stock IS NOT NULL THEN
+      UPDATE rewards SET stock = stock + 1 WHERE id = p_reward_id;
+    END IF;
+    RETURN jsonb_build_object('success', false, 'error',
+      'Not enough points (need ' || v_cost || ')');
+  END IF;
+
+  -- Create redemption record with cost snapshot
+  INSERT INTO reward_redemptions (reward_id, redeemed_by, status, points_cost)
+  VALUES (p_reward_id, p_user_id, 'pending', v_cost);
+
+  RETURN jsonb_build_object('success', true, 'points_spent', v_cost);
+
+EXCEPTION WHEN OTHERS THEN
+  -- Unhandled exception: PG auto-rolls back all writes in this transaction.
+  -- Return structured error to honour the client contract.
+  RETURN jsonb_build_object('success', false, 'error', 'Unexpected error. Please try again.');
+END;
+$$;
+
+-- ============================================================
+-- RPC: resolve_redemption (approve or reject)
+-- ============================================================
+CREATE OR REPLACE FUNCTION resolve_redemption(
+  p_user_id uuid,
+  p_redemption_id uuid,
+  p_action text
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_redemption reward_redemptions%ROWTYPE;
+  v_reward rewards%ROWTYPE;
+  v_rows_affected int;
+BEGIN
+  -- Auth: caller must be the authenticated user
+  IF p_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- Validate action
+  IF p_action NOT IN ('approved', 'rejected') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid action');
+  END IF;
+
+  -- Fetch redemption
+  SELECT * INTO v_redemption FROM reward_redemptions WHERE id = p_redemption_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Redemption not found');
+  END IF;
+
+  IF v_redemption.status != 'pending' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Already resolved');
+  END IF;
+
+  -- Fetch reward for family check
+  SELECT * INTO v_reward FROM rewards WHERE id = v_redemption.reward_id;
+
+  -- Auth: must be parent in same family
+  IF NOT EXISTS (
+    SELECT 1 FROM profiles
+    WHERE id = p_user_id AND family_id = v_reward.family_id AND role = 'parent'
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- Update redemption status (WHERE status = 'pending' prevents double-resolution)
+  UPDATE reward_redemptions
+  SET status = p_action, resolved_at = now(), resolved_by = p_user_id
+  WHERE id = p_redemption_id AND status = 'pending';
+
+  GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+  IF v_rows_affected = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Already resolved');
+  END IF;
+
+  -- On rejection: refund points (using snapshot cost) and restore stock
+  IF p_action = 'rejected' THEN
+    UPDATE profiles SET points = points + v_redemption.points_cost
+    WHERE id = v_redemption.redeemed_by;
+
+    IF v_reward.stock IS NOT NULL THEN
+      UPDATE rewards SET stock = stock + 1 WHERE id = v_reward.id;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object('success', true);
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', 'Unexpected error. Please try again.');
+END;
+$$;


### PR DESCRIPTION
## Summary
- Parents can create, edit, activate/deactivate custom rewards with point costs, categories, icons, and optional stock limits
- Kids browse active rewards and redeem them with atomic point deduction via `redeem_reward` RPC (no double-spending or negative balances)
- Parents approve or reject pending redemptions via `resolve_redemption` RPC; rejections automatically refund the snapshotted point cost

## Test plan
- [ ] Unit tests pass (`npm test`)
- [ ] DB integration tests pass (`npm run test:db`)
- [ ] E2E tests pass (`npm run test:e2e`)
- [ ] Smoke tests pass (`npm run pw:smoke`)
- [ ] Visual tests pass (`npm run pw:visual`)

Closes #41
Closes #42