### PR TITLE
Fix date-sensitive test flakes blocking 100% coverage gate

### DIFF
--- a/__tests__/analytics-utils.test.ts
+++ b/__tests__/analytics-utils.test.ts
@@ -493,7 +493,10 @@ describe('getCurrentWeekStart', () => {
     const today = new Date()
     const cutoff = new Date(today)
     cutoff.setDate(today.getDate() - 6)
-    const cutoffStr = cutoff.toISOString().slice(0, 10)
+    // getCurrentWeekStart returns a LOCAL-timezone date string; build the
+    // cutoff from local date parts too, otherwise evenings in UTC- zones
+    // roll cutoff forward by a day and the comparison spuriously fails.
+    const cutoffStr = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`
     expect(result >= cutoffStr).toBe(true)
   })
 })

--- a/__tests__/components/analytics/streak-heatmap.test.tsx
+++ b/__tests__/components/analytics/streak-heatmap.test.tsx
@@ -3,7 +3,17 @@ import { StreakHeatmap } from '@/components/analytics/streak-heatmap'
 import type { DailyPoint } from '@/lib/types'
 
 describe('StreakHeatmap', () => {
-  const today = new Date()
+  // Pin the clock to a Wednesday so the heatmap grid always has future-dated
+  // cells past `today`, exercising the `d > today → push(null)` branch
+  // regardless of which day of the week the tests run on.
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-18T12:00:00Z'))
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  const today = new Date('2025-06-18T12:00:00Z')
   const toIso = (daysAgo: number) => {
     const d = new Date(today)
     d.setDate(d.getDate() - daysAgo)


### PR DESCRIPTION
## Summary

Two pre-existing date-dependent tests fail deterministically on certain days/times of day, blocking the 100% coverage gate in CI. Neither was caused by recent feature work — both surfaced while preparing the push-notifications PR (#47, branch ready to rebase).

- **`__tests__/analytics-utils.test.ts`** — `getCurrentWeekStart returns a date within the last 7 days` mixed local-timezone and UTC date math when building the `cutoff` string, so on evenings in UTC− timezones the cutoff rolled forward a day and the comparison spuriously failed.
- **`__tests__/components/analytics/streak-heatmap.test.tsx`** — the `d > today → push(null)` branch in the grid builder is not exercised when today is Saturday (`endDate === today`), leaving `components/analytics/streak-heatmap.tsx:43` uncovered. Pinning `Date` to a fixed Wednesday via fake timers makes the branch deterministic regardless of when tests run.

## Test plan

- [x] `npm test` — 1555/1555 pass
- [x] `npm run test:coverage` — global 100% line/branch/function/statement gate holds
- [x] `npm run lint` — 0 errors
- [x] Spot-checked the two specific test files with `npx jest` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)