### PR TITLE
feat: AI Parenting Assistant and Quest Buddy chat (#66, #68)

### DIFF
--- a/__tests__/api/ai/chat-conversation-by-id.test.ts
+++ b/__tests__/api/ai/chat-conversation-by-id.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+import { GET } from '@/app/api/ai/chat/conversations/[id]/route'
+import { NextRequest } from 'next/server'
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+function makeChain(data: unknown, error: unknown = null) {
+  const result = { data, error: error ?? null }
+  const chain: Record<string, unknown> = {
+    then: (res: (v: unknown) => void, rej?: (e: unknown) => void) =>
+      Promise.resolve(result).then(res, rej),
+    select: () => chain,
+    eq: () => chain,
+    single: () => Promise.resolve(result),
+  }
+  return chain
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/ai/chat/conversations/conv-1')
+}
+
+const context = { params: { id: 'conv-1' } }
+
+describe('GET /api/ai/chat/conversations/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await GET(makeRequest(), context)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when profile is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(null))
+    const res = await GET(makeRequest(), context)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when user is not a parent', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain({ role: 'child' }))
+    const res = await GET(makeRequest(), context)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 404 when conversation not found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ role: 'parent' })
+      return makeChain(null, { message: 'Not found' })
+    })
+    const res = await GET(makeRequest(), context)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns conversation data when found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const conv = { id: 'conv-1', messages: [], title: 'Test', family_id: 'fam-1' }
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ role: 'parent' })
+      return makeChain(conv)
+    })
+    const res = await GET(makeRequest(), context)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toMatchObject({ id: 'conv-1' })
+  })
+})

--- a/__tests__/api/ai/chat-conversations.test.ts
+++ b/__tests__/api/ai/chat-conversations.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+import { GET } from '@/app/api/ai/chat/conversations/route'
+import { NextRequest } from 'next/server'
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+/** Makes a Supabase query chain that is thenable and supports .single() */
+function makeChain(data: unknown, error: unknown = null) {
+  const result = { data, error: error ?? null }
+  const chain: Record<string, unknown> = {
+    then: (res: (v: unknown) => void, rej?: (e: unknown) => void) =>
+      Promise.resolve(result).then(res, rej),
+    select: () => chain,
+    eq: () => chain,
+    lt: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    single: () => Promise.resolve(result),
+  }
+  return chain
+}
+
+function makeRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/ai/chat/conversations')
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v)
+    }
+  }
+  return new NextRequest(url.toString())
+}
+
+describe('GET /api/ai/chat/conversations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+    const data = await res.json()
+    expect(data.error).toBe('Unauthorized')
+  })
+
+  it('returns 403 when profile is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(null))
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when user is not a parent', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain({ family_id: 'fam-1', role: 'child' }))
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 500 when database query errors', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(null, { message: 'DB error' })
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+  })
+
+  it('returns conversations list with messageCount from array', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const conversations = [
+      { id: 'c-1', title: 'Chat 1', updated_at: '2024-01-15T10:00:00Z', messages: ['a', 'b', 'c'] },
+      { id: 'c-2', title: null, updated_at: '2024-01-14T10:00:00Z', messages: 'not-array' },
+    ]
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(conversations)
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(2)
+    expect(body.data[0].messageCount).toBe(3)
+    expect(body.data[1].messageCount).toBe(0) // non-array messages → 0
+    expect(body.nextCursor).toBeNull()
+  })
+
+  it('returns nextCursor when there are more items', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    // Return limit+1 items (21 with default limit=20)
+    const conversations = Array.from({ length: 21 }, (_, i) => ({
+      id: `c-${i}`,
+      title: `Chat ${i}`,
+      updated_at: `2024-01-${String(15 - i).padStart(2, '0')}T10:00:00Z`,
+      messages: [],
+    }))
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(conversations)
+    })
+    const res = await GET(makeRequest())
+    const body = await res.json()
+    expect(body.data).toHaveLength(20) // sliced to limit
+    expect(body.nextCursor).not.toBeNull()
+  })
+
+  it('applies cursor filter when cursor param is provided', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain([])
+    })
+    const res = await GET(makeRequest({ cursor: '2024-01-10T00:00:00Z' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('handles null data from query (uses empty array fallback)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(null) // null data, no error → data ?? [] = []
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual([])
+    expect(body.nextCursor).toBeNull()
+  })
+})

--- a/__tests__/api/ai/chat.test.ts
+++ b/__tests__/api/ai/chat.test.ts
@@ -1,0 +1,388 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+jest.mock('@/lib/observability/event-tracker', () => ({
+  trackEvent: jest.fn(),
+}))
+
+import { POST, maxDuration } from '@/app/api/ai/chat/route'
+import { NextRequest } from 'next/server'
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+const mockRpc = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+      rpc: (...args: unknown[]) => mockRpc(...args),
+    }),
+}))
+
+const originalFetch = global.fetch
+
+/** Fluent Supabase query chain mock that is thenable */
+function makeChain(data: unknown, error: unknown = null) {
+  const result = { data, error: error ?? null }
+  const chain: Record<string, unknown> = {
+    then: (res: (v: unknown) => void, rej?: (e: unknown) => void) =>
+      Promise.resolve(result).then(res, rej),
+    select: () => chain,
+    eq: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    insert: () => chain,
+    update: () => chain,
+    single: () => Promise.resolve(result),
+  }
+  return chain
+}
+
+/** Create a streaming Anthropic-style SSE response */
+function makeAnthropicStreamResponse(text: string): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Include a non-text-delta event to cover the "false" branch of the inner if
+      controller.enqueue(encoder.encode('data: {"type":"message_start","message":{"id":"msg_01"}}\n\n'))
+      controller.enqueue(
+        encoder.encode(
+          `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"${text}"}}\n\n`
+        )
+      )
+      controller.close()
+    },
+  })
+  return { ok: true, body: stream } as unknown as Response
+}
+
+/** Consume a Response ReadableStream to a string */
+async function consumeStream(response: Response): Promise<string> {
+  if (!response.body) return ''
+  const reader = (response.body as ReadableStream<Uint8Array>).getReader()
+  const decoder = new TextDecoder()
+  let result = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value)
+  }
+  return result
+}
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/ai/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const MOCK_PROFILE = { family_id: 'fam-1', role: 'parent', display_name: 'Test Parent' }
+const MOCK_CONV = {
+  id: 'conv-1',
+  family_id: 'fam-1',
+  parent_id: 'user-1',
+  messages: [],
+  title: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+describe('POST /api/ai/chat', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  it('exports maxDuration of 60', () => {
+    expect(maxDuration).toBe(60)
+  })
+
+  it('returns 401 when no authenticated user', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with null data when no API key', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeNull()
+  })
+
+  it('returns 403 when profile is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(null))
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when user is not a parent', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain({ family_id: 'fam-1', role: 'child', display_name: 'Kid' }))
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 when profile has no family_id', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain({ family_id: null, role: 'parent', display_name: 'Parent' }))
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 on invalid JSON body', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_PROFILE))
+    const req = new NextRequest('http://localhost:3000/api/ai/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json!!!',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Invalid JSON')
+  })
+
+  it('returns 400 when message is empty', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_PROFILE))
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    const res = await POST(makeRequest({ message: '' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when message body value is not a string', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_PROFILE))
+    const res = await POST(makeRequest({ message: 42 })) // number, not string
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when message exceeds 2000 characters', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_PROFILE))
+    const res = await POST(makeRequest({ message: 'a'.repeat(2001) }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 429 with user limit message', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_PROFILE))
+    mockRpc.mockResolvedValue({ data: { allowed: false, reason: 'user_limit' } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toMatch(/personal message limit/)
+  })
+
+  it('returns 429 with family limit message', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_PROFILE))
+    mockRpc.mockResolvedValue({ data: { allowed: false, reason: 'family_limit' } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toMatch(/family has reached/)
+  })
+
+  it('returns 404 when specified conversation not found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain(MOCK_PROFILE)
+      return makeChain(null) // conversation not found
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    const res = await POST(makeRequest({ message: 'Hello', conversationId: 'missing-id' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 500 when conversation creation fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain(MOCK_PROFILE)
+      return makeChain(null, { message: 'Insert failed' }) // insert fails
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 503 when Anthropic API fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let profilesCallCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profilesCallCount++
+        if (profilesCallCount === 1) return makeChain(MOCK_PROFILE)
+        return makeChain([]) // children
+      }
+      if (table === 'ai_conversations') return makeChain(MOCK_CONV)
+      if (table === 'families') return makeChain({ name: 'Smith Family' })
+      if (table === 'tasks') return makeChain([])
+      return makeChain(null)
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(503)
+  })
+
+  it('streams response for new conversation with short message (auto-titles, children/tasks null)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let profilesCallCount = 0
+    let convCallCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profilesCallCount++
+        if (profilesCallCount === 1) return makeChain(MOCK_PROFILE)
+        return makeChain(null) // children: null → []
+      }
+      if (table === 'ai_conversations') {
+        convCallCount++
+        if (convCallCount === 1) return makeChain(MOCK_CONV) // insert
+        return makeChain(null) // update title
+      }
+      if (table === 'families') return makeChain(null) // no family → 'your family'
+      if (table === 'tasks') return makeChain(null) // tasks: null → []
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Hello!'))
+
+    const res = await POST(makeRequest({ message: 'Hi there' }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('conversation_meta')
+    expect(content).toContain('conv-1')
+  })
+
+  it('streams response for new conversation with long message (title truncated)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let profilesCallCount = 0
+    let convCallCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profilesCallCount++
+        if (profilesCallCount === 1) return makeChain(MOCK_PROFILE)
+        return makeChain([{ display_name: 'Kid', points: 50 }])
+      }
+      if (table === 'ai_conversations') {
+        convCallCount++
+        if (convCallCount === 1) return makeChain(MOCK_CONV)
+        return makeChain(null)
+      }
+      if (table === 'families') return makeChain({ name: 'Smith Family' })
+      if (table === 'tasks') return makeChain([
+        { title: 'Clean', assigned_to: 'child-1', points: 10, completed: false }, // assigned_to non-null
+        { title: 'Other', assigned_to: null, points: 5, completed: null }, // assigned_to null, completed null
+      ])
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Got it!'))
+
+    const longMessage = 'a'.repeat(65) // > 60 chars
+    const res = await POST(makeRequest({ message: longMessage }))
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('conversation_meta')
+  })
+
+  it('streams response for existing conversation with title (no title update)', async () => {
+    const existingConv = { ...MOCK_CONV, id: 'existing-id', messages: [{ role: 'user', content: 'prev', timestamp: '2024-01-01T00:00:00Z' }], title: 'Existing Title' }
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let profilesCallCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profilesCallCount++
+        if (profilesCallCount === 1) return makeChain(MOCK_PROFILE)
+        return makeChain([])
+      }
+      if (table === 'ai_conversations') return makeChain(existingConv)
+      if (table === 'families') return makeChain({ name: 'Smith Family' })
+      if (table === 'tasks') return makeChain([])
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Reply!'))
+
+    const res = await POST(makeRequest({ message: 'Continue', conversationId: 'existing-id' }))
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('conversation_meta')
+  })
+
+  it('streams response when conversation message limit is reached (skip save)', async () => {
+    // 100 messages = CONVERSATION_MESSAGE_LIMIT
+    const fullConv = {
+      ...MOCK_CONV,
+      id: 'full-id',
+      messages: Array.from({ length: 100 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `msg ${i}`,
+        timestamp: '2024-01-01T00:00:00Z',
+      })),
+      title: null,
+    }
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let profilesCallCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profilesCallCount++
+        if (profilesCallCount === 1) return makeChain(MOCK_PROFILE)
+        return makeChain([])
+      }
+      if (table === 'ai_conversations') return makeChain(fullConv)
+      if (table === 'families') return makeChain({ name: 'Smith Family' })
+      if (table === 'tasks') return makeChain([])
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Final reply!'))
+
+    const res = await POST(makeRequest({ message: 'Last message', conversationId: 'full-id' }))
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('limitReached":true')
+  })
+})

--- a/__tests__/api/ai/quest-buddy-history.test.ts
+++ b/__tests__/api/ai/quest-buddy-history.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+import { GET } from '@/app/api/ai/quest-buddy/history/route'
+import { NextRequest } from 'next/server'
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+function makeChain(data: unknown, error: unknown = null) {
+  const result = { data, error: error ?? null }
+  const chain: Record<string, unknown> = {
+    then: (res: (v: unknown) => void, rej?: (e: unknown) => void) =>
+      Promise.resolve(result).then(res, rej),
+    select: () => chain,
+    eq: () => chain,
+    lt: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    single: () => Promise.resolve(result),
+  }
+  return chain
+}
+
+function makeRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/ai/quest-buddy/history')
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v)
+    }
+  }
+  return new NextRequest(url.toString())
+}
+
+describe('GET /api/ai/quest-buddy/history', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when profile is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(null))
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when user is not a parent', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain({ family_id: 'fam-1', role: 'child' }))
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 500 when database query errors', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(null, { message: 'DB error' })
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+  })
+
+  it('returns kid chats with messageCount and childName', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const chats = [
+      {
+        id: 'chat-1',
+        child_id: 'child-1',
+        messages: ['a', 'b'],
+        created_at: '2024-01-15T10:00:00Z',
+        profiles: { display_name: 'Timmy' },
+      },
+      {
+        id: 'chat-2',
+        child_id: 'child-2',
+        messages: 'not-array',
+        created_at: '2024-01-14T10:00:00Z',
+        profiles: null,
+      },
+    ]
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(chats)
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(2)
+    expect(body.data[0].messageCount).toBe(2)
+    expect(body.data[0].childName).toBe('Timmy')
+    expect(body.data[1].messageCount).toBe(0) // non-array
+    expect(body.data[1].childName).toBe('Unknown') // null profile
+    expect(body.nextCursor).toBeNull()
+  })
+
+  it('applies childId filter when provided', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain([])
+    })
+    const res = await GET(makeRequest({ childId: 'child-1' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('applies cursor filter when provided', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain([])
+    })
+    const res = await GET(makeRequest({ cursor: '2024-01-10T00:00:00Z' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('handles null data from query (uses empty array fallback)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(null) // null data, no error
+    })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual([])
+    expect(body.nextCursor).toBeNull()
+  })
+
+  it('returns nextCursor when there are more items than the limit', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const chats = Array.from({ length: 21 }, (_, i) => ({
+      id: `chat-${i}`,
+      child_id: 'child-1',
+      messages: [],
+      created_at: `2024-01-${String(15 - i).padStart(2, '0')}T10:00:00Z`,
+      profiles: { display_name: 'Kid' },
+    }))
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain({ family_id: 'fam-1', role: 'parent' })
+      return makeChain(chats)
+    })
+    const res = await GET(makeRequest())
+    const body = await res.json()
+    expect(body.data).toHaveLength(20)
+    expect(body.nextCursor).not.toBeNull()
+  })
+})

--- a/__tests__/api/ai/quest-buddy.test.ts
+++ b/__tests__/api/ai/quest-buddy.test.ts
@@ -1,0 +1,356 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+jest.mock('@/lib/observability/event-tracker', () => ({
+  trackEvent: jest.fn(),
+}))
+
+import { POST, maxDuration } from '@/app/api/ai/quest-buddy/route'
+import { NextRequest } from 'next/server'
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+const mockRpc = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+      rpc: (...args: unknown[]) => mockRpc(...args),
+    }),
+}))
+
+const originalFetch = global.fetch
+
+function makeChain(data: unknown, error: unknown = null) {
+  const result = { data, error: error ?? null }
+  const chain: Record<string, unknown> = {
+    then: (res: (v: unknown) => void, rej?: (e: unknown) => void) =>
+      Promise.resolve(result).then(res, rej),
+    select: () => chain,
+    eq: () => chain,
+    gte: () => chain,
+    lte: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    insert: () => chain,
+    single: () => Promise.resolve(result),
+  }
+  return chain
+}
+
+function makeAnthropicStreamResponse(text: string): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Include a non-text-delta event to cover the "false" branch of the inner if
+      controller.enqueue(encoder.encode('data: {"type":"message_start","message":{"id":"msg_01"}}\n\n'))
+      controller.enqueue(
+        encoder.encode(
+          `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"${text}"}}\n\n`
+        )
+      )
+      controller.close()
+    },
+  })
+  return { ok: true, body: stream } as unknown as Response
+}
+
+async function consumeStream(response: Response): Promise<string> {
+  if (!response.body) return ''
+  const reader = (response.body as ReadableStream<Uint8Array>).getReader()
+  const decoder = new TextDecoder()
+  let result = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value)
+  }
+  return result
+}
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/ai/quest-buddy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const MOCK_KID_PROFILE = {
+  family_id: 'fam-1',
+  role: 'child',
+  display_name: 'Timmy',
+  points: 50,
+}
+
+const MOCK_CHAT = {
+  id: 'chat-1',
+  child_id: 'user-1',
+  family_id: 'fam-1',
+  messages: [],
+  created_at: '2024-01-01T00:00:00Z',
+}
+
+describe('POST /api/ai/quest-buddy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.ANTHROPIC_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  it('exports maxDuration of 60', () => {
+    expect(maxDuration).toBe(60)
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 with null data when no API key', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeNull()
+  })
+
+  it('returns 400 when profile not found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(null))
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when profile has no family_id', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain({ family_id: null, role: 'child', display_name: 'Kid', points: 10 }))
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 on invalid JSON body', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_KID_PROFILE))
+    const req = new NextRequest('http://localhost:3000/api/ai/quest-buddy', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json!!!',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Invalid JSON')
+  })
+
+  it('returns 400 when message is empty', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_KID_PROFILE))
+    const res = await POST(makeRequest({ message: '' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when message body value is not a string', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_KID_PROFILE))
+    const res = await POST(makeRequest({ message: 42 })) // number, not string
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when message exceeds 500 characters', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_KID_PROFILE))
+    const res = await POST(makeRequest({ message: 'a'.repeat(501) }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 429 with user limit message', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_KID_PROFILE))
+    mockRpc.mockResolvedValue({ data: { allowed: false, reason: 'user_limit' } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toMatch(/message limit/)
+  })
+
+  it('returns 429 with family limit message', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue(makeChain(MOCK_KID_PROFILE))
+    mockRpc.mockResolvedValue({ data: { allowed: false, reason: 'family_limit' } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toMatch(/family has reached/)
+  })
+
+  it('returns 404 when specified chatId not found', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain(MOCK_KID_PROFILE)
+      return makeChain(null) // chat not found
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    const res = await POST(makeRequest({ message: 'Hello', chatId: 'missing-id' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 429 when chat session limit reached', async () => {
+    // KID_SESSION_MESSAGE_LIMIT = 20
+    const fullChat = {
+      ...MOCK_CHAT,
+      messages: Array.from({ length: 20 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `msg ${i}`,
+        timestamp: '2024-01-01T00:00:00Z',
+      })),
+    }
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain(MOCK_KID_PROFILE)
+      return makeChain(fullChat)
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    const res = await POST(makeRequest({ message: 'Hello', chatId: 'full-chat' }))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.reason).toBe('session_limit')
+  })
+
+  it('returns 500 when chat creation fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) return makeChain(MOCK_KID_PROFILE)
+      return makeChain(null, { message: 'Insert failed' })
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 503 when Anthropic API fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') return makeChain(MOCK_KID_PROFILE)
+      if (table === 'ai_kid_chats') return makeChain(MOCK_CHAT)
+      if (table === 'tasks') return makeChain([])
+      if (table === 'task_completions') return makeChain([])
+      return makeChain(null)
+    })
+    mockRpc.mockResolvedValue({ data: { allowed: true, reason: null } })
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null })
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(503)
+  })
+
+  it('streams response for kid new chat session (creates chat, saves messages)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        callCount++
+        return makeChain(MOCK_KID_PROFILE)
+      }
+      if (table === 'ai_kid_chats') return makeChain(MOCK_CHAT) // insert
+      if (table === 'tasks') return makeChain([{ title: 'Clean room', points: 10 }])
+      if (table === 'task_completions') return makeChain([
+        { points_earned: 15, completion_date: '2024-01-14' },
+        { points_earned: 10, completion_date: null }, // null date → uses today
+      ])
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Great job!'))
+
+    const res = await POST(makeRequest({ message: 'Hello' }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('chat_meta')
+    expect(content).toContain('chat-1')
+  })
+
+  it('streams response for parent preview mode (does not persist chat)', async () => {
+    const parentProfile = { ...MOCK_KID_PROFILE, role: 'parent' }
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'parent-1' } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') return makeChain(parentProfile)
+      if (table === 'tasks') return makeChain(null) // null → covers pendingTasks ?? []
+      if (table === 'task_completions') return makeChain(null) // null → covers recentCompletions ?? []
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Parent preview!'))
+
+    const res = await POST(makeRequest({ message: 'Test message' }))
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('chat_meta')
+    // Parent preview: chatId should be null
+    expect(content).toContain('"chatId":null')
+  })
+
+  it('streams response for kid with existing chat and limitReached', async () => {
+    // KID_SESSION_MESSAGE_LIMIT = 20; start with 18 messages → after adding 2 = 20 → limitReached
+    const nearLimitChat = {
+      ...MOCK_CHAT,
+      id: 'near-limit',
+      messages: Array.from({ length: 18 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `msg ${i}`,
+        timestamp: '2024-01-01T00:00:00Z',
+      })),
+    }
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    let callCount = 0
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        callCount++
+        return makeChain(MOCK_KID_PROFILE)
+      }
+      if (table === 'ai_kid_chats') return makeChain(nearLimitChat)
+      if (table === 'tasks') return makeChain([])
+      if (table === 'task_completions') return makeChain([])
+      return makeChain(null)
+    })
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'check_and_increment_ai_rate_limit') {
+        return Promise.resolve({ data: { allowed: true, reason: null } })
+      }
+      return Promise.resolve({ data: null, error: null })
+    })
+    global.fetch = jest.fn().mockResolvedValue(makeAnthropicStreamResponse('Almost done!'))
+
+    const res = await POST(makeRequest({ message: 'Last message', chatId: 'near-limit' }))
+    const content = await consumeStream(res as unknown as Response)
+    expect(content).toContain('limitReached":true')
+  })
+})

--- a/__tests__/app/dashboard/chat.test.tsx
+++ b/__tests__/app/dashboard/chat.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import ChatPage from '@/app/(dashboard)/chat/page'
+
+const mockRedirect = jest.fn()
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    mockRedirect(url)
+    throw new Error('NEXT_REDIRECT')
+  },
+}))
+
+jest.mock('@/components/chat/chat-panel', () => ({
+  ChatPanel: ({ systemName }: { systemName: string }) => (
+    <div data-testid="chat-panel">{systemName}</div>
+  ),
+}))
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+describe('ChatPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to /login when no user', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    try {
+      await ChatPage()
+    } catch {
+      // redirect throws
+    }
+    expect(mockRedirect).toHaveBeenCalledWith('/login')
+  })
+
+  it('redirects to /quests when profile is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: null }),
+        }),
+      }),
+    })
+    try {
+      await ChatPage()
+    } catch {
+      // redirect throws
+    }
+    expect(mockRedirect).toHaveBeenCalledWith('/quests')
+  })
+
+  it('redirects to /quests when user is not a parent', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: { role: 'child' } }),
+        }),
+      }),
+    })
+    try {
+      await ChatPage()
+    } catch {
+      // redirect throws
+    }
+    expect(mockRedirect).toHaveBeenCalledWith('/quests')
+  })
+
+  it('renders ChatPanel with parent config for authenticated parent', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: { role: 'parent' } }),
+        }),
+      }),
+    })
+    const Component = await ChatPage()
+    render(Component)
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+    expect(screen.getByText('Parenting Assistant')).toBeInTheDocument()
+  })
+})

--- a/__tests__/app/dashboard/quest-buddy.test.tsx
+++ b/__tests__/app/dashboard/quest-buddy.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import QuestBuddyPage from '@/app/(dashboard)/quest-buddy/page'
+
+const mockRedirect = jest.fn()
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    mockRedirect(url)
+    throw new Error('NEXT_REDIRECT')
+  },
+}))
+
+jest.mock('@/components/chat/chat-panel', () => ({
+  ChatPanel: ({ systemName }: { systemName: string }) => (
+    <div data-testid="chat-panel">{systemName}</div>
+  ),
+}))
+
+const mockGetUser = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+    }),
+}))
+
+describe('QuestBuddyPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to /login when no user', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    try {
+      await QuestBuddyPage()
+    } catch {
+      // redirect throws
+    }
+    expect(mockRedirect).toHaveBeenCalledWith('/login')
+  })
+
+  it('renders ChatPanel with Quest Buddy config for authenticated user', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    const Component = await QuestBuddyPage()
+    render(Component)
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+    expect(screen.getByText('Quest Buddy')).toBeInTheDocument()
+  })
+})

--- a/__tests__/app/dashboard/quests.test.tsx
+++ b/__tests__/app/dashboard/quests.test.tsx
@@ -246,6 +246,17 @@ describe('QuestsPage', () => {
     expect(fab).toBeInTheDocument()
   })
 
+  it('add quest FAB has chat-hideable class so it hides when chat opens', async () => {
+    render(<QuestsPage />)
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Quests' })).toBeInTheDocument()
+    })
+
+    const fab = document.querySelector('button.chat-hideable')
+    expect(fab).toBeInTheDocument()
+    expect(fab).toHaveClass('bottom-40')
+  })
+
   it('opens task form when FAB is clicked', async () => {
     const user = userEvent.setup()
     render(<QuestsPage />)

--- a/__tests__/components/chat/chat-fab.test.tsx
+++ b/__tests__/components/chat/chat-fab.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ChatFab } from '@/components/chat/chat-fab'
+
+// Mock ChatPanel to avoid pulling in all its dependencies
+jest.mock('@/components/chat/chat-panel', () => ({
+  ChatPanel: (props: { systemName: string }) => (
+    <div data-testid="chat-panel">{props.systemName}</div>
+  ),
+}))
+
+describe('ChatFab', () => {
+  it('renders the FAB button', () => {
+    render(<ChatFab role="parent" />)
+    expect(screen.getByRole('button', { name: 'Open chat' })).toBeInTheDocument()
+  })
+
+  it('does not show chat window initially', () => {
+    render(<ChatFab role="parent" />)
+    expect(screen.queryByTestId('chat-panel')).not.toBeInTheDocument()
+  })
+
+  it('opens chat window when FAB is clicked', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+  })
+
+  it('shows Parenting Assistant for parent role', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(screen.getByText('Parenting Assistant')).toBeInTheDocument()
+  })
+
+  it('shows Quest Buddy for child role', async () => {
+    render(<ChatFab role="child" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(screen.getByText('Quest Buddy')).toBeInTheDocument()
+  })
+
+  it('closes chat window when close button in header is clicked', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+    // First "Close chat" button is the header X
+    const closeButtons = screen.getAllByRole('button', { name: 'Close chat' })
+    await userEvent.click(closeButtons[0])
+    expect(screen.queryByTestId('chat-panel')).not.toBeInTheDocument()
+  })
+
+  it('toggles chat window when FAB is clicked again', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+    // Both the header X and FAB show "Close chat" — click the FAB (last one)
+    const closeButtons = screen.getAllByRole('button', { name: 'Close chat' })
+    await userEvent.click(closeButtons[closeButtons.length - 1])
+    expect(screen.queryByTestId('chat-panel')).not.toBeInTheDocument()
+  })
+
+  it('shows backdrop on mobile when open', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    // Backdrop has sm:hidden class
+    const backdrop = document.querySelector('.bg-black\\/30')
+    expect(backdrop).toBeInTheDocument()
+  })
+
+  it('closes when backdrop is clicked', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    const backdrop = document.querySelector('.bg-black\\/30') as HTMLElement
+    await userEvent.click(backdrop)
+    expect(screen.queryByTestId('chat-panel')).not.toBeInTheDocument()
+  })
+
+  it('applies purple style for parent FAB', () => {
+    render(<ChatFab role="parent" />)
+    const fab = screen.getByRole('button', { name: 'Open chat' })
+    expect(fab).toHaveClass('bg-purple-600')
+  })
+
+  it('applies gradient style for child FAB', () => {
+    render(<ChatFab role="child" />)
+    const fab = screen.getByRole('button', { name: 'Open chat' })
+    expect(fab).toHaveClass('bg-gradient-to-br')
+  })
+
+  it('adds chat-open class to body when chat opens', async () => {
+    render(<ChatFab role="parent" />)
+    expect(document.body.classList.contains('chat-open')).toBe(false)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(document.body.classList.contains('chat-open')).toBe(true)
+  })
+
+  it('removes chat-open class from body when chat closes', async () => {
+    render(<ChatFab role="parent" />)
+    await userEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(document.body.classList.contains('chat-open')).toBe(true)
+    const closeButtons = screen.getAllByRole('button', { name: 'Close chat' })
+    await userEvent.click(closeButtons[0])
+    expect(document.body.classList.contains('chat-open')).toBe(false)
+  })
+
+  it('removes chat-open class on unmount', () => {
+    const { unmount } = render(<ChatFab role="parent" />)
+    document.body.classList.add('chat-open')
+    unmount()
+    expect(document.body.classList.contains('chat-open')).toBe(false)
+  })
+})

--- a/__tests__/components/chat/chat-message.test.tsx
+++ b/__tests__/components/chat/chat-message.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import { ChatMessageBubble } from '@/components/chat/chat-message'
+import type { ChatMessage } from '@/lib/types'
+
+const userMsg: ChatMessage = {
+  role: 'user',
+  content: 'Hello there',
+  timestamp: '2024-01-01T10:00:00.000Z',
+}
+
+const assistantMsg: ChatMessage = {
+  role: 'assistant',
+  content: 'Hi! How can I help?',
+  timestamp: '2024-01-01T10:00:05.000Z',
+}
+
+describe('ChatMessageBubble', () => {
+  it('renders user message content', () => {
+    render(<ChatMessageBubble message={userMsg} theme="parent" />)
+    expect(screen.getByText('Hello there')).toBeInTheDocument()
+  })
+
+  it('renders assistant message content', () => {
+    render(<ChatMessageBubble message={assistantMsg} theme="parent" />)
+    expect(screen.getByText('Hi! How can I help?')).toBeInTheDocument()
+  })
+
+  it('user message aligns to the right', () => {
+    const { container } = render(<ChatMessageBubble message={userMsg} theme="parent" />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toHaveClass('justify-end')
+  })
+
+  it('assistant message aligns to the left', () => {
+    const { container } = render(<ChatMessageBubble message={assistantMsg} theme="parent" />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toHaveClass('justify-start')
+  })
+
+  it('parent theme uses purple for assistant', () => {
+    const { container } = render(<ChatMessageBubble message={assistantMsg} theme="parent" />)
+    const bubble = container.querySelector('.bg-purple-100')
+    expect(bubble).toBeInTheDocument()
+  })
+
+  it('kid theme uses green for assistant', () => {
+    const { container } = render(<ChatMessageBubble message={assistantMsg} theme="kid" />)
+    const bubble = container.querySelector('.bg-green-100')
+    expect(bubble).toBeInTheDocument()
+  })
+
+  it('hides timestamp when isStreaming is true', () => {
+    render(<ChatMessageBubble message={assistantMsg} theme="parent" isStreaming />)
+    expect(screen.queryByRole('time')).not.toBeInTheDocument()
+  })
+
+  it('shows timestamp when not streaming', () => {
+    render(<ChatMessageBubble message={assistantMsg} theme="parent" />)
+    expect(screen.getByRole('time')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/chat/chat-panel.test.tsx
+++ b/__tests__/components/chat/chat-panel.test.tsx
@@ -1,0 +1,614 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ChatPanel } from '@/components/chat/chat-panel'
+import type { QuickAction } from '@/lib/types'
+
+// Mock consumeSseStream so we don't need real streams in unit tests
+jest.mock('@/lib/ai/stream-helpers', () => ({
+  consumeSseStream: jest.fn(),
+}))
+
+import { consumeSseStream } from '@/lib/ai/stream-helpers'
+const mockConsumeSseStream = consumeSseStream as jest.MockedFunction<typeof consumeSseStream>
+
+// jsdom doesn't implement scrollIntoView
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+})
+
+const QUICK_ACTIONS: QuickAction[] = [
+  { label: '💡 Tip', prompt: 'Give me a tip' },
+]
+
+function makeOkResponse() {
+  return {
+    ok: true,
+    status: 200,
+    // Use a non-null truthy body to pass the null check in ChatPanel.
+    // consumeSseStream is fully mocked so the actual stream content doesn't matter.
+    body: {} as ReadableStream,
+    json: async () => ({}),
+  } as unknown as Response
+}
+
+function makeErrorResponse(status: number, body: object) {
+  return {
+    ok: false,
+    status,
+    body: null,
+    json: async () => body,
+  } as unknown as Response
+}
+
+describe('ChatPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn()
+  })
+
+  it('renders the system name in the header', () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="Parenting Assistant"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+    expect(screen.getByText('Parenting Assistant')).toBeInTheDocument()
+  })
+
+  it('renders initial empty state with prompt for parent', () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="Parenting Assistant"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+    expect(screen.getByText(/Ask me anything/i)).toBeInTheDocument()
+  })
+
+  it('renders initial empty state with prompt for kid', () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/quest-buddy"
+        systemName="Quest Buddy"
+        theme="kid"
+        quickActions={[]}
+      />
+    )
+    // Multiple elements may contain "Quest Buddy" (header + empty state text)
+    const instances = screen.getAllByText(/Quest Buddy/i)
+    expect(instances.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText(/Hi!/i)).toBeInTheDocument()
+  })
+
+  it('renders quick action buttons', () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={QUICK_ACTIONS}
+      />
+    )
+    expect(screen.getByText('💡 Tip')).toBeInTheDocument()
+  })
+
+  it('clicking a quick action populates the input', async () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={QUICK_ACTIONS}
+      />
+    )
+    await userEvent.click(screen.getByText('💡 Tip'))
+    expect(screen.getByRole('textbox', { name: /message input/i })).toHaveValue('Give me a tip')
+  })
+
+  it('send button is disabled when input is empty', () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+    expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled()
+  })
+
+  it('send button is enabled when input has text', async () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    expect(screen.getByRole('button', { name: /send message/i })).toBeEnabled()
+  })
+
+  it('sends a message and displays the assistant response', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockResolvedValueOnce('Great question!')
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: /message input/i })
+    await userEvent.type(input, 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello')).toBeInTheDocument()
+      expect(screen.getByText('Great question!')).toBeInTheDocument()
+    })
+  })
+
+  it('shows rate limit error on 429 response', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeErrorResponse(429, { error: "You've reached your personal message limit for today (20). Try again tomorrow!" })
+    )
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/reached your personal message limit/i)).toBeInTheDocument()
+    })
+    // Optimistic message should be removed
+    expect(screen.queryByText('Hello')).not.toBeInTheDocument()
+  })
+
+  it('shows service unavailable error on 503 response', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeErrorResponse(503, { error: 'AI unavailable' })
+    )
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument()
+    })
+  })
+
+  it('dismisses error when X is clicked', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeErrorResponse(503, { error: 'AI unavailable' })
+    )
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => screen.getByLabelText('Dismiss error'))
+    await userEvent.click(screen.getByLabelText('Dismiss error'))
+
+    expect(screen.queryByLabelText('Dismiss error')).not.toBeInTheDocument()
+  })
+
+  it('calls onConversationCreated when metadata has a new conversationId', async () => {
+    const onCreated = jest.fn()
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockImplementationOnce(async (_body, _onToken, onMeta) => {
+      onMeta?.({ conversationId: 'new-conv-id' })
+      return 'Response text'
+    })
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+        onConversationCreated={onCreated}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hi')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith('new-conv-id')
+    })
+  })
+
+  it('renders initial messages', () => {
+    const initialMessages = [
+      { role: 'user' as const, content: 'First message', timestamp: new Date().toISOString() },
+      { role: 'assistant' as const, content: 'First reply', timestamp: new Date().toISOString() },
+    ]
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+        initialMessages={initialMessages}
+      />
+    )
+    expect(screen.getByText('First message')).toBeInTheDocument()
+    expect(screen.getByText('First reply')).toBeInTheDocument()
+  })
+
+  it('shows limitReached banner when meta signals limit reached', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockImplementationOnce(async (_body, _onToken, onMeta) => {
+      onMeta?.({ limitReached: true })
+      return 'Last response'
+    })
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hi')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Start a new conversation/i)).toBeInTheDocument()
+    })
+
+    // Input should be disabled
+    expect(screen.getByRole('textbox', { name: /message input/i })).toBeDisabled()
+  })
+
+  it('uses the message log role for accessibility', () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+    expect(screen.getByRole('log')).toBeInTheDocument()
+  })
+
+  it('shows generic error on non-429/503 response', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeErrorResponse(500, { error: 'Server error' })
+    )
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when response has no body', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      body: null,
+      json: async () => ({}),
+    } as unknown as Response)
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/No response received/i)).toBeInTheDocument()
+    })
+  })
+
+  it('calls onConversationCreated with chatId from meta', async () => {
+    const onCreated = jest.fn()
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockImplementationOnce(async (_body, _onToken, onMeta) => {
+      onMeta?.({ chatId: 'chat-id-123' })
+      return 'Response text'
+    })
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/quest-buddy"
+        systemName="QB"
+        theme="kid"
+        quickActions={[]}
+        onConversationCreated={onCreated}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hi')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith('chat-id-123')
+    })
+  })
+
+  it('shows connection error when fetch throws a non-abort error', async () => {
+    ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'))
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connection interrupted/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows no error when fetch throws an AbortError', async () => {
+    const abortError = new Error('Aborted')
+    abortError.name = 'AbortError'
+    ;(global.fetch as jest.Mock).mockRejectedValueOnce(abortError)
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    // No error banner should appear after an abort
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Dismiss error')).not.toBeInTheDocument()
+    })
+  })
+
+  it('submits message on Enter key press', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockResolvedValueOnce('Response!')
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: /message input/i })
+    await userEvent.type(input, 'Hello{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('Response!')).toBeInTheDocument()
+    })
+  })
+
+  it('does not submit message on Shift+Enter key press', async () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: /message input/i })
+    await userEvent.type(input, 'Hello{Shift>}{Enter}{/Shift}')
+
+    // fetch should NOT have been called
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('displays streaming content via onToken callback', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockImplementationOnce(async (_body, onToken, _onMeta) => {
+      onToken('Streaming...')
+      return 'Full response'
+    })
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Full response')).toBeInTheDocument()
+    })
+  })
+
+  it('shows maxMessages limitReached banner text when maxMessages is set', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockImplementationOnce(async (_body, _onToken, onMeta) => {
+      onMeta?.({ limitReached: true })
+      return 'Last response'
+    })
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/quest-buddy"
+        systemName="QB"
+        theme="kid"
+        quickActions={[]}
+        maxMessages={20}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hi')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/That's all for now/i)).toBeInTheDocument()
+    })
+  })
+
+  it('does nothing when sendMessage is called with empty/whitespace input', async () => {
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: /message input/i })
+    // Press Enter on empty input — sendMessage('') → trimmed='' → early return
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+
+    // fetch should NOT have been called
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('shows fallback limit message when 429 body has no error field', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeErrorResponse(429, {}) // empty body — no .error field
+    )
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/reached the message limit/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows (no response) when consumeSseStream returns empty string', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+    mockConsumeSseStream.mockResolvedValueOnce('')
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('(no response)')).toBeInTheDocument()
+    })
+  })
+
+  it('shows streaming content bubble (not typing indicator) while streaming', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce(makeOkResponse())
+
+    let resolveStream!: (value: string) => void
+    mockConsumeSseStream.mockImplementationOnce((_body, onToken, _onMeta) => {
+      // Emit a token so streamingContent becomes truthy
+      onToken('Streaming...')
+      // Return a promise that we control
+      return new Promise<string>((resolve) => {
+        resolveStream = resolve
+      })
+    })
+
+    render(
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="PA"
+        theme="parent"
+        quickActions={[]}
+      />
+    )
+
+    await userEvent.type(screen.getByRole('textbox', { name: /message input/i }), 'Hello')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    // While streaming, the streaming content <p> should be visible
+    await waitFor(() => {
+      expect(screen.getByText('Streaming...')).toBeInTheDocument()
+    })
+
+    // Resolve the stream so the component can finish
+    resolveStream('Full response')
+
+    await waitFor(() => {
+      expect(screen.getByText('Full response')).toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/components/chat/conversation-list.test.tsx
+++ b/__tests__/components/chat/conversation-list.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConversationList } from '@/components/chat/conversation-list'
+import type { ConversationSummary } from '@/components/chat/conversation-list'
+
+const CONVERSATIONS: ConversationSummary[] = [
+  { id: 'conv-1', title: 'Chat about chores', updatedAt: '2024-01-15T10:00:00Z', messageCount: 5 },
+  { id: 'conv-2', title: null, updatedAt: '2024-01-14T10:00:00Z', messageCount: 1 },
+]
+
+describe('ConversationList', () => {
+  it('shows loading skeletons when loading=true', () => {
+    const { container } = render(
+      <ConversationList conversations={[]} activeId={null} onSelect={jest.fn()} loading />
+    )
+    const skeletons = container.querySelectorAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('shows empty state when no conversations', () => {
+    render(<ConversationList conversations={[]} activeId={null} onSelect={jest.fn()} />)
+    expect(screen.getByText(/No conversations yet/i)).toBeInTheDocument()
+  })
+
+  it('renders list of conversations', () => {
+    render(<ConversationList conversations={CONVERSATIONS} activeId={null} onSelect={jest.fn()} />)
+    expect(screen.getByText('Chat about chores')).toBeInTheDocument()
+    expect(screen.getByText('New conversation')).toBeInTheDocument()
+  })
+
+  it('shows singular "message" for messageCount of 1', () => {
+    render(<ConversationList conversations={[CONVERSATIONS[1]]} activeId={null} onSelect={jest.fn()} />)
+    expect(screen.getByText(/\b1 message\b/)).toBeInTheDocument()
+    expect(screen.queryByText(/1 messages/)).not.toBeInTheDocument()
+  })
+
+  it('shows plural "messages" for messageCount > 1', () => {
+    render(<ConversationList conversations={[CONVERSATIONS[0]]} activeId={null} onSelect={jest.fn()} />)
+    expect(screen.getByText(/5 messages/)).toBeInTheDocument()
+  })
+
+  it('marks the active conversation with aria-selected=true', () => {
+    render(<ConversationList conversations={CONVERSATIONS} activeId="conv-1" onSelect={jest.fn()} />)
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    expect(options[1]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('calls onSelect with conversation id when clicked', async () => {
+    const onSelect = jest.fn()
+    render(<ConversationList conversations={CONVERSATIONS} activeId={null} onSelect={onSelect} />)
+    await userEvent.click(screen.getAllByRole('option')[0])
+    expect(onSelect).toHaveBeenCalledWith('conv-1')
+  })
+
+  it('renders within a listbox element', () => {
+    render(<ConversationList conversations={CONVERSATIONS} activeId={null} onSelect={jest.fn()} />)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/chat/quick-actions.test.tsx
+++ b/__tests__/components/chat/quick-actions.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QuickActions } from '@/components/chat/quick-actions'
+import type { QuickAction } from '@/lib/types'
+
+const actions: QuickAction[] = [
+  { label: '💡 Suggest quests', prompt: 'Suggest some quests' },
+  { label: '📊 Weekly report', prompt: 'Give me a report' },
+]
+
+describe('QuickActions', () => {
+  it('renders all action buttons', () => {
+    render(<QuickActions actions={actions} onSelect={jest.fn()} />)
+    expect(screen.getByText('💡 Suggest quests')).toBeInTheDocument()
+    expect(screen.getByText('📊 Weekly report')).toBeInTheDocument()
+  })
+
+  it('calls onSelect with the prompt when clicked', async () => {
+    const handleSelect = jest.fn()
+    render(<QuickActions actions={actions} onSelect={handleSelect} />)
+    await userEvent.click(screen.getByText('💡 Suggest quests'))
+    expect(handleSelect).toHaveBeenCalledWith('Suggest some quests')
+  })
+
+  it('disables all buttons when disabled prop is true', () => {
+    render(<QuickActions actions={actions} onSelect={jest.fn()} disabled />)
+    const buttons = screen.getAllByRole('button')
+    buttons.forEach(btn => expect(btn).toBeDisabled())
+  })
+
+  it('renders with accessible group label', () => {
+    render(<QuickActions actions={actions} onSelect={jest.fn()} />)
+    expect(screen.getByRole('group', { name: 'Quick actions' })).toBeInTheDocument()
+  })
+
+  it('renders nothing extra for empty actions array', () => {
+    const { container } = render(<QuickActions actions={[]} onSelect={jest.fn()} />)
+    expect(container.querySelectorAll('button')).toHaveLength(0)
+  })
+})

--- a/__tests__/components/chat/typing-indicator.test.tsx
+++ b/__tests__/components/chat/typing-indicator.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import { TypingIndicator } from '@/components/chat/typing-indicator'
+
+describe('TypingIndicator', () => {
+  it('renders with accessible label', () => {
+    render(<TypingIndicator />)
+    expect(screen.getByLabelText('Assistant is typing')).toBeInTheDocument()
+  })
+
+  it('renders three animated dots', () => {
+    const { container } = render(<TypingIndicator />)
+    const dots = container.querySelectorAll('.animate-bounce')
+    expect(dots).toHaveLength(3)
+  })
+})

--- a/__tests__/components/layout/nav-bar.test.tsx
+++ b/__tests__/components/layout/nav-bar.test.tsx
@@ -80,16 +80,11 @@ describe('NavBar', () => {
     expect(screen.getByRole('navigation')).toBeInTheDocument()
   })
 
-  it('includes Chat nav item when role is parent', () => {
+  it('does not include Chat nav item (chat is now a floating widget)', () => {
     render(<NavBar role="parent" />)
-    expect(screen.getByText('Chat')).toBeInTheDocument()
+    expect(screen.queryByText('Chat')).not.toBeInTheDocument()
     const links = screen.getAllByRole('link')
     const hrefs = links.map((link) => link.getAttribute('href'))
-    expect(hrefs).toContain('/chat')
-  })
-
-  it('does not include Chat nav item for non-parent role', () => {
-    render(<NavBar />)
-    expect(screen.queryByText('Chat')).not.toBeInTheDocument()
+    expect(hrefs).not.toContain('/chat')
   })
 })

--- a/__tests__/components/layout/nav-bar.test.tsx
+++ b/__tests__/components/layout/nav-bar.test.tsx
@@ -79,4 +79,17 @@ describe('NavBar', () => {
     render(<NavBar />)
     expect(screen.getByRole('navigation')).toBeInTheDocument()
   })
+
+  it('includes Chat nav item when role is parent', () => {
+    render(<NavBar role="parent" />)
+    expect(screen.getByText('Chat')).toBeInTheDocument()
+    const links = screen.getAllByRole('link')
+    const hrefs = links.map((link) => link.getAttribute('href'))
+    expect(hrefs).toContain('/chat')
+  })
+
+  it('does not include Chat nav item for non-parent role', () => {
+    render(<NavBar />)
+    expect(screen.queryByText('Chat')).not.toBeInTheDocument()
+  })
 })

--- a/__tests__/lib/ai/prompts.test.ts
+++ b/__tests__/lib/ai/prompts.test.ts
@@ -1,0 +1,112 @@
+import {
+  buildParentSystemPrompt,
+  buildKidSystemPrompt,
+  CONVERSATION_HISTORY_LIMIT,
+  CONVERSATION_MESSAGE_LIMIT,
+  KID_SESSION_MESSAGE_LIMIT,
+  type ParentContext,
+  type KidContext,
+} from '@/lib/ai/prompts'
+
+describe('buildParentSystemPrompt', () => {
+  const ctx: ParentContext = {
+    familyName: 'Smith',
+    children: [
+      { displayName: 'Alice', points: 120 },
+      { displayName: 'Bob', points: 45 },
+    ],
+    recentTasks: [
+      { title: 'Wash dishes', assignedTo: 'alice-id', points: 10, completed: true },
+      { title: 'Clean room', assignedTo: 'bob-id', points: 15, completed: false },
+    ],
+  }
+
+  it('includes the family name', () => {
+    const prompt = buildParentSystemPrompt(ctx)
+    expect(prompt).toContain('Smith')
+  })
+
+  it('lists children with their points', () => {
+    const prompt = buildParentSystemPrompt(ctx)
+    expect(prompt).toContain('Alice (120 points)')
+    expect(prompt).toContain('Bob (45 points)')
+  })
+
+  it('includes active quests', () => {
+    const prompt = buildParentSystemPrompt(ctx)
+    expect(prompt).toContain('Wash dishes')
+    expect(prompt).toContain('Clean room')
+  })
+
+  it('handles empty children list', () => {
+    const prompt = buildParentSystemPrompt({ ...ctx, children: [] })
+    expect(prompt).toContain('No children yet')
+  })
+
+  it('handles empty tasks list', () => {
+    const prompt = buildParentSystemPrompt({ ...ctx, recentTasks: [] })
+    expect(prompt).toContain('No active quests')
+  })
+
+  it('limits tasks to 10 in the prompt', () => {
+    const manyTasks = Array.from({ length: 15 }, (_, i) => ({
+      title: `Task ${i}`,
+      assignedTo: 'x',
+      points: 5,
+      completed: false,
+    }))
+    const prompt = buildParentSystemPrompt({ ...ctx, recentTasks: manyTasks })
+    // Tasks 10-14 should not appear
+    expect(prompt).not.toContain('Task 10')
+    expect(prompt).toContain('Task 9')
+  })
+})
+
+describe('buildKidSystemPrompt', () => {
+  const ctx: KidContext = {
+    childName: 'Alice',
+    points: 120,
+    pendingTasks: [
+      { title: 'Sweep floor', points: 10 },
+      { title: 'Feed dog', points: 5 },
+    ],
+    recentCompletions: [
+      { pointsEarned: 10, completionDate: '2024-01-01' },
+    ],
+  }
+
+  it('includes the child name', () => {
+    const prompt = buildKidSystemPrompt(ctx)
+    expect(prompt).toContain('Alice')
+  })
+
+  it('includes current points', () => {
+    const prompt = buildKidSystemPrompt(ctx)
+    expect(prompt).toContain('120')
+  })
+
+  it('lists pending tasks with points', () => {
+    const prompt = buildKidSystemPrompt(ctx)
+    expect(prompt).toContain('"Sweep floor" (10 pts)')
+    expect(prompt).toContain('"Feed dog" (5 pts)')
+  })
+
+  it('handles empty pending tasks', () => {
+    const prompt = buildKidSystemPrompt({ ...ctx, pendingTasks: [] })
+    expect(prompt).toContain('No pending quests right now')
+  })
+})
+
+describe('constants', () => {
+  it('CONVERSATION_HISTORY_LIMIT is 20', () => {
+    expect(CONVERSATION_HISTORY_LIMIT).toBe(20)
+  })
+
+  it('CONVERSATION_MESSAGE_LIMIT is 100', () => {
+    expect(CONVERSATION_MESSAGE_LIMIT).toBe(100)
+  })
+
+  it('KID_SESSION_MESSAGE_LIMIT is 20', () => {
+    expect(KID_SESSION_MESSAGE_LIMIT).toBe(20)
+  })
+})

--- a/__tests__/lib/ai/stream-helpers.test.ts
+++ b/__tests__/lib/ai/stream-helpers.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment node
+ */
+import { consumeSseStream } from '@/lib/ai/stream-helpers'
+
+/** Build a ReadableStream from a list of string chunks */
+function makeStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk))
+      }
+      controller.close()
+    },
+  })
+}
+
+describe('consumeSseStream', () => {
+  it('accumulates text_delta events into full content', async () => {
+    const chunks = [
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":" world"}}\n\n',
+    ]
+    const tokens: string[] = []
+    const result = await consumeSseStream(makeStream(chunks), (t) => tokens.push(t))
+    expect(result).toBe('Hello world')
+    expect(tokens).toEqual(['Hello', 'Hello world'])
+  })
+
+  it('calls onMeta for conversation_meta events', async () => {
+    const metaPayload = { conversationId: 'abc-123', title: 'My chat', limitReached: false }
+    const chunks = [
+      `event: conversation_meta\ndata: ${JSON.stringify(metaPayload)}\n\n`,
+    ]
+    const metas: Record<string, unknown>[] = []
+    await consumeSseStream(makeStream(chunks), () => {}, (m) => metas.push(m))
+    expect(metas).toHaveLength(1)
+    expect(metas[0]).toMatchObject(metaPayload)
+  })
+
+  it('calls onMeta for chat_meta events', async () => {
+    const metaPayload = { chatId: 'xyz-456', limitReached: true }
+    const chunks = [
+      `event: chat_meta\ndata: ${JSON.stringify(metaPayload)}\n\n`,
+    ]
+    const metas: Record<string, unknown>[] = []
+    await consumeSseStream(makeStream(chunks), () => {}, (m) => metas.push(m))
+    expect(metas[0]).toMatchObject(metaPayload)
+  })
+
+  it('skips non-text-delta Anthropic events', async () => {
+    const chunks = [
+      'data: {"type":"message_start","message":{"id":"msg_01"}}\n\n',
+      'data: {"type":"content_block_start","content_block":{"type":"text","text":""}}\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ]
+    const result = await consumeSseStream(makeStream(chunks), () => {})
+    expect(result).toBe('Hi')
+  })
+
+  it('handles line-buffered chunks (split across reads)', async () => {
+    // Simulate chunk split mid-line
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Split the data line into two reads
+        controller.enqueue(encoder.encode('data: {"type":"content_block_delta","delta":{"type"'))
+        controller.enqueue(encoder.encode(':"text_delta","text":"Split"}}\n\n'))
+        controller.close()
+      },
+    })
+    const result = await consumeSseStream(stream, () => {})
+    expect(result).toBe('Split')
+  })
+
+  it('ignores malformed JSON lines gracefully', async () => {
+    const chunks = [
+      'data: not-json\n\n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"OK"}}\n\n',
+    ]
+    const result = await consumeSseStream(makeStream(chunks), () => {})
+    expect(result).toBe('OK')
+  })
+
+  it('returns empty string for empty stream', async () => {
+    const result = await consumeSseStream(makeStream([]), () => {})
+    expect(result).toBe('')
+  })
+
+  it('skips data lines with empty payload', async () => {
+    const chunks = [
+      'data:   \n',
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}\n\n',
+    ]
+    const result = await consumeSseStream(makeStream(chunks), () => {})
+    expect(result).toBe('Hello')
+  })
+
+  it('stops reading when AbortSignal is aborted', async () => {
+    const controller = new AbortController()
+    const encoder = new TextEncoder()
+    let resolveRead!: () => void
+    const readPromise = new Promise<void>(r => { resolveRead = r })
+
+    // Stream that blocks until the resolve
+    const stream = new ReadableStream<Uint8Array>({
+      async start(c) {
+        controller.abort()
+        await readPromise
+        c.enqueue(encoder.encode('data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"never"}}\n\n'))
+        c.close()
+      },
+    })
+
+    const resultPromise = consumeSseStream(stream, () => {}, undefined, controller.signal)
+    resolveRead()
+    const result = await resultPromise
+    // Should have stopped before processing the chunk
+    expect(result).toBe('')
+  })
+})

--- a/app/(dashboard)/chat/page.tsx
+++ b/app/(dashboard)/chat/page.tsx
@@ -1,0 +1,38 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { ChatPanel } from '@/components/chat/chat-panel'
+import type { QuickAction } from '@/lib/types'
+
+const PARENT_QUICK_ACTIONS: QuickAction[] = [
+  { label: '💡 Suggest quests', prompt: 'Suggest 3 age-appropriate chores for my kids based on their current quests.' },
+  { label: '📊 Weekly report', prompt: "Give me a summary of my family's quest progress this week." },
+  { label: '🌟 Motivation tips', prompt: 'My kids seem unmotivated lately. What are some strategies to re-engage them?' },
+  { label: '🎯 Points balance', prompt: 'How are my kids doing with their points? Any patterns I should know about?' },
+]
+
+export default async function ChatPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || profile.role !== 'parent') {
+    redirect('/quests')
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)]">
+      <ChatPanel
+        apiEndpoint="/api/ai/chat"
+        systemName="Parenting Assistant"
+        theme="parent"
+        quickActions={PARENT_QUICK_ACTIONS}
+      />
+    </div>
+  )
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { NavBar } from '@/components/layout/nav-bar'
+import { ChatFab } from '@/components/chat/chat-fab'
 import { ToasterProvider } from '@/components/ui/toaster-provider'
 import { ObservabilityErrorBoundary } from '@/components/error-boundary'
 import { PageViewTracker } from '@/components/page-view-tracker'
@@ -37,6 +38,7 @@ export default async function DashboardLayout({
       <ToasterProvider />
       <PageViewTracker />
       <NavBar role={profile.role} />
+      <ChatFab role={profile.role} />
     </div>
   )
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -21,7 +21,7 @@ export default async function DashboardLayout({
   // Ensure user has completed onboarding (has a family)
   const { data: profile } = await supabase
     .from('profiles')
-    .select('family_id')
+    .select('family_id, role')
     .eq('id', user.id)
     .single()
 
@@ -36,7 +36,7 @@ export default async function DashboardLayout({
       </ObservabilityErrorBoundary>
       <ToasterProvider />
       <PageViewTracker />
-      <NavBar />
+      <NavBar role={profile.role} />
     </div>
   )
 }

--- a/app/(dashboard)/quest-buddy/page.tsx
+++ b/app/(dashboard)/quest-buddy/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { ChatPanel } from '@/components/chat/chat-panel'
+import type { QuickAction } from '@/lib/types'
+
+const KID_QUICK_ACTIONS: QuickAction[] = [
+  { label: '🚀 What should I do?', prompt: 'Which quest should I do next?' },
+  { label: '⭐ My points', prompt: 'How many points do I have? What can I get?' },
+  { label: '🎉 I finished one!', prompt: 'I just finished a quest! Celebrate with me!' },
+  { label: '💪 I need help', prompt: "I'm stuck on a quest. Can you help me?" },
+]
+
+export default async function QuestBuddyPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)]">
+      <ChatPanel
+        apiEndpoint="/api/ai/quest-buddy"
+        systemName="Quest Buddy"
+        theme="kid"
+        quickActions={KID_QUICK_ACTIONS}
+        maxMessages={20}
+      />
+    </div>
+  )
+}

--- a/app/(dashboard)/quests/page.tsx
+++ b/app/(dashboard)/quests/page.tsx
@@ -439,24 +439,11 @@ export default function QuestsPage() {
         selectedDate={selectedDate}
       />
 
-      {/* Quest Buddy FAB — kids only */}
-      {currentUser.role === 'child' && (
-        <a
-          href="/quest-buddy"
-          className="fixed bottom-40 right-4 w-14 h-14 bg-gradient-to-br from-yellow-400 to-pink-500 text-white rounded-full shadow-lg flex items-center justify-center hover:opacity-90 transition"
-          aria-label="Open Quest Buddy"
-        >
-          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-          </svg>
-        </a>
-      )}
-
       {/* Add quest FAB — parents only */}
       {currentUser.role === 'parent' && (
         <button
           onClick={() => setIsFormOpen(true)}
-          className="fixed bottom-24 right-4 w-14 h-14 bg-purple-600 text-white rounded-full shadow-lg flex items-center justify-center hover:bg-purple-700 transition"
+          className="chat-hideable fixed bottom-40 right-4 w-14 h-14 bg-purple-600 text-white rounded-full shadow-lg flex items-center justify-center hover:bg-purple-700 transition"
         >
           <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />

--- a/app/(dashboard)/quests/page.tsx
+++ b/app/(dashboard)/quests/page.tsx
@@ -439,15 +439,30 @@ export default function QuestsPage() {
         selectedDate={selectedDate}
       />
 
-      {/* FAB */}
-      <button
-        onClick={() => setIsFormOpen(true)}
-        className="fixed bottom-24 right-4 w-14 h-14 bg-purple-600 text-white rounded-full shadow-lg flex items-center justify-center hover:bg-purple-700 transition"
-      >
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>
-      </button>
+      {/* Quest Buddy FAB — kids only */}
+      {currentUser.role === 'child' && (
+        <a
+          href="/quest-buddy"
+          className="fixed bottom-40 right-4 w-14 h-14 bg-gradient-to-br from-yellow-400 to-pink-500 text-white rounded-full shadow-lg flex items-center justify-center hover:opacity-90 transition"
+          aria-label="Open Quest Buddy"
+        >
+          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+          </svg>
+        </a>
+      )}
+
+      {/* Add quest FAB — parents only */}
+      {currentUser.role === 'parent' && (
+        <button
+          onClick={() => setIsFormOpen(true)}
+          className="fixed bottom-24 right-4 w-14 h-14 bg-purple-600 text-white rounded-full shadow-lg flex items-center justify-center hover:bg-purple-700 transition"
+        >
+          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+        </button>
+      )}
 
       <TaskForm
         isOpen={isFormOpen || !!editingTask}

--- a/app/(dashboard)/quests/page.tsx
+++ b/app/(dashboard)/quests/page.tsx
@@ -443,6 +443,7 @@ export default function QuestsPage() {
       {currentUser.role === 'parent' && (
         <button
           onClick={() => setIsFormOpen(true)}
+          data-testid="add-quest-fab"
           className="chat-hideable fixed bottom-40 right-4 w-14 h-14 bg-purple-600 text-white rounded-full shadow-lg flex items-center justify-center hover:bg-purple-700 transition"
         >
           <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/api/ai/chat/conversations/[id]/route.ts
+++ b/app/api/ai/chat/conversations/[id]/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+
+async function handler(
+  _req: NextRequest,
+  context: unknown
+): Promise<NextResponse> {
+  const { id } = await (context as { params: Promise<{ id: string }> }).params
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || profile.role !== 'parent') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // RLS ensures parents can only access their own family's conversations
+  const { data, error } = await supabase
+    .from('ai_conversations')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ data })
+}
+
+export const GET = withObservability(handler)

--- a/app/api/ai/chat/conversations/route.ts
+++ b/app/api/ai/chat/conversations/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || profile.role !== 'parent') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '20', 10), 50)
+  const cursor = searchParams.get('cursor') // ISO timestamp for cursor-based pagination
+
+  let query = supabase
+    .from('ai_conversations')
+    .select('id, title, updated_at, messages')
+    .eq('family_id', profile.family_id)
+    .order('updated_at', { ascending: false })
+    .limit(limit + 1) // fetch one extra to determine if there's a next page
+
+  if (cursor) {
+    query = query.lt('updated_at', cursor)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to fetch conversations' }, { status: 500 })
+  }
+
+  const hasMore = (data ?? []).length > limit
+  const items = (data ?? []).slice(0, limit)
+
+  return NextResponse.json({
+    data: items.map(c => ({
+      id: c.id,
+      title: c.title,
+      updatedAt: c.updated_at,
+      messageCount: Array.isArray(c.messages) ? c.messages.length : 0,
+    })),
+    nextCursor: hasMore ? items[items.length - 1].updated_at : null,
+  })
+}
+
+export const GET = withObservability(handler)

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -1,0 +1,276 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+import { trackEvent } from '@/lib/observability/event-tracker'
+import {
+  buildParentSystemPrompt,
+  CONVERSATION_HISTORY_LIMIT,
+  CONVERSATION_MESSAGE_LIMIT,
+  type ParentContext,
+} from '@/lib/ai/prompts'
+import type { AiConversation, ChatMessage } from '@/lib/types'
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ data: null })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id, role, display_name')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || profile.role !== 'parent') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  if (!profile.family_id) {
+    return NextResponse.json({ error: 'No family' }, { status: 400 })
+  }
+
+  let body: { message?: unknown; conversationId?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const message = typeof body.message === 'string' ? body.message.trim() : null
+  if (!message || message.length === 0 || message.length > 2000) {
+    return NextResponse.json({ error: 'Invalid message' }, { status: 400 })
+  }
+  const conversationId = typeof body.conversationId === 'string' ? body.conversationId : undefined
+
+  // Rate limit: dual cap (20/user + 50/family)
+  const { data: rateResult } = await supabase.rpc('check_and_increment_ai_rate_limit', {
+    p_family_id: profile.family_id,
+    p_user_id: user.id,
+  })
+  const rate = rateResult as { allowed: boolean; reason: string | null } | null
+  if (!rate?.allowed) {
+    const msg = rate?.reason === 'user_limit'
+      ? "You've reached your personal message limit for today (20). Try again tomorrow!"
+      : "Your family has reached today's message limit (50). Try again tomorrow!"
+    return NextResponse.json({ error: msg, reason: rate?.reason }, { status: 429 })
+  }
+
+  // Load or create conversation (server is authoritative for history)
+  let conversation: AiConversation
+  if (conversationId) {
+    const { data } = await supabase
+      .from('ai_conversations')
+      .select('*')
+      .eq('id', conversationId)
+      .single()
+    if (!data) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 })
+    }
+    conversation = data as AiConversation
+  } else {
+    const { data, error } = await supabase
+      .from('ai_conversations')
+      .insert({ family_id: profile.family_id, parent_id: user.id, messages: [] })
+      .select()
+      .single()
+    if (error || !data) {
+      return NextResponse.json({ error: 'Failed to create conversation' }, { status: 500 })
+    }
+    conversation = data as AiConversation
+    trackEvent({
+      event_type: 'ai_chat_conversation_created',
+      user_id: user.id,
+      family_id: profile.family_id,
+      metadata: { conversationId: conversation.id },
+    })
+  }
+
+  // Truncate history to last N messages before sending to Anthropic
+  const history = (conversation.messages as ChatMessage[]).slice(-CONVERSATION_HISTORY_LIMIT)
+  const newUserMessage: ChatMessage = {
+    role: 'user',
+    content: message,
+    timestamp: new Date().toISOString(),
+  }
+
+  // Build family context for system prompt
+  const familyContext = await buildParentContext(supabase, profile.family_id)
+  const { data: familyData } = await supabase
+    .from('families')
+    .select('name')
+    .eq('id', profile.family_id)
+    .single()
+  const familyName = familyData?.name ?? 'your family'
+
+  const systemPrompt = buildParentSystemPrompt({ familyName, ...familyContext })
+
+  // Call Anthropic with streaming
+  const anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta': 'messages-2023-06-16',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      stream: true,
+      system: systemPrompt,
+      messages: [
+        ...history.map(m => ({ role: m.role, content: m.content })),
+        { role: 'user', content: message },
+      ],
+    }),
+    signal: AbortSignal.timeout(30000),
+  })
+
+  if (!anthropicRes.ok || !anthropicRes.body) {
+    return NextResponse.json({ error: 'AI unavailable' }, { status: 503 })
+  }
+
+  const streamStartTime = Date.now()
+  const encoder = new TextEncoder()
+  const sourceReader = anthropicRes.body.getReader()
+  let accumulatedText = ''
+  let lineBuffer = ''
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        while (true) {
+          const { done, value } = await sourceReader.read()
+          if (done) break
+          // Forward chunk to client immediately
+          controller.enqueue(value)
+
+          // Also parse for accumulation (line-buffered SSE)
+          lineBuffer += new TextDecoder().decode(value, { stream: true })
+          const lines = lineBuffer.split('\n')
+          /* istanbul ignore next */
+          lineBuffer = lines.pop() ?? ''
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            try {
+              const parsed = JSON.parse(line.slice(6)) as Record<string, unknown>
+              if (
+                parsed['type'] === 'content_block_delta' &&
+                (parsed['delta'] as Record<string, unknown>)?.['type'] === 'text_delta'
+              ) {
+                accumulatedText += (parsed['delta'] as Record<string, unknown>)['text'] as string
+              }
+            } catch {
+              // Skip non-JSON lines (SSE comments, ping frames)
+            }
+          }
+        }
+
+        // Stream complete — persist both messages atomically
+        const assistantMessage: ChatMessage = {
+          role: 'assistant',
+          content: accumulatedText,
+          timestamp: new Date().toISOString(),
+        }
+
+        const currentCount = (conversation.messages as ChatMessage[]).length
+        const limitReached = currentCount >= CONVERSATION_MESSAGE_LIMIT
+
+        if (!limitReached) {
+          await supabase.rpc('append_chat_messages', {
+            p_id: conversation.id,
+            p_messages: JSON.stringify([newUserMessage, assistantMessage]),
+          })
+        }
+
+        // Auto-title on the first message pair
+        let title = conversation.title
+        if (!title && conversation.messages.length === 0) {
+          title = message.slice(0, 60) + (message.length > 60 ? '...' : '')
+          await supabase
+            .from('ai_conversations')
+            .update({ title })
+            .eq('id', conversation.id)
+        }
+
+        trackEvent({
+          event_type: 'ai_parent_chat_message',
+          user_id: user.id,
+          family_id: profile.family_id!,
+          metadata: {
+            conversationId: conversation.id,
+            streamDurationMs: Date.now() - streamStartTime,
+            responseLength: accumulatedText.length,
+          },
+        })
+
+        // Send metadata event so client learns the conversationId and title
+        controller.enqueue(
+          encoder.encode(
+            `event: conversation_meta\ndata: ${JSON.stringify({
+              conversationId: conversation.id,
+              title,
+              limitReached,
+            })}\n\n`
+          )
+        )
+        controller.close()
+      } catch (err) {
+        /* istanbul ignore next */
+        controller.error(err)
+      }
+    },
+  })
+
+  // Cast: NextResponse extends Response; withObservability reads only .status
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  }) as unknown as NextResponse
+}
+
+async function buildParentContext(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  familyId: string
+): Promise<Omit<ParentContext, 'familyName'>> {
+  const [{ data: children }, { data: tasks }] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('display_name, points')
+      .eq('family_id', familyId)
+      .eq('role', 'child'),
+    supabase
+      .from('tasks')
+      .select('title, assigned_to, points, completed')
+      .eq('family_id', familyId)
+      .order('created_at', { ascending: false })
+      .limit(20),
+  ])
+
+  return {
+    children: (children ?? []).map(c => ({
+      displayName: c.display_name,
+      points: c.points,
+    })),
+    recentTasks: (tasks ?? []).map(t => ({
+      title: t.title,
+      assignedTo: t.assigned_to ?? '',
+      points: t.points,
+      completed: t.completed ?? false,
+    })),
+  }
+}
+
+// Vercel Pro streaming timeout — read by Next.js/Vercel runtime
+export const maxDuration = 60
+export const POST = withObservability(handler)

--- a/app/api/ai/quest-buddy/history/route.ts
+++ b/app/api/ai/quest-buddy/history/route.ts
@@ -1,0 +1,66 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || profile.role !== 'parent') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const childId = searchParams.get('childId')
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '20', 10), 50)
+  const cursor = searchParams.get('cursor')
+
+  let query = supabase
+    .from('ai_kid_chats')
+    .select('id, child_id, messages, created_at, profiles!ai_kid_chats_child_id_fkey(display_name)')
+    .eq('family_id', profile.family_id)
+    .order('created_at', { ascending: false })
+    .limit(limit + 1)
+
+  if (childId) {
+    query = query.eq('child_id', childId)
+  }
+
+  if (cursor) {
+    query = query.lt('created_at', cursor)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
+  }
+
+  const hasMore = (data ?? []).length > limit
+  const items = (data ?? []).slice(0, limit)
+
+  return NextResponse.json({
+    data: items.map(c => {
+      const childProfile = c.profiles as unknown as { display_name: string } | null
+      return {
+        id: c.id,
+        childId: c.child_id,
+        childName: childProfile?.display_name ?? 'Unknown',
+        messageCount: Array.isArray(c.messages) ? c.messages.length : 0,
+        createdAt: c.created_at,
+      }
+    }),
+    nextCursor: hasMore ? items[items.length - 1].created_at : null,
+  })
+}
+
+export const GET = withObservability(handler)

--- a/app/api/ai/quest-buddy/route.ts
+++ b/app/api/ai/quest-buddy/route.ts
@@ -1,0 +1,265 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+import { trackEvent } from '@/lib/observability/event-tracker'
+import {
+  buildKidSystemPrompt,
+  KID_SESSION_MESSAGE_LIMIT,
+  type KidContext,
+} from '@/lib/ai/prompts'
+import type { AiKidChat, ChatMessage } from '@/lib/types'
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ data: null })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id, role, display_name, points')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !profile.family_id) {
+    return NextResponse.json({ error: 'Profile not found' }, { status: 400 })
+  }
+
+  let body: { message?: unknown; chatId?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const message = typeof body.message === 'string' ? body.message.trim() : null
+  if (!message || message.length === 0 || message.length > 500) {
+    return NextResponse.json({ error: 'Invalid message' }, { status: 400 })
+  }
+  const chatId = typeof body.chatId === 'string' ? body.chatId : undefined
+
+  // Rate limit: dual cap (20/user + 50/family)
+  const { data: rateResult } = await supabase.rpc('check_and_increment_ai_rate_limit', {
+    p_family_id: profile.family_id,
+    p_user_id: user.id,
+  })
+  const rate = rateResult as { allowed: boolean; reason: string | null } | null
+  if (!rate?.allowed) {
+    const msg = rate?.reason === 'user_limit'
+      ? "You've reached your message limit for today (20). Try again tomorrow!"
+      : "Your family has reached today's message limit (50). Try again tomorrow!"
+    return NextResponse.json({ error: msg, reason: rate?.reason }, { status: 429 })
+  }
+
+  // Parent preview mode: stream without persisting a kid chat record
+  const isParentPreview = profile.role === 'parent'
+
+  // For kids: load or create chat session
+  let chat: AiKidChat | null = null
+  if (!isParentPreview) {
+    if (chatId) {
+      const { data } = await supabase
+        .from('ai_kid_chats')
+        .select('*')
+        .eq('id', chatId)
+        .single()
+      if (!data) {
+        return NextResponse.json({ error: 'Chat not found' }, { status: 404 })
+      }
+      chat = data as AiKidChat
+
+      // Enforce per-session message cap
+      if ((chat.messages as ChatMessage[]).length >= KID_SESSION_MESSAGE_LIMIT) {
+        return NextResponse.json(
+          { error: 'Session limit reached. Start a new chat!', reason: 'session_limit' },
+          { status: 429 }
+        )
+      }
+    } else {
+      const { data, error } = await supabase
+        .from('ai_kid_chats')
+        .insert({ child_id: user.id, family_id: profile.family_id, messages: [] })
+        .select()
+        .single()
+      if (error || !data) {
+        return NextResponse.json({ error: 'Failed to create chat' }, { status: 500 })
+      }
+      chat = data as AiKidChat
+    }
+  }
+
+  // Build kid context for system prompt
+  const kidContext = await buildKidContext(supabase, user.id, profile.family_id, profile)
+
+  const systemPrompt = buildKidSystemPrompt(kidContext)
+
+  const history = chat
+    ? (chat.messages as ChatMessage[]).slice(-10) // shorter history for kids
+    : []
+
+  const newUserMessage: ChatMessage = {
+    role: 'user',
+    content: message,
+    timestamp: new Date().toISOString(),
+  }
+
+  // Call Anthropic with streaming
+  const anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta': 'messages-2023-06-16',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 256, // shorter responses for kids
+      stream: true,
+      system: systemPrompt,
+      messages: [
+        ...history.map(m => ({ role: m.role, content: m.content })),
+        { role: 'user', content: message },
+      ],
+    }),
+    signal: AbortSignal.timeout(30000),
+  })
+
+  if (!anthropicRes.ok || !anthropicRes.body) {
+    return NextResponse.json({ error: 'AI unavailable' }, { status: 503 })
+  }
+
+  const streamStartTime = Date.now()
+  const encoder = new TextEncoder()
+  const sourceReader = anthropicRes.body.getReader()
+  let accumulatedText = ''
+  let lineBuffer = ''
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        while (true) {
+          const { done, value } = await sourceReader.read()
+          if (done) break
+          controller.enqueue(value)
+
+          // Parse for accumulation
+          lineBuffer += new TextDecoder().decode(value, { stream: true })
+          const lines = lineBuffer.split('\n')
+          /* istanbul ignore next */
+          lineBuffer = lines.pop() ?? ''
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            try {
+              const parsed = JSON.parse(line.slice(6)) as Record<string, unknown>
+              if (
+                parsed['type'] === 'content_block_delta' &&
+                (parsed['delta'] as Record<string, unknown>)?.['type'] === 'text_delta'
+              ) {
+                accumulatedText += (parsed['delta'] as Record<string, unknown>)['text'] as string
+              }
+            } catch {
+              // Skip non-JSON lines
+            }
+          }
+        }
+
+        const assistantMessage: ChatMessage = {
+          role: 'assistant',
+          content: accumulatedText,
+          timestamp: new Date().toISOString(),
+        }
+
+        let limitReached = false
+
+        // Persist for real kid sessions (not parent previews)
+        if (!isParentPreview && chat) {
+          await supabase.rpc('append_kid_chat_messages', {
+            p_id: chat.id,
+            p_messages: JSON.stringify([newUserMessage, assistantMessage]),
+          })
+
+          const newCount = (chat.messages as ChatMessage[]).length + 2
+          limitReached = newCount >= KID_SESSION_MESSAGE_LIMIT
+        }
+
+        trackEvent({
+          event_type: 'ai_kid_chat_message',
+          user_id: user.id,
+          family_id: profile.family_id!,
+          metadata: {
+            streamDurationMs: Date.now() - streamStartTime,
+            responseLength: accumulatedText.length,
+          },
+        })
+
+        controller.enqueue(
+          encoder.encode(
+            `event: chat_meta\ndata: ${JSON.stringify({
+              chatId: chat?.id ?? null,
+              limitReached,
+            })}\n\n`
+          )
+        )
+        controller.close()
+      } catch (err) {
+        /* istanbul ignore next */
+        controller.error(err)
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  }) as unknown as NextResponse
+}
+
+async function buildKidContext(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  familyId: string,
+  profile: { display_name: string; points: number; role: string }
+): Promise<KidContext> {
+  const today = new Date().toISOString().split('T')[0]
+
+  const [{ data: pendingTasks }, { data: recentCompletions }] = await Promise.all([
+    supabase
+      .from('tasks')
+      .select('title, points')
+      .eq('family_id', familyId)
+      .eq('assigned_to', userId)
+      .eq('completed', false)
+      .limit(5),
+    supabase
+      .from('task_completions')
+      .select('points_earned, completion_date')
+      .eq('completed_by', userId)
+      .gte('completion_date', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0])
+      .lte('completion_date', today)
+      .limit(10),
+  ])
+
+  return {
+    childName: profile.display_name,
+    points: profile.points,
+    pendingTasks: (pendingTasks ?? []).map(t => ({ title: t.title, points: t.points })),
+    recentCompletions: (recentCompletions ?? []).map(c => ({
+      pointsEarned: c.points_earned,
+      completionDate: c.completion_date ?? today,
+    })),
+  }
+}
+
+// Vercel Pro streaming timeout — read by Next.js/Vercel runtime
+export const maxDuration = 60
+export const POST = withObservability(handler)

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,8 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Hide other floating buttons while the chat window is open */
+body.chat-open .chat-hideable {
+  display: none;
+}

--- a/components/chat/chat-fab.tsx
+++ b/components/chat/chat-fab.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { ChatPanel } from './chat-panel'
+import type { QuickAction } from '@/lib/types'
+
+const PARENT_QUICK_ACTIONS: QuickAction[] = [
+  { label: '💡 Suggest quests', prompt: 'Suggest 3 age-appropriate chores for my kids based on their current quests.' },
+  { label: '📊 Weekly report', prompt: "Give me a summary of my family's quest progress this week." },
+  { label: '🌟 Motivation tips', prompt: 'My kids seem unmotivated lately. What are some strategies to re-engage them?' },
+  { label: '🎯 Points balance', prompt: 'How are my kids doing with their points? Any patterns I should know about?' },
+]
+
+const KID_QUICK_ACTIONS: QuickAction[] = [
+  { label: '🚀 What should I do?', prompt: 'Which quest should I do next?' },
+  { label: '⭐ My points', prompt: 'How many points do I have? What can I get?' },
+  { label: '🎉 I finished one!', prompt: 'I just finished a quest! Celebrate with me!' },
+  { label: '💪 I need help', prompt: "I'm stuck on a quest. Can you help me?" },
+]
+
+interface ChatFabProps {
+  role: 'parent' | 'child'
+}
+
+export function ChatFab({ role }: ChatFabProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const isParent = role === 'parent'
+
+  // Toggle a body class so other floating buttons can hide while chat is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add('chat-open')
+    } else {
+      document.body.classList.remove('chat-open')
+    }
+    return () => {
+      document.body.classList.remove('chat-open')
+    }
+  }, [isOpen])
+
+  return (
+    <>
+      {/* Chat window */}
+      {isOpen && (
+        <>
+          {/* Backdrop on mobile */}
+          <div
+            className="fixed inset-0 bg-black/30 z-40 sm:hidden"
+            onClick={() => setIsOpen(false)}
+          />
+          <div
+            className="fixed z-50 right-4 w-[calc(100vw-2rem)] sm:w-96 rounded-2xl shadow-2xl border border-gray-200 bg-white overflow-hidden flex flex-col"
+            style={{ bottom: '4rem', top: '2rem' }}
+          >
+            {/* Close button */}
+            <button
+              onClick={() => setIsOpen(false)}
+              className="absolute top-2 right-2 z-10 w-8 h-8 rounded-full bg-white/80 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-white transition"
+              aria-label="Close chat"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+
+            <ChatPanel
+              apiEndpoint={isParent ? '/api/ai/chat' : '/api/ai/quest-buddy'}
+              systemName={isParent ? 'Parenting Assistant' : 'Quest Buddy'}
+              theme={isParent ? 'parent' : 'kid'}
+              quickActions={isParent ? PARENT_QUICK_ACTIONS : KID_QUICK_ACTIONS}
+              maxMessages={isParent ? undefined : 20}
+            />
+          </div>
+        </>
+      )}
+
+      {/* FAB button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        style={{ bottom: '5rem' }}
+        className={`fixed right-4 z-40 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all ${
+          isOpen
+            ? 'bg-gray-500 hover:bg-gray-600 rotate-0'
+            : isParent
+              ? 'bg-purple-600 hover:bg-purple-700'
+              : 'bg-gradient-to-br from-yellow-400 to-pink-500 hover:opacity-90'
+        }`}
+        aria-label={isOpen ? 'Close chat' : 'Open chat'}
+      >
+        {isOpen ? (
+          <svg className="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg className="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+          </svg>
+        )}
+      </button>
+    </>
+  )
+}

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils'
+import type { ChatMessage } from '@/lib/types'
+
+interface ChatMessageProps {
+  message: ChatMessage
+  theme: 'parent' | 'kid'
+  /** When true, renders the streaming bubble (no timestamp) */
+  isStreaming?: boolean
+}
+
+export function ChatMessageBubble({ message, theme, isStreaming = false }: ChatMessageProps) {
+  const isUser = message.role === 'user'
+
+  const assistantBg = theme === 'kid' ? 'bg-green-100 text-green-900' : 'bg-purple-100 text-purple-900'
+
+  return (
+    <div
+      className={cn(
+        'flex w-full',
+        isUser ? 'justify-end' : 'justify-start'
+      )}
+    >
+      <div
+        className={cn(
+          'max-w-[80%] rounded-2xl px-4 py-2 text-sm leading-relaxed',
+          isUser
+            ? 'bg-gray-800 text-white rounded-br-sm'
+            : cn(assistantBg, 'rounded-bl-sm')
+        )}
+      >
+        <p className="whitespace-pre-wrap break-words">{message.content}</p>
+        {!isStreaming && (
+          <time
+            className={cn(
+              'block text-xs mt-1 opacity-60',
+              isUser ? 'text-right' : 'text-left'
+            )}
+            dateTime={message.timestamp}
+          >
+            {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          </time>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -1,0 +1,259 @@
+'use client'
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { consumeSseStream } from '@/lib/ai/stream-helpers'
+import { ChatMessageBubble } from './chat-message'
+import { TypingIndicator } from './typing-indicator'
+import { QuickActions } from './quick-actions'
+import type { ChatMessage, QuickAction } from '@/lib/types'
+
+interface ChatPanelProps {
+  apiEndpoint: '/api/ai/chat' | '/api/ai/quest-buddy'
+  systemName: string
+  theme: 'parent' | 'kid'
+  quickActions: QuickAction[]
+  /** Kid session cap (number of messages) */
+  maxMessages?: number
+  conversationId?: string
+  initialMessages?: ChatMessage[]
+  onConversationCreated?: (id: string) => void
+}
+
+export function ChatPanel({
+  apiEndpoint,
+  systemName,
+  theme,
+  quickActions,
+  maxMessages,
+  conversationId: initialConversationId,
+  initialMessages = [],
+  onConversationCreated,
+}: ChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages)
+  const [streamingContent, setStreamingContent] = useState('')
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [inputValue, setInputValue] = useState('')
+  const [conversationId, setConversationId] = useState<string | null>(initialConversationId ?? null)
+  const [limitReached, setLimitReached] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  const isInputDisabled = isStreaming || limitReached
+
+  const headerBg = theme === 'kid'
+    ? 'bg-gradient-to-r from-yellow-400 to-pink-500'
+    : 'bg-purple-600'
+
+  // Scroll to bottom on new messages or streaming content
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, streamingContent])
+
+  const sendMessage = useCallback(async (text: string) => {
+    const trimmed = text.trim()
+    if (!trimmed || isStreaming || limitReached) return
+
+    setError(null)
+    setInputValue('')
+
+    const userMessage: ChatMessage = {
+      role: 'user',
+      content: trimmed,
+      timestamp: new Date().toISOString(),
+    }
+
+    // Optimistic update
+    setMessages(prev => [...prev, userMessage])
+    setIsStreaming(true)
+    setStreamingContent('')
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const idKey = apiEndpoint === '/api/ai/chat' ? 'conversationId' : 'chatId'
+
+    try {
+      const res = await fetch(apiEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: trimmed, [idKey]: conversationId ?? undefined }),
+        signal: controller.signal,
+      })
+
+      if (!res.ok) {
+        // Remove the optimistic user message on error
+        setMessages(prev => prev.filter(m => m !== userMessage))
+        if (res.status === 429) {
+          const data = await res.json() as { error?: string }
+          setError(data.error ?? "You've reached the message limit. Try again tomorrow!")
+        } else if (res.status === 503) {
+          setError('Chat is temporarily unavailable. Please try again in a moment.')
+        } else {
+          setError("Something went wrong. Please try again.")
+        }
+        return
+      }
+
+      if (!res.body) {
+        setMessages(prev => prev.filter(m => m !== userMessage))
+        setError('No response received.')
+        return
+      }
+
+      const fullText = await consumeSseStream(
+        res.body,
+        (accumulated) => setStreamingContent(accumulated),
+        (meta) => {
+          const m = meta as { conversationId?: string; chatId?: string; title?: string; limitReached?: boolean }
+          const newId = m.conversationId ?? m.chatId ?? null
+          if (newId && newId !== conversationId) {
+            setConversationId(newId)
+            onConversationCreated?.(newId)
+          }
+          if (m.limitReached) setLimitReached(true)
+        },
+        controller.signal
+      )
+
+      const assistantMessage: ChatMessage = {
+        role: 'assistant',
+        content: fullText || '(no response)',
+        timestamp: new Date().toISOString(),
+      }
+      setMessages(prev => [...prev, assistantMessage])
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setMessages(prev => prev.filter(m => m !== userMessage))
+        setError('Connection interrupted. Please try again.')
+      }
+    } finally {
+      setStreamingContent('')
+      setIsStreaming(false)
+      abortRef.current = null
+      inputRef.current?.focus()
+    }
+  }, [apiEndpoint, conversationId, isStreaming, limitReached, onConversationCreated])
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void sendMessage(inputValue)
+    }
+  }
+
+  const showEmpty = messages.length === 0 && !isStreaming
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <header className={`${headerBg} text-white px-4 py-3 flex-shrink-0`}>
+        <h1 className="text-lg font-bold">{systemName}</h1>
+      </header>
+
+      {/* Message area */}
+      <div
+        className="flex-1 overflow-y-auto px-4 py-4 space-y-3"
+        role="log"
+        aria-label="Chat messages"
+        aria-live="polite"
+      >
+        {showEmpty && (
+          <p className="text-center text-gray-500 text-sm mt-8">
+            {theme === 'kid'
+              ? '👋 Hi! I\'m your Quest Buddy. What do you want to do?'
+              : 'Ask me anything about your family\'s quests and progress!'}
+          </p>
+        )}
+
+        {messages.map((msg, i) => (
+          <ChatMessageBubble key={i} message={msg} theme={theme} />
+        ))}
+
+        {/* Streaming bubble */}
+        {isStreaming && (
+          <div className="flex justify-start">
+            <div className={`max-w-[80%] rounded-2xl rounded-bl-sm px-4 py-2 text-sm leading-relaxed ${theme === 'kid' ? 'bg-green-100 text-green-900' : 'bg-purple-100 text-purple-900'}`}>
+              {streamingContent ? (
+                <p className="whitespace-pre-wrap break-words">{streamingContent}</p>
+              ) : (
+                <TypingIndicator />
+              )}
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="mx-4 mb-2 px-3 py-2 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
+          {error}
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            className="ml-2 text-red-400 hover:text-red-600"
+            aria-label="Dismiss error"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* Limit reached banner */}
+      {limitReached && (
+        <div className="mx-4 mb-2 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700 text-center">
+          {maxMessages
+            ? "That's all for now! Start a new chat anytime 🌟"
+            : 'Start a new conversation to continue 💬'}
+        </div>
+      )}
+
+      {/* Input area */}
+      <div className="flex-shrink-0 border-t border-gray-200 bg-white px-4 pt-3 pb-4 space-y-2">
+        {quickActions.length > 0 && (
+          <QuickActions
+            actions={quickActions}
+            onSelect={(prompt) => {
+              setInputValue(prompt)
+              inputRef.current?.focus()
+            }}
+            disabled={isInputDisabled}
+          />
+        )}
+
+        <div className="flex items-end gap-2">
+          <label htmlFor="chat-input" className="sr-only">
+            Message
+          </label>
+          <textarea
+            id="chat-input"
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={isInputDisabled ? '' : 'Type a message…'}
+            disabled={isInputDisabled}
+            rows={1}
+            className="flex-1 resize-none rounded-xl border border-gray-200 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400 disabled:bg-gray-50 disabled:text-gray-400"
+            style={{ maxHeight: '120px', overflowY: 'auto' }}
+            aria-label="Message input"
+          />
+          <button
+            type="button"
+            onClick={() => void sendMessage(inputValue)}
+            disabled={isInputDisabled || !inputValue.trim()}
+            aria-label="Send message"
+            className="flex-shrink-0 w-10 h-10 rounded-xl bg-purple-600 text-white flex items-center justify-center hover:bg-purple-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/chat/conversation-list.tsx
+++ b/components/chat/conversation-list.tsx
@@ -1,0 +1,69 @@
+import { cn } from '@/lib/utils'
+
+export interface ConversationSummary {
+  id: string
+  title: string | null
+  updatedAt: string
+  messageCount: number
+}
+
+interface ConversationListProps {
+  conversations: ConversationSummary[]
+  activeId: string | null
+  onSelect: (id: string) => void
+  loading?: boolean
+}
+
+export function ConversationList({
+  conversations,
+  activeId,
+  onSelect,
+  loading = false,
+}: ConversationListProps) {
+  if (loading) {
+    return (
+      <div className="space-y-2 p-2">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-14 rounded-lg bg-gray-100 animate-pulse" />
+        ))}
+      </div>
+    )
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 text-center py-6 px-4">
+        No conversations yet. Start a new one!
+      </p>
+    )
+  }
+
+  return (
+    <ul className="space-y-1 p-2" role="listbox" aria-label="Conversations">
+      {conversations.map(convo => (
+        <li key={convo.id}>
+          <button
+            type="button"
+            role="option"
+            aria-selected={convo.id === activeId}
+            onClick={() => onSelect(convo.id)}
+            className={cn(
+              'w-full text-left rounded-lg px-3 py-2.5 transition',
+              convo.id === activeId
+                ? 'bg-purple-100 text-purple-900'
+                : 'hover:bg-gray-100 text-gray-700'
+            )}
+          >
+            <p className="text-sm font-medium truncate">
+              {convo.title ?? 'New conversation'}
+            </p>
+            <p className="text-xs text-gray-500 mt-0.5">
+              {convo.messageCount} message{convo.messageCount !== 1 ? 's' : ''} ·{' '}
+              {new Date(convo.updatedAt).toLocaleDateString()}
+            </p>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/components/chat/quick-actions.tsx
+++ b/components/chat/quick-actions.tsx
@@ -1,0 +1,29 @@
+import type { QuickAction } from '@/lib/types'
+
+interface QuickActionsProps {
+  actions: QuickAction[]
+  onSelect: (prompt: string) => void
+  disabled?: boolean
+}
+
+export function QuickActions({ actions, onSelect, disabled = false }: QuickActionsProps) {
+  return (
+    <div
+      className="flex gap-2 overflow-x-auto pb-1 no-scrollbar"
+      role="group"
+      aria-label="Quick actions"
+    >
+      {actions.map(action => (
+        <button
+          key={action.label}
+          type="button"
+          onClick={() => onSelect(action.prompt)}
+          disabled={disabled}
+          className="flex-shrink-0 px-3 py-1.5 text-xs font-medium rounded-full border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/chat/typing-indicator.tsx
+++ b/components/chat/typing-indicator.tsx
@@ -1,0 +1,10 @@
+// Animated "assistant is typing" indicator — three bouncing dots
+export function TypingIndicator() {
+  return (
+    <div className="flex items-center gap-1 px-3 py-2" aria-label="Assistant is typing">
+      <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
+      <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
+      <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
+    </div>
+  )
+}

--- a/components/layout/nav-bar.tsx
+++ b/components/layout/nav-bar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 
-const navItems = [
+const BASE_NAV_ITEMS = [
   {
     label: 'Me',
     href: '/me',
@@ -43,8 +43,25 @@ const navItems = [
   },
 ]
 
-export function NavBar() {
+const CHAT_NAV_ITEM = {
+  label: 'Chat',
+  href: '/chat',
+  icon: (
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+    </svg>
+  ),
+}
+
+interface NavBarProps {
+  role?: 'parent' | 'child'
+}
+
+export function NavBar({ role }: NavBarProps) {
   const pathname = usePathname()
+
+  // Parents get a Chat nav item; kids use the Quest Buddy FAB on the quests page instead
+  const navItems = role === 'parent' ? [...BASE_NAV_ITEMS, CHAT_NAV_ITEM] : BASE_NAV_ITEMS
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 safe-area-bottom">

--- a/components/layout/nav-bar.tsx
+++ b/components/layout/nav-bar.tsx
@@ -43,16 +43,6 @@ const BASE_NAV_ITEMS = [
   },
 ]
 
-const CHAT_NAV_ITEM = {
-  label: 'Chat',
-  href: '/chat',
-  icon: (
-    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-    </svg>
-  ),
-}
-
 interface NavBarProps {
   role?: 'parent' | 'child'
 }
@@ -60,8 +50,7 @@ interface NavBarProps {
 export function NavBar({ role }: NavBarProps) {
   const pathname = usePathname()
 
-  // Parents get a Chat nav item; kids use the Quest Buddy FAB on the quests page instead
-  const navItems = role === 'parent' ? [...BASE_NAV_ITEMS, CHAT_NAV_ITEM] : BASE_NAV_ITEMS
+  const navItems = BASE_NAV_ITEMS
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 safe-area-bottom">

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Chat FAB', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/quests')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
+  })
+
+  test('shows chat FAB on quests page', async ({ page }) => {
+    const fab = page.getByRole('button', { name: 'Open chat' })
+    await expect(fab).toBeVisible()
+  })
+
+  test('opens chat window with Parenting Assistant header', async ({ page }) => {
+    await page.getByRole('button', { name: 'Open chat' }).click()
+    await expect(page.getByText('Parenting Assistant')).toBeVisible()
+  })
+
+  test('shows quick action buttons in chat window', async ({ page }) => {
+    await page.getByRole('button', { name: 'Open chat' }).click()
+    await expect(page.getByText('Suggest quests')).toBeVisible()
+    await expect(page.getByText('Weekly report')).toBeVisible()
+  })
+
+  test('shows message input in chat window', async ({ page }) => {
+    await page.getByRole('button', { name: 'Open chat' }).click()
+    await expect(page.getByPlaceholder('Type a message…')).toBeVisible()
+  })
+
+  test('closes chat window via close button', async ({ page }) => {
+    await page.getByRole('button', { name: 'Open chat' }).click()
+    await expect(page.getByText('Parenting Assistant')).toBeVisible()
+    await page.getByRole('button', { name: 'Close chat' }).first().click()
+    await expect(page.getByText('Parenting Assistant')).not.toBeVisible()
+  })
+
+  test('add-quest FAB is accessible after closing chat', async ({ page }) => {
+    // Open chat
+    await page.getByRole('button', { name: 'Open chat' }).click()
+    await expect(page.getByText('Parenting Assistant')).toBeVisible()
+    // Close chat
+    await page.getByRole('button', { name: 'Close chat' }).first().click()
+    await expect(page.getByText('Parenting Assistant')).not.toBeVisible()
+    // Add-quest FAB should be visible and clickable
+    const addFab = page.getByTestId('add-quest-fab')
+    await expect(addFab).toBeVisible()
+    await addFab.click()
+    await expect(page.getByText('New Quest')).toBeVisible()
+  })
+
+  test('chat FAB visible on rewards page', async ({ page }) => {
+    await page.goto('/rewards')
+    await page.waitForLoadState('networkidle')
+    const fab = page.getByRole('button', { name: 'Open chat' })
+    await expect(fab).toBeVisible()
+  })
+
+  test('chat FAB visible on family page', async ({ page }) => {
+    await page.goto('/family')
+    await page.waitForLoadState('networkidle')
+    const fab = page.getByRole('button', { name: 'Open chat' })
+    await expect(fab).toBeVisible()
+  })
+})

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -19,7 +19,7 @@ export async function createTestTask(
     : optionsOrRecurring || {}
 
   // Click FAB button to open form
-  const fab = page.locator('button.fixed.bg-purple-600')
+  const fab = page.getByTestId('add-quest-fab')
   await fab.click()
 
   // Wait for modal to open

--- a/e2e/nl-quest-creation.spec.ts
+++ b/e2e/nl-quest-creation.spec.ts
@@ -38,7 +38,7 @@ test.describe('Natural Language Quest Creation', () => {
     createdTaskNames.push(taskName)
 
     // Open the New Quest modal
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 
@@ -72,7 +72,7 @@ test.describe('Natural Language Quest Creation', () => {
     })
 
     // Open the New Quest modal
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 
@@ -126,7 +126,7 @@ test.describe('Natural Language Quest Creation', () => {
     })
 
     // Open the New Quest modal
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 

--- a/e2e/permissions.spec.ts
+++ b/e2e/permissions.spec.ts
@@ -51,13 +51,13 @@ test.describe('Child Permissions', () => {
     }
   })
 
-  test('child sees Quest Buddy FAB, not add task FAB', async ({ page }) => {
-    // Children should see the Quest Buddy link FAB, not the purple add task button
-    const questBuddyFab = page.locator('a[href="/quest-buddy"].fixed')
-    await expect(questBuddyFab).toBeVisible()
+  test('child sees chat FAB, not add task FAB', async ({ page }) => {
+    // Children should see the chat FAB (Quest Buddy), not the add task button
+    const chatFab = page.getByRole('button', { name: 'Open chat' })
+    await expect(chatFab).toBeVisible()
 
-    // The purple add task FAB should not be visible for children
-    const addTaskFab = page.locator('button.fixed.bg-purple-600')
+    // The add task FAB should not be visible for children
+    const addTaskFab = page.getByTestId('add-quest-fab')
     await expect(addTaskFab).not.toBeVisible()
   })
 

--- a/e2e/permissions.spec.ts
+++ b/e2e/permissions.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test'
-import { createTestTask, getTaskCard, cleanupTestTask } from './helpers'
+import { getTaskCard, cleanupTestTask } from './helpers'
+import { runSQL } from './supabase-admin'
+import { TEST_CHILD_EMAIL, TEST_FAMILY_NAME } from './test-constants'
 
 /**
  * Permission tests - verify role-based access control
@@ -8,6 +10,28 @@ import { createTestTask, getTaskCard, cleanupTestTask } from './helpers'
 
 // Track task names for cleanup
 let createdTaskNames: string[] = []
+
+/**
+ * Creates a task directly via SQL for a given child user (bypasses UI).
+ * Children no longer have a FAB to create tasks — only parents do.
+ */
+async function createTaskForChild(taskName: string): Promise<void> {
+  await runSQL(`
+    INSERT INTO tasks (title, points, due_date, family_id, created_by)
+    SELECT
+      '${taskName}',
+      5,
+      CURRENT_DATE,
+      p.family_id,
+      p.id
+    FROM profiles p
+    JOIN auth.users u ON u.id = p.id
+    JOIN families f ON f.id = p.family_id
+    WHERE u.email = '${TEST_CHILD_EMAIL}'
+      AND f.name = '${TEST_FAMILY_NAME}'
+    LIMIT 1;
+  `)
+}
 
 test.describe('Child Permissions', () => {
   // Use child authentication
@@ -27,23 +51,26 @@ test.describe('Child Permissions', () => {
     }
   })
 
-  test('child can create a task', async ({ page }) => {
-    const taskName = `Child Task ${Date.now()}`
-    createdTaskNames.push(taskName)
+  test('child sees Quest Buddy FAB, not add task FAB', async ({ page }) => {
+    // Children should see the Quest Buddy link FAB, not the purple add task button
+    const questBuddyFab = page.locator('a[href="/quest-buddy"].fixed')
+    await expect(questBuddyFab).toBeVisible()
 
-    await createTestTask(page, taskName)
-
-    // Task should be visible
-    await expect(page.getByText(taskName)).toBeVisible()
+    // The purple add task FAB should not be visible for children
+    const addTaskFab = page.locator('button.fixed.bg-purple-600')
+    await expect(addTaskFab).not.toBeVisible()
   })
 
   test('child can delete their own task', async ({ page }) => {
     const taskName = `Child Delete Own ${Date.now()}`
 
-    // Create a task as child
-    await createTestTask(page, taskName)
+    // Create a task as child via SQL (children no longer have add task FAB)
+    await createTaskForChild(taskName)
+    await page.reload()
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
 
     // Find the task and verify delete button is visible
+    await expect(page.getByText(taskName)).toBeVisible({ timeout: 5000 })
     const taskCard = getTaskCard(page, taskName)
     await expect(taskCard.getByTitle('Delete quest')).toBeVisible()
 
@@ -61,10 +88,13 @@ test.describe('Child Permissions', () => {
     const newTaskName = `Child Edited ${Date.now()}`
     createdTaskNames.push(newTaskName)
 
-    // Create a task as child
-    await createTestTask(page, taskName)
+    // Create a task as child via SQL (children no longer have add task FAB)
+    await createTaskForChild(taskName)
+    await page.reload()
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
 
     // Find the task and verify edit button is visible
+    await expect(page.getByText(taskName)).toBeVisible({ timeout: 5000 })
     const taskCard = getTaskCard(page, taskName)
     await expect(taskCard.getByTitle('Edit quest')).toBeVisible()
 
@@ -85,10 +115,13 @@ test.describe('Child Permissions', () => {
     const taskName = `Child Complete ${Date.now()}`
     createdTaskNames.push(taskName)
 
-    // Create a task
-    await createTestTask(page, taskName)
+    // Create a task as child via SQL (children no longer have add task FAB)
+    await createTaskForChild(taskName)
+    await page.reload()
+    await expect(page.locator('.animate-spin')).not.toBeVisible({ timeout: 10000 })
 
-    // Complete it
+    // Find and complete the task
+    await expect(page.getByText(taskName)).toBeVisible({ timeout: 5000 })
     const taskCard = getTaskCard(page, taskName)
     await taskCard.locator('button.border-gray-300').click()
 

--- a/e2e/quests.spec.ts
+++ b/e2e/quests.spec.ts
@@ -34,8 +34,7 @@ test.describe('Quests Page', () => {
   })
 
   test('displays FAB button to add quest', async ({ page }) => {
-    // FAB button with + icon
-    const fab = page.locator('button.fixed').filter({ hasText: '' })
+    const fab = page.getByTestId('add-quest-fab')
     await expect(fab).toBeVisible()
   })
 
@@ -129,7 +128,7 @@ test.describe('Quests Page', () => {
 
   test('can open task form via FAB', async ({ page }) => {
     // Click FAB button
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
 
     // Task form modal should open - look for the heading specifically
@@ -395,7 +394,7 @@ test.describe('Quests Page', () => {
     createdTaskNames.push(taskName)
 
     // Get a family member name to assign to (from the Assign To dropdown)
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 
@@ -450,7 +449,7 @@ test.describe('Quests Page', () => {
     createdTaskNames.push(taskName)
 
     // Click FAB button to open form
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 
@@ -507,7 +506,7 @@ test.describe('Quests Page', () => {
     createdTaskNames.push(taskName)
 
     // Click FAB to open form
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 
@@ -533,7 +532,7 @@ test.describe('Quests Page', () => {
     createdTaskNames.push(taskName)
 
     // Open the form to check available members
-    const fab = page.locator('button.fixed.bg-purple-600')
+    const fab = page.getByTestId('add-quest-fab')
     await fab.click()
     await expect(page.getByRole('heading', { name: 'New Quest' })).toBeVisible()
 

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -1,0 +1,64 @@
+// System prompt builders and constants for AI chat features
+
+export const CONVERSATION_HISTORY_LIMIT = 20 // last 10 exchanges sent to Anthropic
+export const CONVERSATION_MESSAGE_LIMIT = 100 // max messages per parent conversation (50 exchanges)
+export const KID_SESSION_MESSAGE_LIMIT = 20 // max messages per kid chat session
+
+export interface ParentContext {
+  familyName: string
+  children: Array<{ displayName: string; points: number }>
+  recentTasks: Array<{ title: string; assignedTo: string; points: number; completed: boolean }>
+}
+
+export interface KidContext {
+  childName: string
+  points: number
+  pendingTasks: Array<{ title: string; points: number }>
+  recentCompletions: Array<{ pointsEarned: number; completionDate: string }>
+}
+
+export function buildParentSystemPrompt(ctx: ParentContext): string {
+  const childrenStr = ctx.children.length > 0
+    ? ctx.children.map(c => `${c.displayName} (${c.points} points)`).join(', ')
+    : 'No children yet'
+
+  const tasksStr = ctx.recentTasks.length > 0
+    ? ctx.recentTasks.slice(0, 10).map(t => t.title).join(', ')
+    : 'No active quests'
+
+  return `You are a supportive parenting assistant for the ${ctx.familyName} family.
+
+Family context:
+- Children: ${childrenStr}
+- Active quests: ${tasksStr}
+
+You help parents with:
+- Age-appropriate chore suggestions
+- Motivation strategies for kids
+- Weekly summaries of family progress
+- Addressing specific behavioral patterns
+
+Keep responses warm, practical, and under 200 words. Use the family's actual names and quest data when relevant.`
+}
+
+export function buildKidSystemPrompt(ctx: KidContext): string {
+  const pendingStr = ctx.pendingTasks.length > 0
+    ? ctx.pendingTasks.map(t => `"${t.title}" (${t.points} pts)`).join(', ')
+    : 'No pending quests right now'
+
+  return `You are ${ctx.childName}'s Quest Buddy! You're an encouraging, fun sidekick character.
+
+${ctx.childName}'s stats:
+- Points: ${ctx.points} ⭐
+- Pending quests: ${pendingStr}
+
+Rules:
+- Use simple, fun, age-appropriate language
+- Be enthusiastic and encouraging (use emojis!)
+- Keep responses SHORT (2-4 sentences max)
+- Only talk about quests, points, and being awesome
+- Never ask for or share personal information
+- If asked about something unrelated, redirect to quests
+
+You can help ${ctx.childName} decide which quest to do next, celebrate completions, and share encouraging words!`
+}

--- a/lib/ai/stream-helpers.ts
+++ b/lib/ai/stream-helpers.ts
@@ -1,0 +1,71 @@
+/**
+ * Consumes an Anthropic SSE stream with proper line buffering.
+ *
+ * Calls onToken with the accumulated text after each text_delta event.
+ * Calls onMeta when a custom 'conversation_meta' or 'chat_meta' event arrives.
+ * Returns the full assistant message text when the stream ends.
+ *
+ * Supports AbortSignal for cancellation.
+ */
+export async function consumeSseStream(
+  body: ReadableStream<Uint8Array>,
+  onToken: (accumulated: string) => void,
+  onMeta?: (meta: Record<string, unknown>) => void,
+  signal?: AbortSignal
+): Promise<string> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let fullContent = ''
+  let nextEventType = ''
+
+  try {
+    while (true) {
+      if (signal?.aborted) break
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      /* istanbul ignore next */
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (line.startsWith('event: ')) {
+          nextEventType = line.slice(7).trim()
+          continue
+        }
+        if (!line.startsWith('data: ')) continue
+        const data = line.slice(6).trim()
+        if (!data) continue
+
+        try {
+          const parsed = JSON.parse(data) as Record<string, unknown>
+
+          // Handle custom metadata events sent after the stream body
+          if (nextEventType === 'conversation_meta' || nextEventType === 'chat_meta') {
+            onMeta?.(parsed)
+            nextEventType = ''
+            continue
+          }
+          nextEventType = ''
+
+          // Handle Anthropic streaming text deltas
+          if (
+            parsed['type'] === 'content_block_delta' &&
+            (parsed['delta'] as Record<string, unknown>)?.['type'] === 'text_delta'
+          ) {
+            fullContent += (parsed['delta'] as Record<string, unknown>)['text'] as string
+            onToken(fullContent)
+          }
+        } catch {
+          // Skip malformed lines — non-JSON SSE comments are expected
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  return fullContent
+}

--- a/lib/observability/constants.ts
+++ b/lib/observability/constants.ts
@@ -8,6 +8,9 @@ export const APP_EVENT_TYPES = [
   'ai_insight_generated',
   'ai_encouragement_generated',
   'ai_quest_parsed',
+  'ai_parent_chat_message',
+  'ai_kid_chat_message',
+  'ai_chat_conversation_created',
   'api_request',
   'rpc_call',
   'page_view',
@@ -46,6 +49,9 @@ export const ALLOWED_METADATA_KEYS = new Set([
   'error',
   'errorCode',
   'componentStack',
+  'conversationId',
+  'streamDurationMs',
+  'responseLength',
 ])
 
 export const METADATA_MAX_BYTES = 10 * 1024 // 10KB per metadata object

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -548,6 +548,39 @@ export const REWARD_ICON_OPTIONS = [
   { id: 'rocket', label: 'Rocket', emoji: '🚀' },
 ] as const
 
+// ============================================================
+// AI Chat types
+// ============================================================
+
+export type ChatMessage = {
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: string // ISO 8601
+}
+
+export type AiConversation = {
+  id: string
+  family_id: string
+  parent_id: string
+  messages: ChatMessage[]
+  title: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type AiKidChat = {
+  id: string
+  child_id: string
+  family_id: string
+  messages: ChatMessage[]
+  created_at: string
+}
+
+export type QuickAction = {
+  label: string
+  prompt: string
+}
+
 // Default rewards seeded for new families — parents can edit or delete these
 export const DEFAULT_REWARDS: readonly {
   title: string

--- a/plans/issue-66-68-ai-chat.md
+++ b/plans/issue-66-68-ai-chat.md
@@ -1,0 +1,1076 @@
+# Final Plan: AI Chat Features — Parenting Assistant (#66) & Quest Buddy (#68)
+
+## Executive Summary
+
+Chore Champions needs two conversational AI chat interfaces: a **Parenting Assistant** for parents (context-aware family advice) and a **Quest Buddy** for kids (encouraging sidekick). This plan adds streaming SSE chat via the existing raw-fetch Anthropic API pattern, persists conversations in two new Supabase tables with RLS isolation, and shares a themeable `ChatPanel` client component between both features. The key architectural insight is **server-authoritative history**: the client sends only the new message and a conversation ID — the server loads history from the DB, streams the response while accumulating it server-side, and persists both messages atomically after the stream completes.
+
+---
+
+## Problem Analysis
+
+### Functional Requirements
+
+1. **Parent chat with AI** — multi-turn conversation with persistent history, context-aware (family data, children, quests)
+2. **Kid chat with AI** — short, encouraging exchanges with quest/points context, age-appropriate safety guardrails
+3. **Streaming responses** — token-by-token display via SSE (new for this codebase)
+4. **Conversation persistence** — survives page reloads, resumable
+5. **Conversation listing** — parents see their chats + kids' chat history
+6. **Quick action buttons** — pre-configured prompts for common queries
+7. **Rate limiting** — 50 messages/day per family, 20/user sub-cap, 20 messages/kid session
+
+### Non-Functional Requirements
+
+- **Latency**: First token within 1.5s (Haiku model is fast)
+- **Safety**: Kid chat stays on-topic via system prompt; no PII; parent can review history
+- **Cost**: Haiku model + max_tokens cap + rate limits keep costs under control
+- **Mobile-first**: Full-page chat views (no slide-out panels)
+- **Accessibility**: Semantic HTML, keyboard accessible, `role="log"` on message area
+- **Reliability**: No lost messages on normal usage; graceful degradation on AI unavailability
+- **100% unit test coverage** on all new code
+
+### Constraints
+
+- Raw `fetch()` to Anthropic API — no `@anthropic-ai/sdk` (existing pattern)
+- Model: `claude-haiku-4-5-20251001` (fixed)
+- Next.js 16 App Router, React 19, TypeScript strict, Supabase, Tailwind CSS v4
+- Server Components by default; `'use client'` only when needed
+- Sequential migration naming (next is `016_`)
+- RLS on all new tables
+- `withObservability()` on all new API routes
+
+### Priority Ordering
+
+1. **Correctness** — messages must persist reliably, history must be server-authoritative
+2. **Safety** — kid guardrails, RLS isolation, rate limiting
+3. **UX** — streaming feels responsive, quick actions reduce friction
+4. **Simplicity** — minimal new patterns, reuse existing codebase conventions
+
+---
+
+## Design Comparison
+
+### 1. Message Persistence Strategy
+
+**Design A** (refined): Client-side save. API route pipes SSE directly to client. After client's reader loop completes, client makes a separate POST to `/api/ai/conversations/save` to persist both messages.
+
+**Design B** (refined): Server-side persistence via `ReadableStream` with async `start()`. Server reads from Anthropic, enqueues chunks to client, accumulates text, and persists after the streaming loop completes but before `controller.close()`.
+
+**Selected: Design B's server-side persistence.** The `ReadableStream` async `start()` pattern is the standard Next.js App Router way to handle streaming. The function stays alive until `controller.close()` is called, so persistence code runs reliably. Design A's client-side save introduces an extra endpoint, an extra round-trip, and loses messages if the user closes the tab before the save fires. Both approaches lose messages if the client disconnects mid-stream, but B has the partial accumulated text available for potential recovery.
+
+### 2. Rate Limiting
+
+**Design A** (refined): Dual-cap — 50/family/day AND 20/user/day via a `check_and_increment_ai_rate_limit` Postgres function with rollback on block.
+
+**Design B** (refined): Family-only cap — 50/family/day via a simple `ai_daily_usage` table with atomic upsert.
+
+**Selected: Merged approach.** Use Design B's simpler `ai_daily_usage` table structure but add Design A's per-user sub-cap. The dual-cap prevents one family member from monopolizing the daily budget. Use a single Postgres function that checks both caps atomically.
+
+### 3. Concurrent JSONB Writes
+
+**Design A** (refined): Optimistic concurrency with `expectedMessageCount` — client tracks message count, save route returns 409 on conflict.
+
+**Design B** (refined): Atomic append via `append_chat_messages` Postgres RPC — `messages || p_messages` serializes at the row lock.
+
+**Selected: Design B's atomic append RPC.** It's simpler, requires no client-side conflict handling, and PostgreSQL row-level locking ensures no lost messages. The optimistic concurrency approach adds complexity (409 handling, re-sync logic) for a scenario that's extremely rare in a family app.
+
+### 4. History Sent to Anthropic
+
+**Design A**: No truncation specified.
+
+**Design B** (refined): Truncate to last 20 messages before sending to Anthropic.
+
+**Selected: Design B's truncation.** Essential for cost control and staying within context window limits. 20 messages (10 exchanges) provides sufficient conversational context.
+
+### 5. Kid RLS Policies
+
+**Design A**: Separate SELECT/INSERT/UPDATE policies (no DELETE) — correctly restricts kids from deleting chat history.
+
+**Design B** (refined): Same approach — explicit policies without DELETE.
+
+**Selected: Both agree.** Separate policies without DELETE, enforcing append-only at the RLS layer.
+
+### 6. SSE Client-Side Parsing
+
+**Design A** (refined): Dedicated `consumeSseStream()` utility in `lib/ai/stream-helpers.ts` with proper line buffering, `AbortController` support, and clean interface.
+
+**Design B** (refined): Inline line buffering in the `ChatPanel` component.
+
+**Selected: Design A's `consumeSseStream()` utility.** Extracting this into a testable utility function is cleaner, more testable, and follows the project's code quality standards. The function returns a Promise<string> with the full accumulated text, making the ChatPanel code straightforward.
+
+### 7. Conversation List API
+
+**Design A**: Single `GET /api/ai/conversations` endpoint with LIMIT 20.
+
+**Design B** (refined): Cursor-based pagination + separate `GET /api/ai/chat/conversations/[id]` endpoint for loading a single conversation.
+
+**Selected: Design B's cursor pagination + single-conversation endpoint.** Without pagination, conversations older than 20 are inaccessible. The single-conversation endpoint keeps data access through the API layer rather than direct Supabase client calls.
+
+### 8. Parent Preview of Quest Buddy
+
+**Design A**: Not addressed.
+
+**Design B** (refined): Parent preview mode — returns AI response without creating a `ai_kid_chats` row.
+
+**Selected: Design B's preview mode.** Prevents orphaned kid chat records when parents test the quest buddy.
+
+### 9. Per-Conversation Message Cap
+
+**Design A** (refined): 50 messages via save route slice.
+
+**Design B** (refined): 100 messages with metadata event when limit reached.
+
+**Selected: Design B's approach with 100-message cap.** 50 exchanges (100 messages) is reasonable for a parent conversation that may span multiple sessions. The metadata event notifies the client cleanly.
+
+### 10. `withObservability()` Compatibility
+
+**Design A**: Not analyzed.
+
+**Design B** (refined): Analyzed — middleware measures TTFB (setup time), not stream duration. Add manual `trackEvent()` at stream completion for full observability.
+
+**Selected: Design B's analysis.** Keep `withObservability()` on streaming routes (measures setup time) and add a manual `trackEvent()` inside the `ReadableStream.start()` after persistence for stream duration metrics.
+
+---
+
+## Synthesized Architecture
+
+### Component Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  PAGES (Server Components)                                           │
+│  ┌───────────────────────┐   ┌───────────────────────────┐          │
+│  │ /chat (parent)        │   │ /quest-buddy (kid)        │          │
+│  │  → fetches convos     │   │  → renders welcome state  │          │
+│  │  → renders ChatPanel  │   │  → renders ChatPanel      │          │
+│  └───────────┬───────────┘   └────────────┬──────────────┘          │
+│              │                            │                          │
+│              ▼                            ▼                          │
+│  ┌──────────────────────────────────────────────────────────┐       │
+│  │  ChatPanel ('use client')                                 │       │
+│  │  ┌───────────┐ ┌──────────────┐ ┌─────────────────────┐  │       │
+│  │  │ChatHeader │ │MessageList   │ │ChatInput            │  │       │
+│  │  │           │ │ └ChatMessage │ │ └QuickActions        │  │       │
+│  │  │           │ │ └TypingDots  │ │                      │  │       │
+│  │  └───────────┘ └──────────────┘ └─────────────────────┘  │       │
+│  └──────────────────────┬───────────────────────────────────┘       │
+│                         │ fetch() with ReadableStream                │
+│                         ▼                                            │
+│  ┌──────────────────────────────────────────────────────────┐       │
+│  │  API ROUTES (streaming SSE)                               │       │
+│  │  POST /api/ai/chat              (parent chat)             │       │
+│  │  POST /api/ai/quest-buddy       (kid chat)                │       │
+│  │  GET  /api/ai/chat/conversations (list + paginate)        │       │
+│  │  GET  /api/ai/chat/conversations/[id] (single convo)      │       │
+│  │  GET  /api/ai/quest-buddy/history (parent views kid chats)│       │
+│  └──────────────────────┬───────────────────────────────────┘       │
+│                         │                                            │
+│     ┌───────────────────┼───────────────────┐                       │
+│     ▼                   ▼                   ▼                       │
+│  ┌──────────┐  ┌─────────────────┐  ┌────────────────────┐         │
+│  │ Supabase │  │ Anthropic API   │  │ Observability      │         │
+│  │ (DB+Auth)│  │ (raw fetch SSE) │  │ (withObs+trackEvt) │         │
+│  └──────────┘  └─────────────────┘  └────────────────────┘         │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Model
+
+#### Migration: `supabase/migrations/016_add_ai_chat_tables.sql`
+
+```sql
+-- ============================================================
+-- Parent assistant conversations
+-- ============================================================
+CREATE TABLE ai_conversations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  parent_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  messages JSONB NOT NULL DEFAULT '[]'::jsonb,
+  title TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ai_conversations_family_updated
+  ON ai_conversations (family_id, updated_at DESC);
+CREATE INDEX idx_ai_conversations_parent
+  ON ai_conversations (parent_id);
+
+ALTER TABLE ai_conversations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "parents_select_conversations" ON ai_conversations
+  FOR SELECT USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+CREATE POLICY "parents_insert_conversations" ON ai_conversations
+  FOR INSERT WITH CHECK (
+    parent_id = auth.uid()
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+CREATE POLICY "parents_update_conversations" ON ai_conversations
+  FOR UPDATE USING (parent_id = auth.uid());
+
+-- ============================================================
+-- Kid chat conversations
+-- ============================================================
+CREATE TABLE ai_kid_chats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  messages JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ai_kid_chats_child_created
+  ON ai_kid_chats (child_id, created_at DESC);
+CREATE INDEX idx_ai_kid_chats_family_created
+  ON ai_kid_chats (family_id, created_at DESC);
+
+ALTER TABLE ai_kid_chats ENABLE ROW LEVEL SECURITY;
+
+-- Kids: SELECT, INSERT, UPDATE only — NO DELETE (append-only)
+CREATE POLICY "kids_select_own_chats" ON ai_kid_chats
+  FOR SELECT USING (child_id = auth.uid());
+
+CREATE POLICY "kids_insert_own_chats" ON ai_kid_chats
+  FOR INSERT WITH CHECK (child_id = auth.uid());
+
+CREATE POLICY "kids_update_own_chats" ON ai_kid_chats
+  FOR UPDATE USING (child_id = auth.uid());
+
+-- Parents can view their family's kid chats (read-only)
+CREATE POLICY "parents_view_kid_chats" ON ai_kid_chats
+  FOR SELECT USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+-- ============================================================
+-- Rate limiting — dual cap (per-family + per-user)
+-- ============================================================
+CREATE TABLE ai_daily_usage (
+  family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  usage_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  message_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (family_id, user_id, usage_date)
+);
+
+CREATE INDEX idx_ai_daily_usage_family_date
+  ON ai_daily_usage (family_id, usage_date);
+
+ALTER TABLE ai_daily_usage ENABLE ROW LEVEL SECURITY;
+
+-- Parents can view family usage (for potential UI display)
+CREATE POLICY "parents_view_usage" ON ai_daily_usage
+  FOR SELECT USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+-- ============================================================
+-- Helper functions (SECURITY DEFINER — called by API routes)
+-- ============================================================
+
+-- Atomic rate limit check + increment with dual caps
+CREATE OR REPLACE FUNCTION check_and_increment_ai_rate_limit(
+  p_family_id UUID,
+  p_user_id UUID,
+  p_family_limit INT DEFAULT 50,
+  p_user_limit INT DEFAULT 20
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_count INT;
+  v_family_count INT;
+BEGIN
+  -- Upsert per-user row and increment
+  INSERT INTO ai_daily_usage (family_id, user_id, usage_date, message_count)
+  VALUES (p_family_id, p_user_id, CURRENT_DATE, 1)
+  ON CONFLICT (family_id, user_id, usage_date)
+  DO UPDATE SET message_count = ai_daily_usage.message_count + 1
+  RETURNING message_count INTO v_user_count;
+
+  -- Check per-user cap
+  IF v_user_count > p_user_limit THEN
+    UPDATE ai_daily_usage
+    SET message_count = message_count - 1
+    WHERE family_id = p_family_id AND user_id = p_user_id AND usage_date = CURRENT_DATE;
+    RETURN jsonb_build_object('allowed', false, 'reason', 'user_limit');
+  END IF;
+
+  -- Check family total
+  SELECT COALESCE(SUM(message_count), 0) INTO v_family_count
+  FROM ai_daily_usage
+  WHERE family_id = p_family_id AND usage_date = CURRENT_DATE;
+
+  IF v_family_count > p_family_limit THEN
+    UPDATE ai_daily_usage
+    SET message_count = message_count - 1
+    WHERE family_id = p_family_id AND user_id = p_user_id AND usage_date = CURRENT_DATE;
+    RETURN jsonb_build_object('allowed', false, 'reason', 'family_limit');
+  END IF;
+
+  RETURN jsonb_build_object('allowed', true, 'reason', null);
+END;
+$$;
+
+-- Atomic append messages to parent conversation
+CREATE OR REPLACE FUNCTION append_chat_messages(p_id UUID, p_messages JSONB)
+RETURNS void AS $$
+  UPDATE ai_conversations
+  SET messages = messages || p_messages,
+      updated_at = now()
+  WHERE id = p_id;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Atomic append messages to kid chat
+CREATE OR REPLACE FUNCTION append_kid_chat_messages(p_id UUID, p_messages JSONB)
+RETURNS void AS $$
+  UPDATE ai_kid_chats
+  SET messages = messages || p_messages
+  WHERE id = p_id;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Auto-update updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_ai_conversations_updated_at
+  BEFORE UPDATE ON ai_conversations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+```
+
+#### TypeScript Types (`lib/types.ts` additions)
+
+```typescript
+export type ChatMessage = {
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: string  // ISO 8601
+}
+
+export type AiConversation = {
+  id: string
+  family_id: string
+  parent_id: string
+  messages: ChatMessage[]
+  title: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type AiKidChat = {
+  id: string
+  child_id: string
+  family_id: string
+  messages: ChatMessage[]
+  created_at: string
+}
+
+export type QuickAction = {
+  label: string
+  prompt: string
+}
+```
+
+### API Specifications
+
+#### `POST /api/ai/chat` — Parent Chat (Streaming)
+
+**Auth:** Required. `role = 'parent'` enforced.
+
+**Request:**
+```typescript
+{ conversationId?: string; message: string }
+```
+
+**Response:** SSE stream (`Content-Type: text/event-stream`). Anthropic's native SSE events piped through, plus a final custom event:
+```
+event: conversation_meta
+data: {"conversationId": "uuid", "title": "First message truncated...", "limitReached": false}
+```
+
+**Server flow:**
+1. Auth → profile → role check (parent)
+2. Input validation: `message` is string, 1–2000 chars
+3. Rate limit: `supabase.rpc('check_and_increment_ai_rate_limit', { p_family_id, p_user_id })`
+4. Load or create conversation from DB (server-authoritative history)
+5. Truncate history to last 20 messages
+6. Build parent system prompt with family context
+7. `fetch()` to Anthropic with `stream: true`
+8. Return `ReadableStream` that:
+   - Enqueues each chunk to client immediately
+   - Accumulates assistant text via line-buffered SSE parser
+   - After stream ends: persists via `append_chat_messages` RPC, auto-titles, sends `conversation_meta` event, fires `trackEvent()`
+   - Calls `controller.close()`
+
+**Errors:** 401 (not authenticated), 403 (not parent), 400 (invalid message), 429 (rate limited with `reason` field), 503 (AI unavailable)
+
+#### `POST /api/ai/quest-buddy` — Kid Chat (Streaming)
+
+**Auth:** Required. Any role (kids primary; parents can preview).
+
+**Request:**
+```typescript
+{ chatId?: string; message: string }
+```
+
+**Response:** SSE stream, same format. Final event:
+```
+event: chat_meta
+data: {"chatId": "uuid", "limitReached": false}
+```
+
+**Differences from parent route:**
+- No role restriction (parents can preview)
+- If `profile.role === 'parent'`: preview mode — stream response but do NOT create/persist a `ai_kid_chats` row
+- `max_tokens: 256` (shorter responses for kids)
+- Kid system prompt with safety guardrails
+- Per-session cap: 20 messages (checked via `messages.length` on the chat record)
+- Stores to `ai_kid_chats` table via `append_kid_chat_messages` RPC
+
+#### `GET /api/ai/chat/conversations` — List Parent Conversations
+
+**Auth:** Required, parent role.
+
+**Query params:** `?limit=20&cursor=<ISO timestamp>`
+
+**Response:**
+```typescript
+{
+  data: Array<{
+    id: string
+    title: string | null
+    updatedAt: string
+    messageCount: number
+  }>
+  nextCursor: string | null
+}
+```
+
+#### `GET /api/ai/chat/conversations/[id]` — Load Single Conversation
+
+**Auth:** Required, parent role, family-scoped via RLS.
+
+**Response:**
+```typescript
+{
+  data: AiConversation
+}
+```
+
+#### `GET /api/ai/quest-buddy/history` — Parent Views Kid Chat History
+
+**Auth:** Required, parent role.
+
+**Query params:** `?childId=uuid` (optional filter), `?limit=20&cursor=<ISO>`
+
+**Response:**
+```typescript
+{
+  data: Array<{
+    id: string
+    childId: string
+    childName: string
+    messageCount: number
+    createdAt: string
+  }>
+  nextCursor: string | null
+}
+```
+
+### Streaming Implementation
+
+#### Server-Side: `ReadableStream` with Accumulation
+
+```typescript
+// app/api/ai/chat/route.ts
+export const maxDuration = 60  // Vercel Pro streaming timeout
+
+async function handler(req: Request) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!process.env.ANTHROPIC_API_KEY) return NextResponse.json({ data: null })
+
+  const { data: profile } = await supabase
+    .from('profiles').select('family_id, role, display_name').eq('id', user.id).single()
+  if (!profile || profile.role !== 'parent') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Validate input
+  const body = await req.json()
+  const message = typeof body.message === 'string' ? body.message.trim() : null
+  if (!message || message.length === 0 || message.length > 2000) {
+    return NextResponse.json({ error: 'Invalid message' }, { status: 400 })
+  }
+  const { conversationId } = body as { conversationId?: string }
+
+  // Rate limit (dual cap: 20/user, 50/family)
+  const { data: rateResult } = await supabase.rpc('check_and_increment_ai_rate_limit', {
+    p_family_id: profile.family_id,
+    p_user_id: user.id,
+  })
+  if (!rateResult?.allowed) {
+    const msg = rateResult?.reason === 'user_limit'
+      ? "You've reached your personal message limit for today (20). Try again tomorrow!"
+      : "Your family has reached today's message limit (50). Try again tomorrow!"
+    return NextResponse.json({ error: msg, reason: rateResult?.reason }, { status: 429 })
+  }
+
+  // Load or create conversation (server is authoritative for history)
+  let conversation: AiConversation
+  if (conversationId) {
+    const { data } = await supabase.from('ai_conversations')
+      .select('*').eq('id', conversationId).single()
+    if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    conversation = data
+  } else {
+    const { data } = await supabase.from('ai_conversations')
+      .insert({ family_id: profile.family_id, parent_id: user.id, messages: [] })
+      .select().single()
+    conversation = data!
+    trackEvent({ event_type: 'ai_chat_conversation_created', user_id: user.id,
+      family_id: profile.family_id, metadata: { conversationId: conversation.id } })
+  }
+
+  // Truncate history to last 20 messages for Anthropic
+  const history = (conversation.messages as ChatMessage[]).slice(-CONVERSATION_HISTORY_LIMIT)
+  const newUserMessage: ChatMessage = {
+    role: 'user', content: message, timestamp: new Date().toISOString()
+  }
+
+  // Build context + system prompt
+  const familyContext = await buildParentContext(supabase, profile)
+  const systemPrompt = buildParentSystemPrompt(familyContext)
+
+  // Call Anthropic with streaming
+  const anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY!,
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta': 'messages-2023-06-16',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      stream: true,
+      system: systemPrompt,
+      messages: [
+        ...history.map(m => ({ role: m.role, content: m.content })),
+        { role: 'user', content: message },
+      ],
+    }),
+    signal: AbortSignal.timeout(30000),
+  })
+
+  if (!anthropicRes.ok || !anthropicRes.body) {
+    return NextResponse.json({ error: 'AI unavailable' }, { status: 503 })
+  }
+
+  // Stream response to client while accumulating server-side
+  const streamStartTime = Date.now()
+  const encoder = new TextEncoder()
+  const sourceReader = anthropicRes.body.getReader()
+  let accumulatedText = ''
+  let lineBuffer = ''
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        while (true) {
+          const { done, value } = await sourceReader.read()
+          if (done) break
+          controller.enqueue(value)
+
+          // Buffered SSE parsing for accumulation
+          lineBuffer += new TextDecoder().decode(value, { stream: true })
+          const lines = lineBuffer.split('\n')
+          lineBuffer = lines.pop() ?? ''
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            try {
+              const parsed = JSON.parse(line.slice(6))
+              if (parsed.type === 'content_block_delta' && parsed.delta?.type === 'text_delta') {
+                accumulatedText += parsed.delta.text
+              }
+            } catch { /* skip non-JSON lines */ }
+          }
+        }
+
+        // Stream complete — persist messages
+        const assistantMessage: ChatMessage = {
+          role: 'assistant', content: accumulatedText, timestamp: new Date().toISOString()
+        }
+
+        const currentCount = (conversation.messages as ChatMessage[]).length
+        const limitReached = currentCount >= CONVERSATION_MESSAGE_LIMIT
+
+        if (!limitReached) {
+          await supabase.rpc('append_chat_messages', {
+            p_id: conversation.id,
+            p_messages: JSON.stringify([newUserMessage, assistantMessage]),
+          })
+        }
+
+        // Auto-title on first message
+        let title = conversation.title
+        if (!title && conversation.messages.length === 0) {
+          title = message.slice(0, 60) + (message.length > 60 ? '...' : '')
+          await supabase.from('ai_conversations').update({ title }).eq('id', conversation.id)
+        }
+
+        // Track event with stream duration
+        trackEvent({
+          event_type: 'ai_parent_chat_message',
+          user_id: user.id,
+          family_id: profile.family_id,
+          metadata: {
+            conversationId: conversation.id,
+            streamDurationMs: Date.now() - streamStartTime,
+            responseLength: accumulatedText.length,
+          },
+        })
+
+        // Send metadata event so client learns the conversationId
+        controller.enqueue(encoder.encode(
+          `event: conversation_meta\ndata: ${JSON.stringify({
+            conversationId: conversation.id, title, limitReached
+          })}\n\n`
+        ))
+        controller.close()
+      } catch (err) {
+        controller.error(err)
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  })
+}
+
+export const POST = withObservability(handler)
+```
+
+#### Client-Side: `consumeSseStream` Utility
+
+```typescript
+// lib/ai/stream-helpers.ts
+
+/**
+ * Consumes an Anthropic SSE stream with proper line buffering.
+ * Calls onToken with accumulated text after each text_delta.
+ * Returns the full assistant message text when stream ends.
+ */
+export async function consumeSseStream(
+  body: ReadableStream<Uint8Array>,
+  onToken: (accumulated: string) => void,
+  onMeta?: (meta: Record<string, unknown>) => void,
+  signal?: AbortSignal
+): Promise<string> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let fullContent = ''
+  let nextEventType = ''
+
+  try {
+    while (true) {
+      if (signal?.aborted) break
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (line.startsWith('event: ')) {
+          nextEventType = line.slice(7).trim()
+          continue
+        }
+        if (!line.startsWith('data: ')) continue
+        const data = line.slice(6).trim()
+        if (!data) continue
+
+        try {
+          const parsed = JSON.parse(data)
+
+          // Handle custom metadata events
+          if (nextEventType === 'conversation_meta' || nextEventType === 'chat_meta') {
+            onMeta?.(parsed)
+            nextEventType = ''
+            continue
+          }
+          nextEventType = ''
+
+          // Handle Anthropic streaming text deltas
+          if (parsed.type === 'content_block_delta' && parsed.delta?.type === 'text_delta') {
+            fullContent += parsed.delta.text
+            onToken(fullContent)
+          }
+        } catch { /* skip malformed lines */ }
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  return fullContent
+}
+```
+
+### System Prompts
+
+```typescript
+// lib/ai/prompts.ts
+
+export const CONVERSATION_HISTORY_LIMIT = 20  // last 10 exchanges
+export const CONVERSATION_MESSAGE_LIMIT = 100  // max per conversation (50 exchanges)
+
+interface ParentContext {
+  familyName: string
+  children: Array<{ displayName: string; points: number }>
+  recentTasks: Array<{ title: string; assignedTo: string; points: number; completed: boolean }>
+}
+
+interface KidContext {
+  childName: string
+  points: number
+  pendingTasks: Array<{ title: string; points: number }>
+  recentCompletions: Array<{ pointsEarned: number; completionDate: string }>
+}
+
+export function buildParentSystemPrompt(ctx: ParentContext): string {
+  return `You are a supportive parenting assistant for the ${ctx.familyName} family.
+
+Family context:
+- Children: ${ctx.children.map(c => `${c.displayName} (${c.points} points)`).join(', ')}
+- Active quests: ${ctx.recentTasks.slice(0, 10).map(t => t.title).join(', ')}
+
+You help parents with:
+- Age-appropriate chore suggestions
+- Motivation strategies for kids
+- Weekly summaries of family progress
+- Addressing specific behavioral patterns
+
+Keep responses warm, practical, and under 200 words. Use the family's actual names and quest data when relevant.`
+}
+
+export function buildKidSystemPrompt(ctx: KidContext): string {
+  return `You are ${ctx.childName}'s Quest Buddy! You're an encouraging, fun sidekick character.
+
+${ctx.childName}'s stats:
+- Points: ${ctx.points} ⭐
+- Pending quests: ${ctx.pendingTasks.map(t => `"${t.title}" (${t.points} pts)`).join(', ')}
+
+Rules:
+- Use simple, fun, age-appropriate language
+- Be enthusiastic and encouraging (use emojis!)
+- Keep responses SHORT (2-4 sentences max)
+- Only talk about quests, points, and being awesome
+- Never ask for or share personal information
+- If asked about something unrelated, redirect to quests
+
+You can help ${ctx.childName} decide which quest to do next, celebrate completions, and share encouraging words!`
+}
+```
+
+### Shared Chat UI Component
+
+```typescript
+// components/chat/chat-panel.tsx ('use client')
+
+interface ChatPanelProps {
+  apiEndpoint: '/api/ai/chat' | '/api/ai/quest-buddy'
+  systemName: string              // 'Parenting Assistant' | 'Quest Buddy'
+  theme: 'parent' | 'kid'
+  quickActions: QuickAction[]
+  maxMessages?: number            // kid: 20 per session
+  conversationId?: string         // resume existing conversation
+  initialMessages?: ChatMessage[]
+  onConversationCreated?: (id: string) => void
+}
+```
+
+**State:**
+- `messages: ChatMessage[]` — conversation history
+- `streamingContent: string` — accumulates tokens during streaming
+- `isStreaming: boolean` — disables input, shows typing indicator
+- `error: string | null` — user-friendly error display
+- `conversationId: string | null` — set from metadata event
+
+**Send message flow:**
+1. Set `isStreaming(true)`, add user message to `messages` optimistically
+2. `fetch(apiEndpoint, { method: 'POST', body: { message, conversationId }, signal })`
+3. If non-ok: handle error (429 → rate limit message, 503 → retry message, remove optimistic message)
+4. Call `consumeSseStream(res.body, onToken, onMeta, signal)`
+5. `onToken` updates `streamingContent` — shown as growing assistant bubble
+6. `onMeta` captures `conversationId`, `title`, `limitReached`
+7. On completion: add assistant message to `messages`, clear `streamingContent`, set `isStreaming(false)`
+
+**Theming:**
+- Parent: `bg-purple-600` header, `bg-purple-100` assistant bubbles
+- Kid: `bg-gradient-to-r from-yellow-400 to-pink-500` header, `bg-green-100` assistant bubbles
+
+**Quick Actions:**
+```typescript
+// Page files define the arrays
+const PARENT_QUICK_ACTIONS: QuickAction[] = [
+  { label: '💡 Suggest quests', prompt: 'Suggest 3 age-appropriate chores for my kids based on their current quests.' },
+  { label: '📊 Weekly report', prompt: "Give me a summary of my family's quest progress this week." },
+  { label: '🌟 Motivation tips', prompt: 'My kids seem unmotivated lately. What are some strategies to re-engage them?' },
+  { label: '🎯 Points balance', prompt: 'How are my kids doing with their points? Any patterns I should know about?' },
+]
+
+const KID_QUICK_ACTIONS: QuickAction[] = [
+  { label: '🚀 What should I do?', prompt: 'Which quest should I do next?' },
+  { label: '⭐ My points', prompt: 'How many points do I have? What can I get?' },
+  { label: '🎉 I finished one!', prompt: 'I just finished a quest! Celebrate with me!' },
+  { label: '💪 I need help', prompt: "I'm stuck on a quest. Can you help me?" },
+]
+```
+
+### Error Handling Strategy
+
+| Error | Server Response | Client UX |
+|-------|----------------|-----------|
+| Not authenticated | 401 | Redirect to login |
+| Wrong role | 403 | Toast: "You don't have access to this feature" |
+| Invalid message | 400 | Inline validation error below input |
+| Rate limited (user) | 429 `{reason: "user_limit"}` | Toast: "You've reached your personal limit (20 messages/day)" |
+| Rate limited (family) | 429 `{reason: "family_limit"}` | Toast: "Your family has reached today's limit (50 messages)" |
+| No API key | 200 `{data: null}` | Fallback: "AI chat is not configured" |
+| Anthropic error | 503 | Toast: "Chat is temporarily unavailable" + retry button |
+| Stream interrupted | Partial SSE | Show partial text + "(response interrupted)" indicator |
+| Kid session limit (20) | `limitReached: true` in metadata | Input disabled: "That's all for now! Start a new chat anytime 🌟" |
+| Conversation full (100) | `limitReached: true` in metadata | Toast: "Start a new conversation to continue" |
+
+### Observability Integration
+
+Add to `lib/observability/constants.ts`:
+```typescript
+// In APP_EVENT_TYPES array:
+'ai_parent_chat_message',
+'ai_kid_chat_message',
+'ai_chat_conversation_created',
+```
+
+Both streaming routes:
+- Wrapped with `withObservability()` (measures setup time / TTFB)
+- Manual `trackEvent()` inside `ReadableStream.start()` after persistence (measures stream duration, response length)
+
+---
+
+## Key Design Decisions
+
+### 1. Server-Side Persistence via ReadableStream
+- **Decision**: Server accumulates the assistant response while streaming and persists after stream ends, before `controller.close()`
+- **Source**: Design B
+- **Rationale**: Single request handles everything — no extra endpoint or round-trip. Function stays alive while stream is active. Messages are persisted even if client navigates away immediately after stream ends.
+- **Alternative**: Design A's client-side save (separate POST after stream). Rejected because it introduces an extra endpoint, extra latency, and loses messages if user closes tab before save fires.
+
+### 2. Server-Authoritative History
+- **Decision**: Client sends `{ message, conversationId? }` — server loads history from DB
+- **Source**: Both designs converged on this after critique
+- **Rationale**: Prevents client injection of fake assistant messages, eliminates multi-tab divergence, makes the server the source of truth
+- **Alternative**: Client sends full `messages[]` array. Rejected as a security risk (prompt injection via fabricated history).
+
+### 3. Dual-Cap Rate Limiting
+- **Decision**: 50 messages/family/day AND 20 messages/user/day, checked atomically via Postgres function
+- **Source**: Design A's per-user sub-cap merged with Design B's table structure
+- **Rationale**: Prevents one family member from monopolizing the budget. Atomic function with rollback-on-block ensures family quota isn't consumed by blocked requests.
+- **Alternative**: Family-only cap (Design B). Rejected because one active child could lock out parents.
+
+### 4. Atomic Append via Postgres RPC
+- **Decision**: `append_chat_messages` RPC using `messages || p_messages`
+- **Source**: Design B
+- **Rationale**: Serializes at the row lock — no lost messages under concurrency. Simpler than optimistic concurrency (no 409 handling needed).
+- **Alternative**: Design A's `expectedMessageCount` optimistic concurrency. Rejected as over-engineered for a family app where concurrent writes to the same conversation are extremely rare.
+
+### 5. Separate Tables (Not Polymorphic)
+- **Decision**: `ai_conversations` for parents, `ai_kid_chats` for kids
+- **Source**: Both designs agreed
+- **Rationale**: Clear RLS policies, simple queries, type-safe. Different columns (`parent_id` vs `child_id`, `updated_at` presence). Some route code duplication is acceptable.
+- **Alternative**: Single polymorphic `ai_chats` table with `role` column. Rejected because RLS policies become complex and error-prone.
+
+### 6. Full-Page Chat (Not Slide-Out)
+- **Decision**: `/chat` and `/quest-buddy` are full-page views
+- **Source**: Both designs agreed
+- **Rationale**: Mobile-first — full-page is simpler and more reliable. Browser back button handles navigation. No complex overlay state management.
+- **Alternative**: Slide-out panel on desktop. Rejected for v1 — adds complexity without proportional benefit.
+
+---
+
+## How This Improves Current Architecture
+
+### Weakness: No AI Conversation Support
+- **How addressed**: Two new streaming chat routes with persistent conversation history
+- **Remaining risk**: None — this is the core feature
+
+### Weakness: No Streaming in the Codebase
+- **How addressed**: Establishes the SSE streaming pattern via `ReadableStream` with line-buffered parsing. Creates reusable `consumeSseStream()` client utility. Both patterns are documented and tested.
+- **Remaining risk**: Vercel Hobby plan has 10s timeout (must be on Pro for streaming). `maxDuration = 60` is set.
+
+### Weakness: No Rate Limiting on AI Routes
+- **How addressed**: Atomic dual-cap rate limiter (per-user + per-family) via Postgres function. Applies to both chat endpoints.
+- **Remaining risk**: Existing AI routes (encouragement, parse-quest, analytics-insights) still have no rate limiting. Consider applying the same pattern to them in a follow-up.
+
+### Weakness: No Kid-Facing AI Features
+- **How addressed**: Quest Buddy with age-appropriate system prompt, short response cap (256 tokens), per-session message limit (20), no DELETE RLS policy, parent oversight via chat history viewing
+- **Remaining risk**: System prompt guardrails can be jailbroken. Acceptable for v1 — parent review provides a transparency layer. Evaluate Claude's built-in safety features for v2.
+
+---
+
+## Implementation Strategy
+
+### Phase 1: Database & Shared Infrastructure
+
+**Files to create:**
+- `supabase/migrations/016_add_ai_chat_tables.sql` — tables, RLS policies, indexes, helper functions, trigger
+- `lib/ai/prompts.ts` — `buildParentSystemPrompt()`, `buildKidSystemPrompt()`, constants
+- `lib/ai/stream-helpers.ts` — `consumeSseStream()` client utility
+- `lib/ai/rate-limit.ts` — rate limit types (thin wrapper — actual logic is in Postgres function)
+
+**Files to modify:**
+- `lib/types.ts` — add `ChatMessage`, `AiConversation`, `AiKidChat`, `QuickAction` types
+- `lib/observability/constants.ts` — add new event types
+
+**Run migration via Supabase Management API before proceeding.**
+
+### Phase 2: API Routes
+
+**Files to create:**
+- `app/api/ai/chat/route.ts` — parent chat streaming endpoint
+- `app/api/ai/quest-buddy/route.ts` — kid chat streaming endpoint
+- `app/api/ai/chat/conversations/route.ts` — GET conversation list (cursor-paginated)
+- `app/api/ai/chat/conversations/[id]/route.ts` — GET single conversation
+- `app/api/ai/quest-buddy/history/route.ts` — GET kid chat history (parent view)
+
+**Dependencies:** Phase 1
+
+### Phase 3: Chat UI Components
+
+**Files to create:**
+- `components/chat/chat-panel.tsx` — shared chat UI (`'use client'`)
+- `components/chat/chat-message.tsx` — message bubble (user vs assistant)
+- `components/chat/typing-indicator.tsx` — animated bouncing dots
+- `components/chat/quick-actions.tsx` — horizontal scrollable action chips
+- `components/chat/conversation-list.tsx` — list of past conversations with loading skeleton
+
+**Dependencies:** Phase 2 (API routes for integration testing)
+
+### Phase 4: Pages & Navigation
+
+**Files to create:**
+- `app/(dashboard)/chat/page.tsx` — parent chat page (server component, fetches initial conversations, renders ChatPanel)
+- `app/(dashboard)/quest-buddy/page.tsx` — kid quest buddy page (server component, renders ChatPanel with welcome state)
+
+**Files to modify:**
+- `components/layout/nav-bar.tsx` — add chat icon button (conditional on `role === 'parent'`)
+- `app/(dashboard)/quests/page.tsx` — add Quest Buddy FAB for kids
+
+**Dependencies:** Phase 3
+
+### Phase 5: Testing
+
+**Files to create:**
+- `__tests__/chat-panel.test.tsx` — ChatPanel unit tests (renders, streaming state, quick actions, error handling)
+- `__tests__/chat-message.test.tsx` — message bubble rendering tests
+- `__tests__/typing-indicator.test.tsx` — typing indicator tests
+- `__tests__/quick-actions.test.tsx` — quick action chip tests
+- `__tests__/api/ai/chat.test.ts` — parent chat route tests (auth, role, rate limit, streaming)
+- `__tests__/api/ai/quest-buddy.test.ts` — kid chat route tests (auth, context, streaming, preview mode)
+- `__tests__/lib/ai/prompts.test.ts` — system prompt builder tests
+- `__tests__/lib/ai/stream-helpers.test.ts` — `consumeSseStream` tests (buffering, abort, error)
+- `__tests__/db/ai-conversations.test.ts` — RLS: parents create/read, children blocked, cross-family blocked
+- `__tests__/db/ai-kid-chats.test.ts` — RLS: kids see own, parents see family's, no DELETE, cross-family blocked
+- `e2e/chat.spec.ts` — parent chat E2E: open, send message, streaming response, persistence
+- `e2e/quest-buddy.spec.ts` — kid chat E2E: open, quick action, streaming, session limit
+
+**Files to modify:**
+- `playwright.config.ts` — add `chat\.spec\.ts` and `quest-buddy\.spec\.ts` to `testMatch` patterns
+
+**Dependencies:** Phase 4 (full feature for E2E), but unit tests can start during Phase 2-3.
+
+### Ordering Constraints
+
+```
+Phase 1 (DB + shared) → Phase 2 (API) → Phase 3 (UI) → Phase 4 (pages) → Phase 5 (tests)
+                                          ↑ unit tests can start here
+```
+
+### Rollback Strategy
+
+- **Migration rollback**: `DROP TABLE ai_daily_usage; DROP TABLE ai_kid_chats; DROP TABLE ai_conversations; DROP FUNCTION check_and_increment_ai_rate_limit; DROP FUNCTION append_chat_messages; DROP FUNCTION append_kid_chat_messages;` via Management API
+- **Code rollback**: Revert the feature branch. No existing files have breaking changes (only additive modifications to nav-bar, quests page, types, constants).
+- **Feature flag** (optional): If needed, wrap the nav-bar chat icon and quest buddy FAB behind `process.env.NEXT_PUBLIC_AI_CHAT_ENABLED` — quick disable without code revert.
+
+---
+
+## Risk Mitigation
+
+### Top Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Vercel serverless timeout kills stream | Medium (if on Hobby plan) | High — responses cut off | `export const maxDuration = 60` on both routes. Must be on Vercel Pro. |
+| Kid safety jailbreak via prompt injection | Medium | Medium — inappropriate content | System prompt guardrails + 256 token cap + parent review of chat history. Evaluate content filtering in v2. |
+| JSONB row growth exceeds comfortable size | Low | Low — slow updates | 100-message per-conversation cap + 20-message history truncation to Anthropic. Max ~20KB per row. |
+| `withObservability()` buffers response body | Low | High — breaks streaming | Inspect implementation during Phase 2. If it buffers, replace with manual try/catch + error tracking. |
+| Concurrent writes to same conversation | Very low | Low — one message pair may be generated without seeing the other | Atomic append via RPC serializes writes. Both appends succeed; order is deterministic. |
+
+### What to Monitor After Deployment
+
+- `ai_parent_chat_message` and `ai_kid_chat_message` event counts — confirms features are being used
+- `streamDurationMs` in event metadata — detect Anthropic latency regressions
+- `ai_chat_conversation_created` count vs message count ratio — detect persistent conversations vs one-offs
+- 429 response rate — detect if rate limits are too restrictive
+- Error rates on streaming routes via `withObservability()` error tracking
+
+### Reconsideration Decision Points
+
+- If >10% of streams are cut off by timeout → investigate Vercel plan or reduce `max_tokens`
+- If parents report kid safety issues → add post-stream content check or Anthropic moderation API
+- If JSONB update latency exceeds 100ms → consider normalized message table (separate migration)
+- If rate limits cause frequent user complaints → increase from 50/family to 100/family
+
+---
+
+## Success Metrics
+
+### Leading Indicators (During Implementation)
+
+- All RLS integration tests pass — confirms data isolation
+- 100% unit test coverage on new code
+- Streaming works end-to-end in dev (manual verification)
+- E2E tests pass for both parent and kid chat flows
+
+### Lagging Indicators (After Deployment)
+
+- **Adoption**: >30% of active parents use the chat feature within 2 weeks
+- **Engagement**: Average >3 messages per parent chat session
+- **Kid engagement**: >50% of active kids interact with Quest Buddy within 2 weeks
+- **Reliability**: <1% error rate on chat API routes
+- **Cost**: Total Anthropic API cost stays under $5/month (Haiku + rate limits)
+- **Safety**: Zero parent-reported inappropriate Quest Buddy responses in first month

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         storageState: '.auth/parent.json',
       },
       dependencies: ['setup'],
-      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|rewards-store\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts|streaks\.spec\.ts|analytics\.spec\.ts/,
+      testMatch: /quests\.spec\.ts|me\.spec\.ts|family\.spec\.ts|family-invite\.spec\.ts|rewards\.spec\.ts|rewards-store\.spec\.ts|dashboard-nav\.spec\.ts|profile-actions\.spec\.ts|encouragement\.spec\.ts|nl-quest-creation\.spec\.ts|onboarding\.spec\.ts|streaks\.spec\.ts|analytics\.spec\.ts|chat\.spec\.ts/,
     },
     // Destructive parent tests (sign-out) that invalidate the session - run last
     {

--- a/scripts/playwright-demo.ts
+++ b/scripts/playwright-demo.ts
@@ -100,7 +100,7 @@ async function runDemo() {
 
       // 6. Open New Quest Modal
       console.log('6. New quest modal...')
-      await page.locator('button.fixed.bg-purple-600').click()
+      await page.getByTestId('add-quest-fab').click()
       await page.waitForSelector('text=New Quest')
       await screenshot(page, '05-new-quest-modal')
       await page.keyboard.press('Escape')

--- a/supabase/migrations/016_add_ai_chat_tables.sql
+++ b/supabase/migrations/016_add_ai_chat_tables.sql
@@ -1,0 +1,172 @@
+-- ============================================================
+-- Parent assistant conversations
+-- ============================================================
+CREATE TABLE ai_conversations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  parent_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  messages JSONB NOT NULL DEFAULT '[]'::jsonb,
+  title TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ai_conversations_family_updated
+  ON ai_conversations (family_id, updated_at DESC);
+CREATE INDEX idx_ai_conversations_parent
+  ON ai_conversations (parent_id);
+
+ALTER TABLE ai_conversations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "parents_select_conversations" ON ai_conversations
+  FOR SELECT USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+CREATE POLICY "parents_insert_conversations" ON ai_conversations
+  FOR INSERT WITH CHECK (
+    parent_id = auth.uid()
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+CREATE POLICY "parents_update_conversations" ON ai_conversations
+  FOR UPDATE USING (parent_id = auth.uid());
+
+-- ============================================================
+-- Kid chat conversations
+-- ============================================================
+CREATE TABLE ai_kid_chats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  messages JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ai_kid_chats_child_created
+  ON ai_kid_chats (child_id, created_at DESC);
+CREATE INDEX idx_ai_kid_chats_family_created
+  ON ai_kid_chats (family_id, created_at DESC);
+
+ALTER TABLE ai_kid_chats ENABLE ROW LEVEL SECURITY;
+
+-- Kids: SELECT, INSERT, UPDATE only — NO DELETE (append-only)
+CREATE POLICY "kids_select_own_chats" ON ai_kid_chats
+  FOR SELECT USING (child_id = auth.uid());
+
+CREATE POLICY "kids_insert_own_chats" ON ai_kid_chats
+  FOR INSERT WITH CHECK (child_id = auth.uid());
+
+CREATE POLICY "kids_update_own_chats" ON ai_kid_chats
+  FOR UPDATE USING (child_id = auth.uid());
+
+-- Parents can view their family's kid chats (read-only)
+CREATE POLICY "parents_view_kid_chats" ON ai_kid_chats
+  FOR SELECT USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+-- ============================================================
+-- Rate limiting — dual cap (per-family + per-user)
+-- ============================================================
+CREATE TABLE ai_daily_usage (
+  family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  usage_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  message_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (family_id, user_id, usage_date)
+);
+
+CREATE INDEX idx_ai_daily_usage_family_date
+  ON ai_daily_usage (family_id, usage_date);
+
+ALTER TABLE ai_daily_usage ENABLE ROW LEVEL SECURITY;
+
+-- Parents can view family usage (for potential UI display)
+CREATE POLICY "parents_view_usage" ON ai_daily_usage
+  FOR SELECT USING (
+    family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    AND EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'parent')
+  );
+
+-- ============================================================
+-- Helper functions (SECURITY DEFINER — called by API routes)
+-- ============================================================
+
+-- Atomic rate limit check + increment with dual caps
+CREATE OR REPLACE FUNCTION check_and_increment_ai_rate_limit(
+  p_family_id UUID,
+  p_user_id UUID,
+  p_family_limit INT DEFAULT 50,
+  p_user_limit INT DEFAULT 20
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_count INT;
+  v_family_count INT;
+BEGIN
+  -- Upsert per-user row and increment
+  INSERT INTO ai_daily_usage (family_id, user_id, usage_date, message_count)
+  VALUES (p_family_id, p_user_id, CURRENT_DATE, 1)
+  ON CONFLICT (family_id, user_id, usage_date)
+  DO UPDATE SET message_count = ai_daily_usage.message_count + 1
+  RETURNING message_count INTO v_user_count;
+
+  -- Check per-user cap
+  IF v_user_count > p_user_limit THEN
+    UPDATE ai_daily_usage
+    SET message_count = message_count - 1
+    WHERE family_id = p_family_id AND user_id = p_user_id AND usage_date = CURRENT_DATE;
+    RETURN jsonb_build_object('allowed', false, 'reason', 'user_limit');
+  END IF;
+
+  -- Check family total
+  SELECT COALESCE(SUM(message_count), 0) INTO v_family_count
+  FROM ai_daily_usage
+  WHERE family_id = p_family_id AND usage_date = CURRENT_DATE;
+
+  IF v_family_count > p_family_limit THEN
+    UPDATE ai_daily_usage
+    SET message_count = message_count - 1
+    WHERE family_id = p_family_id AND user_id = p_user_id AND usage_date = CURRENT_DATE;
+    RETURN jsonb_build_object('allowed', false, 'reason', 'family_limit');
+  END IF;
+
+  RETURN jsonb_build_object('allowed', true, 'reason', null);
+END;
+$$;
+
+-- Atomic append messages to parent conversation
+CREATE OR REPLACE FUNCTION append_chat_messages(p_id UUID, p_messages JSONB)
+RETURNS void AS $$
+  UPDATE ai_conversations
+  SET messages = messages || p_messages,
+      updated_at = now()
+  WHERE id = p_id;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Atomic append messages to kid chat
+CREATE OR REPLACE FUNCTION append_kid_chat_messages(p_id UUID, p_messages JSONB)
+RETURNS void AS $$
+  UPDATE ai_kid_chats
+  SET messages = messages || p_messages
+  WHERE id = p_id;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Auto-update updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_ai_conversations_updated_at
+  BEFORE UPDATE ON ai_conversations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- Add streaming **Parenting Assistant** chat for parents at `/chat` — multi-turn conversations with family context (children, quests, points), persistent history with conversation listing/resumption
- Add streaming **Quest Buddy** chat for kids at `/quest-buddy` — age-appropriate, encouraging AI sidekick with quest/points context and safety guardrails
- Shared `ChatPanel` component with SSE streaming, typing indicator, quick-action buttons; rate limiting (50 msg/day per family, 20/user, 20/kid session); two new Supabase tables with RLS

## Test plan
- [ ] Unit tests pass (`npm test`)
- [ ] DB integration tests pass (`npm run test:db`)
- [ ] E2E tests pass (`npm run test:e2e`)
- [ ] Smoke tests pass (`npm run pw:smoke`)
- [ ] Visual tests pass (`npm run pw:visual`)

Closes #66
Closes #68