### PR TITLE
feat: push notification schema, preferences API, and observability (#47 PR 1/5)

### DIFF
--- a/__tests__/api/push/preferences.test.ts
+++ b/__tests__/api/push/preferences.test.ts
@@ -1,0 +1,426 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+import { GET, PATCH } from '@/app/api/push/preferences/route'
+import { NextRequest } from 'next/server'
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+interface QueryResult {
+  data: unknown
+  error: unknown
+}
+
+function makeSelectChain(result: QueryResult) {
+  const chain: Record<string, unknown> = {}
+  chain.select = () => chain
+  chain.eq = () => chain
+  chain.maybeSingle = () => Promise.resolve(result)
+  chain.single = () => Promise.resolve(result)
+  return chain
+}
+
+function makeInsertChain(result: QueryResult) {
+  const chain: Record<string, unknown> = {}
+  chain.insert = () => chain
+  chain.select = () => chain
+  chain.single = () => Promise.resolve(result)
+  return chain
+}
+
+function makeUpsertChain(result: QueryResult) {
+  const chain: Record<string, unknown> = {}
+  chain.upsert = () => chain
+  chain.select = () => chain
+  chain.single = () => Promise.resolve(result)
+  return chain
+}
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/push/preferences')
+}
+
+function makePatchRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/push/preferences', {
+    method: 'PATCH',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+function existingRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    user_id: USER_ID,
+    push_enabled: true,
+    types_enabled: { task_completed: true, streak_milestone: true, test: true },
+    quiet_hours_start: null,
+    quiet_hours_end: null,
+    timezone: 'UTC',
+    updated_at: '2026-04-11T10:00:00Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GET /api/push/preferences', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('Unauthorized')
+  })
+
+  it('returns existing preferences row when one exists', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom.mockReturnValueOnce(makeSelectChain({ data: existingRow({ push_enabled: false }), error: null }))
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.push_enabled).toBe(false)
+    expect(body.data.user_id).toBe(USER_ID)
+    expect(body.data.types_enabled.task_completed).toBe(true)
+  })
+
+  it('normalizes malformed types_enabled on existing row', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom.mockReturnValueOnce(
+      makeSelectChain({ data: existingRow({ types_enabled: { task_completed: false, bogus: true, streak_milestone: 'nope' } }), error: null }),
+    )
+    const res = await GET(makeGetRequest())
+    const body = await res.json()
+    expect(body.data.types_enabled).toEqual({
+      task_completed: false,
+      streak_milestone: true, // non-boolean "nope" is ignored; default preserved
+      test: true,
+    })
+  })
+
+  it('normalizes non-object types_enabled on existing row', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom.mockReturnValueOnce(
+      makeSelectChain({ data: existingRow({ types_enabled: null }), error: null }),
+    )
+    const res = await GET(makeGetRequest())
+    const body = await res.json()
+    expect(body.data.types_enabled).toEqual({ task_completed: true, streak_milestone: true, test: true })
+  })
+
+  it('returns 500 when the select query errors', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom.mockReturnValueOnce(makeSelectChain({ data: null, error: { message: 'boom' } }))
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(500)
+  })
+
+  it('auto-creates a default row when none exists', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: null, error: null }))
+      .mockReturnValueOnce(makeInsertChain({ data: existingRow(), error: null }))
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.push_enabled).toBe(true)
+  })
+
+  it('returns 500 when insert of default row fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: null, error: null }))
+      .mockReturnValueOnce(makeInsertChain({ data: null, error: { message: 'insert failed' } }))
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 500 when insert returns no row and no error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: null, error: null }))
+      .mockReturnValueOnce(makeInsertChain({ data: null, error: null }))
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('PATCH /api/push/preferences', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await PATCH(makePatchRequest({ push_enabled: false }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when body is not valid JSON', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest('not json'))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('Invalid JSON')
+  })
+
+  it('returns 400 when body is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest(null))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe('Invalid body')
+  })
+
+  it('returns 400 when body is an array', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest([]))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when push_enabled is not a boolean', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ push_enabled: 'yes' }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/push_enabled/)
+  })
+
+  it('returns 400 when types_enabled is not an object', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ types_enabled: 'foo' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when types_enabled is an array', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ types_enabled: [] }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when types_enabled contains an unknown type', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ types_enabled: { bogus: true } }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/Unknown notification type/)
+  })
+
+  it('returns 400 when types_enabled has non-boolean value', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ types_enabled: { task_completed: 'yes' } }))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/must be a boolean/)
+  })
+
+  it('returns 400 when quiet_hours_start is out of range', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ quiet_hours_start: 24 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when quiet_hours_start is negative', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ quiet_hours_start: -1 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when quiet_hours_start is not an integer', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ quiet_hours_start: 3.5 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when quiet_hours_end is invalid', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ quiet_hours_end: 'lol' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when timezone is not a string', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ timezone: 42 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when timezone is an empty string', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ timezone: '' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when timezone is unrecognised', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const res = await PATCH(makePatchRequest({ timezone: 'Not/A_Zone' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('merges push_enabled onto existing row, leaving other fields intact', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const current = existingRow({ push_enabled: true, quiet_hours_start: 22, quiet_hours_end: 7 })
+    let upserted: Record<string, unknown> = {}
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: current, error: null }))
+      .mockReturnValueOnce({
+        upsert: (row: Record<string, unknown>) => {
+          upserted = row
+          return {
+            select: () => ({
+              single: () => Promise.resolve({ data: { ...current, ...row, updated_at: '2026-04-11T11:00:00Z' }, error: null }),
+            }),
+          }
+        },
+      })
+
+    const res = await PATCH(makePatchRequest({ push_enabled: false }))
+    expect(res.status).toBe(200)
+    expect(upserted.push_enabled).toBe(false)
+    expect(upserted.quiet_hours_start).toBe(22)
+    expect(upserted.quiet_hours_end).toBe(7)
+    expect(upserted.types_enabled).toEqual({ task_completed: true, streak_milestone: true, test: true })
+  })
+
+  it('merges types_enabled partial update onto existing types', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const current = existingRow({
+      types_enabled: { task_completed: true, streak_milestone: true, test: true },
+    })
+    let upserted: Record<string, unknown> = {}
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: current, error: null }))
+      .mockReturnValueOnce({
+        upsert: (row: Record<string, unknown>) => {
+          upserted = row
+          return {
+            select: () => ({
+              single: () => Promise.resolve({ data: { ...current, ...row }, error: null }),
+            }),
+          }
+        },
+      })
+
+    await PATCH(makePatchRequest({ types_enabled: { task_completed: false } }))
+    expect(upserted.types_enabled).toEqual({
+      task_completed: false,
+      streak_milestone: true,
+      test: true,
+    })
+  })
+
+  it('accepts null for quiet_hours fields to clear them', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const current = existingRow({ quiet_hours_start: 22, quiet_hours_end: 7 })
+    let upserted: Record<string, unknown> = {}
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: current, error: null }))
+      .mockReturnValueOnce({
+        upsert: (row: Record<string, unknown>) => {
+          upserted = row
+          return {
+            select: () => ({
+              single: () => Promise.resolve({ data: { ...current, ...row }, error: null }),
+            }),
+          }
+        },
+      })
+    await PATCH(makePatchRequest({ quiet_hours_start: null, quiet_hours_end: null }))
+    expect(upserted.quiet_hours_start).toBeNull()
+    expect(upserted.quiet_hours_end).toBeNull()
+  })
+
+  it('accepts valid timezone update', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const current = existingRow()
+    let upserted: Record<string, unknown> = {}
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: current, error: null }))
+      .mockReturnValueOnce({
+        upsert: (row: Record<string, unknown>) => {
+          upserted = row
+          return {
+            select: () => ({
+              single: () => Promise.resolve({ data: { ...current, ...row }, error: null }),
+            }),
+          }
+        },
+      })
+    await PATCH(makePatchRequest({ timezone: 'America/Los_Angeles' }))
+    expect(upserted.timezone).toBe('America/Los_Angeles')
+  })
+
+  it('falls back to defaults when no existing row exists', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    let upserted: Record<string, unknown> = {}
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: null, error: null }))
+      .mockReturnValueOnce({
+        upsert: (row: Record<string, unknown>) => {
+          upserted = row
+          return {
+            select: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: { ...existingRow(), ...row, updated_at: '2026-04-11T11:00:00Z' },
+                  error: null,
+                }),
+            }),
+          }
+        },
+      })
+
+    const res = await PATCH(makePatchRequest({ quiet_hours_start: 22, quiet_hours_end: 7 }))
+    expect(res.status).toBe(200)
+    expect(upserted.user_id).toBe(USER_ID)
+    expect(upserted.push_enabled).toBe(true) // default
+    expect(upserted.types_enabled).toEqual({ task_completed: true, streak_milestone: true, test: true })
+    expect(upserted.quiet_hours_start).toBe(22)
+    expect(upserted.quiet_hours_end).toBe(7)
+    expect(upserted.timezone).toBe('UTC')
+  })
+
+  it('returns 500 when upsert fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: existingRow(), error: null }))
+      .mockReturnValueOnce(makeUpsertChain({ data: null, error: { message: 'boom' } }))
+    const res = await PATCH(makePatchRequest({ push_enabled: false }))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 500 when upsert returns no row and no error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: existingRow(), error: null }))
+      .mockReturnValueOnce(makeUpsertChain({ data: null, error: null }))
+    const res = await PATCH(makePatchRequest({ push_enabled: false }))
+    expect(res.status).toBe(500)
+  })
+
+  it('ignores a types_enabled with no recognised keys after validation', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } })
+    const current = existingRow()
+    let upserted: Record<string, unknown> = {}
+    mockFrom
+      .mockReturnValueOnce(makeSelectChain({ data: current, error: null }))
+      .mockReturnValueOnce({
+        upsert: (row: Record<string, unknown>) => {
+          upserted = row
+          return {
+            select: () => ({
+              single: () => Promise.resolve({ data: { ...current, ...row }, error: null }),
+            }),
+          }
+        },
+      })
+    // Empty object passes validation; merge leaves types_enabled untouched.
+    const res = await PATCH(makePatchRequest({ types_enabled: {} }))
+    expect(res.status).toBe(200)
+    expect(upserted.types_enabled).toEqual({ task_completed: true, streak_milestone: true, test: true })
+  })
+})

--- a/__tests__/db/push-notifications.db.test.ts
+++ b/__tests__/db/push-notifications.db.test.ts
@@ -1,0 +1,453 @@
+jest.retryTimes(1, { logErrorsBeforeRetry: true })
+
+import { ensureDbTestUser, runSQLWithRetry } from './helpers/db-test-helpers'
+
+let userA: string
+let userB: string
+
+async function ensureSecondUser(): Promise<string> {
+  const email = 'db-test-b@chore-champions-test.local'
+  const existing = (await runSQLWithRetry(
+    `SELECT id FROM auth.users WHERE email = '${email}' LIMIT 1`,
+  )) as Array<{ id: string }>
+  if (existing.length > 0) return existing[0].id
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing env vars')
+
+  const res = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${serviceRoleKey}`,
+      apikey: serviceRoleKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password: 'TestPassword123!',
+      email_confirm: true,
+      user_metadata: { display_name: 'DB Test User B' },
+    }),
+  })
+  const data = (await res.json()) as { id: string }
+  return data.id
+}
+
+async function ensureProfile(userId: string): Promise<void> {
+  await runSQLWithRetry(`
+    INSERT INTO profiles (id, display_name, role)
+    VALUES ('${userId}', 'DB Test', 'child')
+    ON CONFLICT (id) DO NOTHING
+  `)
+}
+
+/**
+ * Runs SQL with the authenticated role set and request.jwt.claims populated
+ * so RLS policies referencing auth.uid() enforce against `userId`.
+ *
+ * The Management API returns the result of the last statement, so the
+ * caller must put the statement under test last.
+ */
+async function sqlAsUser(userId: string, sql: string): Promise<unknown[]> {
+  return runSQLWithRetry(`
+    SELECT set_config('request.jwt.claims', '{"sub":"${userId}","role":"authenticated"}', true);
+    SET LOCAL ROLE authenticated;
+    ${sql}
+  `)
+}
+
+async function expectSqlError(
+  fn: () => Promise<unknown>,
+  matcher: RegExp,
+): Promise<void> {
+  let err: unknown
+  try {
+    await fn()
+  } catch (e) {
+    err = e
+  }
+  if (!err) throw new Error('Expected SQL to throw, but it did not')
+  const msg = err instanceof Error ? err.message : String(err)
+  expect(msg).toMatch(matcher)
+}
+
+async function cleanupAll(): Promise<void> {
+  await runSQLWithRetry(`
+    DELETE FROM push_subscriptions WHERE user_id IN ('${userA}', '${userB}');
+    DELETE FROM notification_preferences WHERE user_id IN ('${userA}', '${userB}');
+  `)
+}
+
+beforeAll(async () => {
+  const primary = await ensureDbTestUser()
+  userA = primary.userId
+
+  userB = await ensureSecondUser()
+  await ensureProfile(userB)
+
+  await cleanupAll()
+})
+
+afterAll(async () => {
+  await cleanupAll()
+})
+
+afterEach(async () => {
+  await cleanupAll()
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// push_subscriptions
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('push_subscriptions RLS + constraints', () => {
+  it('user can insert their own subscription', async () => {
+    const rows = (await sqlAsUser(
+      userA,
+      `INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+       VALUES ('${userA}', 'https://push.example.com/a', 'pk', 'ak')
+       RETURNING id`,
+    )) as Array<{ id: string }>
+    expect(rows).toHaveLength(1)
+  })
+
+  it('user cannot insert a subscription for a different user', async () => {
+    await expectSqlError(
+      () =>
+        sqlAsUser(
+          userA,
+          `INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+           VALUES ('${userB}', 'https://push.example.com/x', 'pk', 'ak')
+           RETURNING id`,
+        ),
+      /row-level security/i,
+    )
+  })
+
+  it('user can only SELECT their own subscriptions', async () => {
+    // Seed one row per user via the service role (bypasses RLS)
+    await runSQLWithRetry(`
+      INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key) VALUES
+        ('${userA}', 'https://push.example.com/own-a', 'pk', 'ak'),
+        ('${userB}', 'https://push.example.com/own-b', 'pk', 'ak');
+    `)
+
+    const asA = (await sqlAsUser(
+      userA,
+      `SELECT user_id, endpoint FROM push_subscriptions ORDER BY endpoint`,
+    )) as Array<{ user_id: string; endpoint: string }>
+    expect(asA).toHaveLength(1)
+    expect(asA[0].user_id).toBe(userA)
+
+    const asB = (await sqlAsUser(
+      userB,
+      `SELECT user_id, endpoint FROM push_subscriptions ORDER BY endpoint`,
+    )) as Array<{ user_id: string; endpoint: string }>
+    expect(asB).toHaveLength(1)
+    expect(asB[0].user_id).toBe(userB)
+  })
+
+  it('user can DELETE their own subscription but not another user\'s', async () => {
+    await runSQLWithRetry(`
+      INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key) VALUES
+        ('${userA}', 'https://push.example.com/del-a', 'pk', 'ak'),
+        ('${userB}', 'https://push.example.com/del-b', 'pk', 'ak');
+    `)
+
+    // A tries to delete B's row — RLS filters to 0 rows affected (no error, no deletion)
+    await sqlAsUser(
+      userA,
+      `DELETE FROM push_subscriptions WHERE endpoint = 'https://push.example.com/del-b'`,
+    )
+    const stillThere = (await runSQLWithRetry(
+      `SELECT id FROM push_subscriptions WHERE endpoint = 'https://push.example.com/del-b'`,
+    )) as Array<{ id: string }>
+    expect(stillThere).toHaveLength(1)
+
+    // A deletes its own row — succeeds
+    await sqlAsUser(
+      userA,
+      `DELETE FROM push_subscriptions WHERE endpoint = 'https://push.example.com/del-a'`,
+    )
+    const ownGone = (await runSQLWithRetry(
+      `SELECT id FROM push_subscriptions WHERE endpoint = 'https://push.example.com/del-a'`,
+    )) as Array<{ id: string }>
+    expect(ownGone).toHaveLength(0)
+  })
+
+  it('enforces UNIQUE (user_id, endpoint)', async () => {
+    await sqlAsUser(
+      userA,
+      `INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+       VALUES ('${userA}', 'https://push.example.com/dup', 'pk', 'ak')
+       RETURNING id`,
+    )
+
+    await expectSqlError(
+      () =>
+        sqlAsUser(
+          userA,
+          `INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+           VALUES ('${userA}', 'https://push.example.com/dup', 'pk2', 'ak2')
+           RETURNING id`,
+        ),
+      /duplicate key|unique constraint/i,
+    )
+  })
+
+  it('different users can share the same endpoint', async () => {
+    await sqlAsUser(
+      userA,
+      `INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+       VALUES ('${userA}', 'https://push.example.com/shared', 'pk', 'ak')
+       RETURNING id`,
+    )
+    const rows = (await sqlAsUser(
+      userB,
+      `INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+       VALUES ('${userB}', 'https://push.example.com/shared', 'pk', 'ak')
+       RETURNING id`,
+    )) as Array<{ id: string }>
+    expect(rows).toHaveLength(1)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// notification_preferences
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('notification_preferences RLS + constraints', () => {
+  it('user can insert their own preferences row', async () => {
+    const rows = (await sqlAsUser(
+      userA,
+      `INSERT INTO notification_preferences (user_id)
+       VALUES ('${userA}')
+       RETURNING user_id, push_enabled, types_enabled, timezone`,
+    )) as Array<{
+      user_id: string
+      push_enabled: boolean
+      types_enabled: Record<string, boolean>
+      timezone: string
+    }>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].push_enabled).toBe(true)
+    expect(rows[0].timezone).toBe('UTC')
+    expect(rows[0].types_enabled).toEqual({
+      task_completed: true,
+      streak_milestone: true,
+      test: true,
+    })
+  })
+
+  it('user cannot insert preferences for another user', async () => {
+    await expectSqlError(
+      () =>
+        sqlAsUser(
+          userA,
+          `INSERT INTO notification_preferences (user_id) VALUES ('${userB}') RETURNING user_id`,
+        ),
+      /row-level security/i,
+    )
+  })
+
+  it('user can only SELECT their own preferences', async () => {
+    await runSQLWithRetry(`
+      INSERT INTO notification_preferences (user_id) VALUES ('${userA}'), ('${userB}')
+    `)
+
+    const asA = (await sqlAsUser(
+      userA,
+      `SELECT user_id FROM notification_preferences`,
+    )) as Array<{ user_id: string }>
+    expect(asA).toHaveLength(1)
+    expect(asA[0].user_id).toBe(userA)
+  })
+
+  it('user can UPDATE their own preferences but not another user\'s', async () => {
+    await runSQLWithRetry(`
+      INSERT INTO notification_preferences (user_id, push_enabled) VALUES
+        ('${userA}', true),
+        ('${userB}', true)
+    `)
+
+    // A attempts to disable B's notifications — RLS filters to 0 rows (no error, no update)
+    await sqlAsUser(
+      userA,
+      `UPDATE notification_preferences SET push_enabled = false WHERE user_id = '${userB}'`,
+    )
+    const bValue = (await runSQLWithRetry(
+      `SELECT push_enabled FROM notification_preferences WHERE user_id = '${userB}'`,
+    )) as Array<{ push_enabled: boolean }>
+    expect(bValue[0].push_enabled).toBe(true)
+
+    // A updates its own row — succeeds
+    await sqlAsUser(
+      userA,
+      `UPDATE notification_preferences SET push_enabled = false WHERE user_id = '${userA}'`,
+    )
+    const aValue = (await runSQLWithRetry(
+      `SELECT push_enabled FROM notification_preferences WHERE user_id = '${userA}'`,
+    )) as Array<{ push_enabled: boolean }>
+    expect(aValue[0].push_enabled).toBe(false)
+  })
+
+  it('rejects quiet_hours_start below 0', async () => {
+    await expectSqlError(
+      () =>
+        sqlAsUser(
+          userA,
+          `INSERT INTO notification_preferences (user_id, quiet_hours_start) VALUES ('${userA}', -1) RETURNING user_id`,
+        ),
+      /check constraint/i,
+    )
+  })
+
+  it('rejects quiet_hours_start above 23', async () => {
+    await expectSqlError(
+      () =>
+        sqlAsUser(
+          userA,
+          `INSERT INTO notification_preferences (user_id, quiet_hours_start) VALUES ('${userA}', 24) RETURNING user_id`,
+        ),
+      /check constraint/i,
+    )
+  })
+
+  it('rejects quiet_hours_end below 0', async () => {
+    await expectSqlError(
+      () =>
+        sqlAsUser(
+          userA,
+          `INSERT INTO notification_preferences (user_id, quiet_hours_end) VALUES ('${userA}', -5) RETURNING user_id`,
+        ),
+      /check constraint/i,
+    )
+  })
+
+  it('accepts boundary hours 0 and 23', async () => {
+    const rows = (await sqlAsUser(
+      userA,
+      `INSERT INTO notification_preferences (user_id, quiet_hours_start, quiet_hours_end)
+       VALUES ('${userA}', 0, 23)
+       RETURNING quiet_hours_start, quiet_hours_end`,
+    )) as Array<{ quiet_hours_start: number; quiet_hours_end: number }>
+    expect(rows[0].quiet_hours_start).toBe(0)
+    expect(rows[0].quiet_hours_end).toBe(23)
+  })
+
+  it('accepts NULL for quiet hours', async () => {
+    const rows = (await sqlAsUser(
+      userA,
+      `INSERT INTO notification_preferences (user_id, quiet_hours_start, quiet_hours_end)
+       VALUES ('${userA}', NULL, NULL)
+       RETURNING quiet_hours_start, quiet_hours_end`,
+    )) as Array<{ quiet_hours_start: number | null; quiet_hours_end: number | null }>
+    expect(rows[0].quiet_hours_start).toBeNull()
+    expect(rows[0].quiet_hours_end).toBeNull()
+  })
+
+  it('updated_at trigger bumps timestamp on UPDATE', async () => {
+    await runSQLWithRetry(
+      `INSERT INTO notification_preferences (user_id, updated_at) VALUES ('${userA}', '2020-01-01T00:00:00Z')`,
+    )
+    await sqlAsUser(
+      userA,
+      `UPDATE notification_preferences SET push_enabled = false WHERE user_id = '${userA}'`,
+    )
+    const rows = (await runSQLWithRetry(
+      `SELECT updated_at FROM notification_preferences WHERE user_id = '${userA}'`,
+    )) as Array<{ updated_at: string }>
+    expect(new Date(rows[0].updated_at).getFullYear()).toBeGreaterThan(2024)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// notification_type enum
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('notification_type enum', () => {
+  it('casts valid values', async () => {
+    const rows = (await runSQLWithRetry(
+      `SELECT 'task_completed'::notification_type AS t`,
+    )) as Array<{ t: string }>
+    expect(rows[0].t).toBe('task_completed')
+  })
+
+  it('rejects invalid values', async () => {
+    await expectSqlError(
+      () => runSQLWithRetry(`SELECT 'bogus_type'::notification_type AS t`),
+      /invalid input value for enum/i,
+    )
+  })
+
+  it('contains all expected values', async () => {
+    const rows = (await runSQLWithRetry(
+      `SELECT unnest(enum_range(NULL::notification_type))::text AS t ORDER BY t`,
+    )) as Array<{ t: string }>
+    const values = rows.map((r) => r.t).sort()
+    expect(values).toEqual(['streak_milestone', 'task_completed', 'test'])
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cascade on profile delete
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('cascade on profile delete', () => {
+  it('deletes push_subscriptions and notification_preferences when profile is deleted', async () => {
+    // Create a throwaway user so we can delete its profile without impacting userA/userB
+    const email = 'db-test-cascade@chore-champions-test.local'
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+    const existing = (await runSQLWithRetry(
+      `SELECT id FROM auth.users WHERE email = '${email}' LIMIT 1`,
+    )) as Array<{ id: string }>
+    let tempId: string
+    if (existing.length > 0) {
+      tempId = existing[0].id
+    } else {
+      const res = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${serviceRoleKey}`,
+          apikey: serviceRoleKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password: 'TestPassword123!', email_confirm: true }),
+      })
+      tempId = ((await res.json()) as { id: string }).id
+    }
+
+    await runSQLWithRetry(`
+      INSERT INTO profiles (id, display_name, role)
+      VALUES ('${tempId}', 'Cascade Test', 'child')
+      ON CONFLICT (id) DO NOTHING;
+      INSERT INTO push_subscriptions (user_id, endpoint, p256dh_key, auth_key)
+      VALUES ('${tempId}', 'https://push.example.com/cascade', 'pk', 'ak');
+      INSERT INTO notification_preferences (user_id) VALUES ('${tempId}');
+    `)
+
+    // Delete profile — FK cascades
+    await runSQLWithRetry(`DELETE FROM profiles WHERE id = '${tempId}'`)
+
+    const subs = (await runSQLWithRetry(
+      `SELECT id FROM push_subscriptions WHERE user_id = '${tempId}'`,
+    )) as unknown[]
+    expect(subs).toHaveLength(0)
+
+    const prefs = (await runSQLWithRetry(
+      `SELECT user_id FROM notification_preferences WHERE user_id = '${tempId}'`,
+    )) as unknown[]
+    expect(prefs).toHaveLength(0)
+
+    // Clean up the temp auth user
+    await fetch(`${supabaseUrl}/auth/v1/admin/users/${tempId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${serviceRoleKey}`,
+        apikey: serviceRoleKey,
+      },
+    })
+  })
+})

--- a/__tests__/lib/observability/constants.test.ts
+++ b/__tests__/lib/observability/constants.test.ts
@@ -20,6 +20,13 @@ describe('observability constants', () => {
     expect(APP_EVENT_TYPES).toContain('health_probe')
   })
 
+  it('APP_EVENT_TYPES contains push notification events', () => {
+    expect(APP_EVENT_TYPES).toContain('push_subscription_created')
+    expect(APP_EVENT_TYPES).toContain('push_subscription_deleted')
+    expect(APP_EVENT_TYPES).toContain('push_notification_sent')
+    expect(APP_EVENT_TYPES).toContain('push_notification_failed')
+  })
+
   it('APP_ERROR_TYPES contains expected values', () => {
     expect(APP_ERROR_TYPES).toContain('rpc')
     expect(APP_ERROR_TYPES).toContain('api')
@@ -43,6 +50,12 @@ describe('observability constants', () => {
     expect(ALLOWED_METADATA_KEYS.has('route')).toBe(true)
     expect(ALLOWED_METADATA_KEYS.has('rpcName')).toBe(true)
     expect(ALLOWED_METADATA_KEYS.has('taskName')).toBe(true)
+  })
+
+  it('ALLOWED_METADATA_KEYS includes push notification metadata', () => {
+    expect(ALLOWED_METADATA_KEYS.has('notificationType')).toBe(true)
+    expect(ALLOWED_METADATA_KEYS.has('subscriberCount')).toBe(true)
+    expect(ALLOWED_METADATA_KEYS.has('failureReason')).toBe(true)
   })
 
   it('METADATA_MAX_BYTES is defined', () => {

--- a/__tests__/lib/push/quiet-hours.test.ts
+++ b/__tests__/lib/push/quiet-hours.test.ts
@@ -1,0 +1,92 @@
+import { isWithinQuietHours } from '@/lib/push/quiet-hours'
+
+// Build a Date that represents a given UTC hour so we can reason about tz offsets.
+function utcAt(year: number, month: number, day: number, hour: number): Date {
+  return new Date(Date.UTC(year, month - 1, day, hour, 0, 0))
+}
+
+describe('isWithinQuietHours', () => {
+  const utc = 'UTC'
+
+  it('returns false when startHour is null', () => {
+    expect(isWithinQuietHours(utcAt(2026, 4, 11, 23), null, 7, utc)).toBe(false)
+  })
+
+  it('returns false when endHour is null', () => {
+    expect(isWithinQuietHours(utcAt(2026, 4, 11, 23), 22, null, utc)).toBe(false)
+  })
+
+  it('returns false when both bounds are null', () => {
+    expect(isWithinQuietHours(utcAt(2026, 4, 11, 23), null, null, utc)).toBe(false)
+  })
+
+  it('returns false when start equals end (empty window)', () => {
+    expect(isWithinQuietHours(utcAt(2026, 4, 11, 9), 9, 9, utc)).toBe(false)
+  })
+
+  describe('same-day range (9→17)', () => {
+    it('returns true at the start hour (inclusive)', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 9), 9, 17, utc)).toBe(true)
+    })
+
+    it('returns true in the middle of the window', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 13), 9, 17, utc)).toBe(true)
+    })
+
+    it('returns false at the end hour (exclusive)', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 17), 9, 17, utc)).toBe(false)
+    })
+
+    it('returns false before the window', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 8), 9, 17, utc)).toBe(false)
+    })
+
+    it('returns false after the window', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 20), 9, 17, utc)).toBe(false)
+    })
+  })
+
+  describe('overnight range (22→7)', () => {
+    it('returns true at start (22:00)', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 22), 22, 7, utc)).toBe(true)
+    })
+
+    it('returns true at 23:00 (before midnight)', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 23), 22, 7, utc)).toBe(true)
+    })
+
+    it('returns true at 03:00 (after midnight)', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 3), 22, 7, utc)).toBe(true)
+    })
+
+    it('returns false at 07:00 (end hour, exclusive)', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 7), 22, 7, utc)).toBe(false)
+    })
+
+    it('returns false at noon', () => {
+      expect(isWithinQuietHours(utcAt(2026, 4, 11, 12), 22, 7, utc)).toBe(false)
+    })
+  })
+
+  describe('timezone conversion', () => {
+    it('uses the user timezone, not UTC, to compute the current hour', () => {
+      // 06:00 UTC is 23:00 the previous day in America/Los_Angeles (UTC-7 during DST).
+      // A 22→7 window in LA should include 23:00 LA time.
+      const moment = utcAt(2026, 4, 11, 6)
+      expect(isWithinQuietHours(moment, 22, 7, 'America/Los_Angeles')).toBe(true)
+    })
+
+    it('is tz-aware across date boundaries', () => {
+      // 14:00 UTC = 07:00 LA. A 22→7 overnight window is inclusive of [22,0)∪[0,7),
+      // and 07:00 itself is the exclusive end, so LA 07:00 should be OUTSIDE the window.
+      const moment = utcAt(2026, 4, 11, 14)
+      expect(isWithinQuietHours(moment, 22, 7, 'America/Los_Angeles')).toBe(false)
+    })
+
+    it('handles a positive-offset tz (Asia/Tokyo, UTC+9)', () => {
+      // 00:00 UTC = 09:00 Tokyo; a 9→17 window should match.
+      const moment = utcAt(2026, 4, 11, 0)
+      expect(isWithinQuietHours(moment, 9, 17, 'Asia/Tokyo')).toBe(true)
+    })
+  })
+})

--- a/__tests__/lib/push/types.test.ts
+++ b/__tests__/lib/push/types.test.ts
@@ -1,0 +1,44 @@
+import {
+  NOTIFICATION_TYPES,
+  DEFAULT_TYPES_ENABLED,
+  isNotificationType,
+} from '@/lib/push/types'
+
+describe('NOTIFICATION_TYPES', () => {
+  it('exposes the expected set of types', () => {
+    expect(NOTIFICATION_TYPES).toEqual(['task_completed', 'streak_milestone', 'test'])
+  })
+})
+
+describe('DEFAULT_TYPES_ENABLED', () => {
+  it('defaults every notification type to enabled', () => {
+    for (const t of NOTIFICATION_TYPES) {
+      expect(DEFAULT_TYPES_ENABLED[t]).toBe(true)
+    }
+  })
+
+  it('has exactly one key per NOTIFICATION_TYPES entry', () => {
+    expect(Object.keys(DEFAULT_TYPES_ENABLED).sort()).toEqual([...NOTIFICATION_TYPES].sort())
+  })
+})
+
+describe('isNotificationType', () => {
+  it('accepts known types', () => {
+    expect(isNotificationType('task_completed')).toBe(true)
+    expect(isNotificationType('streak_milestone')).toBe(true)
+    expect(isNotificationType('test')).toBe(true)
+  })
+
+  it('rejects unknown strings', () => {
+    expect(isNotificationType('bogus')).toBe(false)
+    expect(isNotificationType('')).toBe(false)
+  })
+
+  it('rejects non-string values', () => {
+    expect(isNotificationType(null)).toBe(false)
+    expect(isNotificationType(undefined)).toBe(false)
+    expect(isNotificationType(42)).toBe(false)
+    expect(isNotificationType({})).toBe(false)
+    expect(isNotificationType(['task_completed'])).toBe(false)
+  })
+})

--- a/app/api/push/preferences/route.ts
+++ b/app/api/push/preferences/route.ts
@@ -1,0 +1,231 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+import {
+  DEFAULT_TYPES_ENABLED,
+  NOTIFICATION_TYPES,
+  type NotificationPreferences,
+  type NotificationType,
+  type TypesEnabled,
+} from '@/lib/push/types'
+
+interface PrefsRow {
+  user_id: string
+  push_enabled: boolean
+  types_enabled: unknown
+  quiet_hours_start: number | null
+  quiet_hours_end: number | null
+  timezone: string
+  updated_at: string
+}
+
+function normalizeTypesEnabled(raw: unknown): TypesEnabled {
+  const merged: TypesEnabled = { ...DEFAULT_TYPES_ENABLED }
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    for (const type of NOTIFICATION_TYPES) {
+      const value = (raw as Record<string, unknown>)[type]
+      if (typeof value === 'boolean') {
+        merged[type] = value
+      }
+    }
+  }
+  return merged
+}
+
+function rowToPreferences(row: PrefsRow): NotificationPreferences {
+  return {
+    user_id: row.user_id,
+    push_enabled: row.push_enabled,
+    types_enabled: normalizeTypesEnabled(row.types_enabled),
+    quiet_hours_start: row.quiet_hours_start,
+    quiet_hours_end: row.quiet_hours_end,
+    timezone: row.timezone,
+    updated_at: row.updated_at,
+  }
+}
+
+async function getHandler(): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: existing, error: selectError } = await supabase
+    .from('notification_preferences')
+    .select('*')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (selectError) {
+    return NextResponse.json({ error: 'Failed to load preferences' }, { status: 500 })
+  }
+
+  if (existing) {
+    return NextResponse.json({ data: rowToPreferences(existing as PrefsRow) })
+  }
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('notification_preferences')
+    .insert({ user_id: user.id })
+    .select('*')
+    .single()
+
+  if (insertError || !inserted) {
+    return NextResponse.json({ error: 'Failed to create preferences' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: rowToPreferences(inserted as PrefsRow) })
+}
+
+interface ValidatedPatch {
+  push_enabled?: boolean
+  types_enabled?: TypesEnabled
+  quiet_hours_start?: number | null
+  quiet_hours_end?: number | null
+  timezone?: string
+}
+
+function isValidHour(value: unknown): value is number | null {
+  if (value === null) return true
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 23
+}
+
+function isValidTimezone(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) return false
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function validatePatch(body: unknown): ValidatedPatch | { error: string } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { error: 'Invalid body' }
+  }
+  const input = body as Record<string, unknown>
+  const patch: ValidatedPatch = {}
+
+  if ('push_enabled' in input) {
+    if (typeof input.push_enabled !== 'boolean') {
+      return { error: 'push_enabled must be a boolean' }
+    }
+    patch.push_enabled = input.push_enabled
+  }
+
+  if ('types_enabled' in input) {
+    const raw = input.types_enabled
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { error: 'types_enabled must be an object' }
+    }
+    const entries = raw as Record<string, unknown>
+    for (const [key, value] of Object.entries(entries)) {
+      if (!(NOTIFICATION_TYPES as readonly string[]).includes(key)) {
+        return { error: `Unknown notification type: ${key}` }
+      }
+      if (typeof value !== 'boolean') {
+        return { error: `types_enabled.${key} must be a boolean` }
+      }
+    }
+    patch.types_enabled = entries as unknown as TypesEnabled
+  }
+
+  if ('quiet_hours_start' in input) {
+    if (!isValidHour(input.quiet_hours_start)) {
+      return { error: 'quiet_hours_start must be null or an integer 0-23' }
+    }
+    patch.quiet_hours_start = input.quiet_hours_start as number | null
+  }
+
+  if ('quiet_hours_end' in input) {
+    if (!isValidHour(input.quiet_hours_end)) {
+      return { error: 'quiet_hours_end must be null or an integer 0-23' }
+    }
+    patch.quiet_hours_end = input.quiet_hours_end as number | null
+  }
+
+  if ('timezone' in input) {
+    if (!isValidTimezone(input.timezone)) {
+      return { error: 'Invalid timezone' }
+    }
+    patch.timezone = input.timezone
+  }
+
+  return patch
+}
+
+async function patchHandler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const result = validatePatch(body)
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 400 })
+  }
+
+  const { data: existing } = await supabase
+    .from('notification_preferences')
+    .select('*')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  const current: NotificationPreferences = existing
+    ? rowToPreferences(existing as PrefsRow)
+    : {
+        user_id: user.id,
+        push_enabled: true,
+        types_enabled: { ...DEFAULT_TYPES_ENABLED },
+        quiet_hours_start: null,
+        quiet_hours_end: null,
+        timezone: 'UTC',
+        updated_at: new Date().toISOString(),
+      }
+
+  const mergedTypes: TypesEnabled = { ...current.types_enabled }
+  if (result.types_enabled) {
+    for (const type of NOTIFICATION_TYPES) {
+      const value = result.types_enabled[type as NotificationType]
+      if (typeof value === 'boolean') {
+        mergedTypes[type as NotificationType] = value
+      }
+    }
+  }
+
+  const nextRow = {
+    user_id: user.id,
+    push_enabled: result.push_enabled ?? current.push_enabled,
+    types_enabled: mergedTypes,
+    quiet_hours_start:
+      'quiet_hours_start' in result ? (result.quiet_hours_start ?? null) : current.quiet_hours_start,
+    quiet_hours_end:
+      'quiet_hours_end' in result ? (result.quiet_hours_end ?? null) : current.quiet_hours_end,
+    timezone: result.timezone ?? current.timezone,
+  }
+
+  const { data: saved, error: saveError } = await supabase
+    .from('notification_preferences')
+    .upsert(nextRow, { onConflict: 'user_id' })
+    .select('*')
+    .single()
+
+  if (saveError || !saved) {
+    return NextResponse.json({ error: 'Failed to save preferences' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: rowToPreferences(saved as PrefsRow) })
+}
+
+export const GET = withObservability(getHandler)
+export const PATCH = withObservability(patchHandler)

--- a/lib/observability/constants.ts
+++ b/lib/observability/constants.ts
@@ -15,6 +15,10 @@ export const APP_EVENT_TYPES = [
   'rpc_call',
   'page_view',
   'health_probe',
+  'push_subscription_created',
+  'push_subscription_deleted',
+  'push_notification_sent',
+  'push_notification_failed',
 ] as const
 
 export type AppEventType = typeof APP_EVENT_TYPES[number]
@@ -52,6 +56,9 @@ export const ALLOWED_METADATA_KEYS = new Set([
   'conversationId',
   'streamDurationMs',
   'responseLength',
+  'notificationType',
+  'subscriberCount',
+  'failureReason',
 ])
 
 export const METADATA_MAX_BYTES = 10 * 1024 // 10KB per metadata object

--- a/lib/push/quiet-hours.ts
+++ b/lib/push/quiet-hours.ts
@@ -1,0 +1,33 @@
+/**
+ * Returns true if `now` falls within the user's quiet-hours window.
+ *
+ * Hours are 0-23 in the user's local `timezone`. A null on either bound
+ * disables quiet hours. An overnight range (e.g. 22→7) is detected when
+ * start > end and wraps midnight. The window is inclusive of `startHour`
+ * and exclusive of `endHour`, so a 9→17 window blocks 09:00 but not 17:00.
+ */
+export function isWithinQuietHours(
+  now: Date,
+  startHour: number | null,
+  endHour: number | null,
+  timezone: string,
+): boolean {
+  if (startHour === null || endHour === null) return false
+  if (startHour === endHour) return false
+
+  const hourInTz = getHourInTimeZone(now, timezone)
+
+  if (startHour < endHour) {
+    return hourInTz >= startHour && hourInTz < endHour
+  }
+  return hourInTz >= startHour || hourInTz < endHour
+}
+
+function getHourInTimeZone(now: Date, timezone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: '2-digit',
+    hourCycle: 'h23',
+  })
+  return parseInt(formatter.format(now), 10)
+}

--- a/lib/push/types.ts
+++ b/lib/push/types.ts
@@ -1,0 +1,33 @@
+export const NOTIFICATION_TYPES = ['task_completed', 'streak_milestone', 'test'] as const
+
+export type NotificationType = (typeof NOTIFICATION_TYPES)[number]
+
+export function isNotificationType(value: unknown): value is NotificationType {
+  return typeof value === 'string' && (NOTIFICATION_TYPES as readonly string[]).includes(value)
+}
+
+export type TypesEnabled = Record<NotificationType, boolean>
+
+export const DEFAULT_TYPES_ENABLED: TypesEnabled = {
+  task_completed: true,
+  streak_milestone: true,
+  test: true,
+}
+
+export interface NotificationPreferences {
+  user_id: string
+  push_enabled: boolean
+  types_enabled: TypesEnabled
+  quiet_hours_start: number | null
+  quiet_hours_end: number | null
+  timezone: string
+  updated_at: string
+}
+
+export interface NotificationPreferencesPatch {
+  push_enabled?: boolean
+  types_enabled?: Partial<TypesEnabled>
+  quiet_hours_start?: number | null
+  quiet_hours_end?: number | null
+  timezone?: string
+}

--- a/plans/issue-47-push-notifications.md
+++ b/plans/issue-47-push-notifications.md
@@ -1,0 +1,688 @@
+# Issue #47 — Push Notifications & Reminders
+
+**Status:** Draft — awaiting review
+**Branch:** `feature/issue-47-push-notifications`
+**Related:** #46 (approval workflow — not yet built), #38–40 (gamification), #57 (initiative reward)
+
+---
+
+## 1. Goal
+
+Let families opt in to web push notifications so kids and parents get timely, relevant nudges about chores, milestones, and family activity — without pulling them back into the app manually.
+
+## 2. Scope
+
+### In scope (this PR — "Phase 1: foundation + event-driven pushes")
+
+- `push_subscriptions` + `notification_preferences` tables with RLS
+- VAPID keypair generation + env-var wiring
+- Service worker at `public/sw.js` handling `push` and `notificationclick`
+- Client subscribe/unsubscribe flow (registers SW, asks permission, posts subscription to API)
+- Server send helper `lib/push/send.ts` using `web-push` npm package
+- API routes:
+  - `POST /api/push/subscribe` — store subscription
+  - `POST /api/push/unsubscribe` — remove subscription
+  - `GET /api/push/preferences` — read prefs (auto-creates default row)
+  - `PATCH /api/push/preferences` — update prefs
+- Settings UI: new **Notifications** tab on `/me` with enable toggle, per-type toggles, quiet-hours inputs, and a "Send test notification" button
+- **Two event-driven push types wired end-to-end:**
+  1. **Task completed (parent)** — when a child inserts a `task_completions` row, each parent in the family with the `task_completed` pref enabled gets a push: *"Leo completed 'Take out trash'"*. Fires from a new `POST /api/tasks/complete` route that wraps the existing client-side insert (see §6 for why we're refactoring this path).
+  2. **Streak milestone (child)** — when `claim_streak_milestone` RPC returns success on the client, the client calls `POST /api/push/trigger/streak-milestone` which sends the child a celebratory push. Parents in the family also get one if they have the pref on.
+- Quiet hours + per-type preference enforcement inside `lib/push/send.ts`
+- Full unit + E2E test coverage (see §9)
+- Observability events: `push_subscription_created`, `push_subscription_deleted`, `push_notification_sent`, `push_notification_failed`
+
+### Explicitly out of scope (defer to issue #47b / new issue)
+
+- Scheduled notifications: morning task reminders, overdue alerts, streak-at-risk warnings, weekly summary. These need Vercel Cron or Supabase Edge Function scheduling — separate infra decision, separate PR.
+- Approval request / approval result pushes — blocked on issue #46 (approval workflow doesn't exist yet).
+- Achievement-unlocked pushes for badges (blocked on issue #39).
+- iOS Safari home-screen PWA push — web push works on iOS 16.4+ only for installed PWAs; we'll document the limitation in the UI but not build install prompts here.
+- Rich notification actions (Accept/Dismiss buttons in the notification itself).
+- Notification history / in-app inbox.
+
+**Reason to split:** Scheduled pushes are a separate architectural conversation (where does the cron run? who pays? what's the failure mode?). Bundling them makes the PR unreviewable and couples unrelated risks.
+
+## 3. Architecture
+
+```
+┌──────────────┐   subscribe    ┌─────────────────────┐
+│   Browser    │ ─────────────► │  /api/push/*        │
+│              │                │  (Next.js routes)    │
+│  sw.js       │                └──────────┬──────────┘
+│  ↑ push      │                           │
+│  ↑ notif     │                           ▼
+└──────┬───────┘                ┌─────────────────────┐
+       │                        │  Supabase           │
+       │        web-push        │  push_subscriptions │
+       │      ◄────────────     │  notification_prefs │
+       │                        └─────────────────────┘
+       │
+       │                        ┌─────────────────────┐
+       └────────────────────────│  Web Push Service   │
+              (VAPID)           │  (FCM / Mozilla)    │
+                                └─────────────────────┘
+```
+
+**Send path:** Event happens (task completion, streak milestone) → API route handler calls `sendPushToUser(userId, { type, title, body, url })` → helper reads `notification_preferences` (skips if disabled or in quiet hours) → reads all `push_subscriptions` rows → `web-push.sendNotification()` in parallel → on `410 Gone`, deletes the stale subscription → logs observability event.
+
+## 4. Database changes
+
+**Migration:** `supabase/migrations/017_add_push_notifications.sql`
+
+```sql
+-- ============================================================================
+-- Push Notifications
+-- ============================================================================
+
+CREATE TABLE push_subscriptions (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  endpoint     text        NOT NULL,
+  p256dh_key   text        NOT NULL,
+  auth_key     text        NOT NULL,
+  user_agent   text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, endpoint)
+);
+
+CREATE INDEX push_subscriptions_user_id_idx ON push_subscriptions(user_id);
+
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_select_own_subscriptions" ON push_subscriptions
+  FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY "users_insert_own_subscriptions" ON push_subscriptions
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "users_delete_own_subscriptions" ON push_subscriptions
+  FOR DELETE USING (user_id = auth.uid());
+
+-- ----------------------------------------------------------------------------
+
+CREATE TYPE notification_type AS ENUM (
+  'task_completed',       -- parent: child completed a task
+  'streak_milestone',     -- child + parent: streak milestone hit
+  'test'                  -- "Send test notification" button
+);
+
+CREATE TABLE notification_preferences (
+  user_id          uuid        PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  push_enabled     boolean     NOT NULL DEFAULT true,
+  types_enabled    jsonb       NOT NULL DEFAULT '{"task_completed":true,"streak_milestone":true,"test":true}'::jsonb,
+  quiet_hours_start smallint   CHECK (quiet_hours_start BETWEEN 0 AND 23),
+  quiet_hours_end   smallint   CHECK (quiet_hours_end BETWEEN 0 AND 23),
+  timezone         text        NOT NULL DEFAULT 'UTC',
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_manage_own_preferences" ON notification_preferences
+  FOR ALL USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+```
+
+**Design notes:**
+- `types_enabled` as JSONB (not a join table) keeps the common path cheap — one row per user, one query per send.
+- `quiet_hours_start/end` are ints in the user's local timezone. `NULL` = no quiet hours. Overnight ranges (e.g. 22→7) handled in app logic (`start > end` means the range wraps midnight).
+- Using a Postgres ENUM for `notification_type` for server-side validation; client passes strings.
+- `UNIQUE (user_id, endpoint)` prevents duplicate rows when a user re-subscribes from the same device.
+- No `SECURITY DEFINER` RPC needed — all writes are scoped to `auth.uid()` and expressible as plain RLS.
+
+## 5. File tree
+
+```
+plans/issue-47-push-notifications.md                    (this file)
+
+supabase/migrations/017_add_push_notifications.sql      NEW
+
+public/sw.js                                            NEW — service worker
+next.config.ts                                          EDIT — sw.js cache headers
+
+lib/push/
+  send.ts                                               NEW — sendPushToUser helper
+  subscribe.ts                                          NEW — client SW register + subscribe
+  vapid.ts                                              NEW — VAPID key helpers, urlBase64ToUint8Array
+  quiet-hours.ts                                        NEW — pure isWithinQuietHours(now, start, end, tz)
+  types.ts                                              NEW — NotificationType, Preferences types
+
+lib/observability/constants.ts                          EDIT — add 4 new APP_EVENT_TYPES
+
+lib/types.ts                                            EDIT — export new types
+
+app/api/push/subscribe/route.ts                         NEW
+app/api/push/unsubscribe/route.ts                       NEW
+app/api/push/preferences/route.ts                       NEW — GET + PATCH
+app/api/push/test/route.ts                              NEW — "send test" button
+app/api/push/trigger/streak-milestone/route.ts          NEW — called after claim_streak_milestone
+
+app/api/tasks/complete/route.ts                         NEW — wraps completion insert + fires parent push
+
+app/(dashboard)/quests/page.tsx                         EDIT — call new API route instead of direct insert
+components/streaks/streak-tab.tsx                       EDIT — call trigger route after claim (if that's the claim site)
+
+app/(dashboard)/me/page.tsx                             EDIT — add "Notifications" tab
+
+components/me/notification-settings-tab.tsx             NEW — the settings UI
+components/me/permission-prompt.tsx                     NEW — "Enable notifications" CTA with browser permission state
+
+__tests__/lib/push/send.test.ts                         NEW
+__tests__/lib/push/subscribe.test.ts                    NEW
+__tests__/lib/push/quiet-hours.test.ts                  NEW
+__tests__/lib/push/vapid.test.ts                        NEW
+__tests__/api/push/subscribe.test.ts                    NEW
+__tests__/api/push/unsubscribe.test.ts                  NEW
+__tests__/api/push/preferences.test.ts                  NEW
+__tests__/api/push/test.test.ts                         NEW
+__tests__/api/push/trigger-streak-milestone.test.ts     NEW
+__tests__/api/tasks/complete.test.ts                    NEW
+__tests__/components/me/notification-settings-tab.test.tsx   NEW
+__tests__/components/me/permission-prompt.test.tsx      NEW
+
+__tests__/db/push-notifications.test.ts                 NEW — RLS + constraints (npm run test:db)
+
+e2e/push-notifications.spec.ts                          NEW
+e2e/push-delivery.spec.ts                               NEW
+e2e/push-helpers.ts                                     NEW
+playwright.config.ts                                    EDIT — add to testMatch regex
+
+.env.local                                              EDIT — VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT
+package.json                                            EDIT — add web-push dep
+```
+
+**Estimated diff:** ~1,800 LOC production + ~1,400 LOC tests.
+
+## 6. Implementation notes
+
+### 6.1 Why a new `POST /api/tasks/complete` route?
+
+Currently `app/(dashboard)/quests/page.tsx:277` inserts into `task_completions` directly from the client. To send a push to the parent when a child completes a task, we need server code that runs after the insert. Options considered:
+
+| Option | Pros | Cons |
+|---|---|---|
+| DB trigger → Edge Function | Robust, decoupled | Needs edge function infra — out of scope |
+| pg_net from trigger | No extra infra | Brittle, hard to test, secrets in DB |
+| **Server route (chosen)** | Easy to test, same stack as rest of app, observable | Requires refactoring one client call |
+
+The new route validates the caller owns the task's family, inserts the completion, then triggers the push. The client swaps one `supabase.from(...).insert(...)` call for `fetch('/api/tasks/complete', ...)`. All existing completion behavior (points award, streak update via DB triggers) is preserved because we're still writing the same row to the same table.
+
+### 6.2 `web-push` package
+
+- Installed as a regular dependency (server-only code path; not bundled client-side because `lib/push/send.ts` is only imported from route handlers).
+- Types: `@types/web-push`.
+- VAPID keys generated once with `npx web-push generate-vapid-keys`, stored in `.env.local` and GitHub secrets.
+
+### 6.3 Service worker (`public/sw.js`)
+
+Kept intentionally tiny and dependency-free:
+
+```js
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+  const payload = event.data.json();
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      icon: '/icons/notification-192.png',
+      badge: '/icons/badge-72.png',
+      data: { url: payload.url || '/' },
+      tag: payload.tag,
+    })
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || '/';
+  event.waitUntil(
+    clients.matchAll({ type: 'window' }).then((windowClients) => {
+      const existing = windowClients.find((c) => c.url.includes(url));
+      if (existing) return existing.focus();
+      return clients.openWindow(url);
+    })
+  );
+});
+```
+
+Served with `Cache-Control: public, max-age=0, must-revalidate` via `next.config.ts` header rule.
+
+### 6.4 Quiet hours logic
+
+`lib/push/quiet-hours.ts` exports a pure function — no DB, no clock reads — so it's trivially unit-testable:
+
+```ts
+export function isWithinQuietHours(
+  now: Date,
+  startHour: number | null,
+  endHour: number | null,
+  timezone: string
+): boolean
+```
+
+Handles `null` (no quiet hours), same-day range (9→17), and overnight range (22→7). Uses `Intl.DateTimeFormat` with the user's tz to get the current hour.
+
+### 6.5 Stale subscription cleanup
+
+`web-push.sendNotification()` throws with `statusCode: 410` (Gone) or `404` when the subscription is dead. `sendPushToUser` catches these and deletes the row. Any other error is logged as `push_notification_failed` observability event and swallowed — a push failure must never break the triggering user action.
+
+### 6.6 Observability
+
+Add to `lib/observability/constants.ts` `APP_EVENT_TYPES`:
+- `push_subscription_created`
+- `push_subscription_deleted`
+- `push_notification_sent`
+- `push_notification_failed`
+
+Add allowed metadata keys: `notificationType`, `subscriberCount`, `failureReason`.
+
+## 7. UI design
+
+### 7.1 Notifications tab on `/me`
+
+```
+┌─ Notifications ──────────────────────────────────────┐
+│                                                      │
+│  Push notifications                     [   ○]      │   ← master toggle
+│  Get reminders and celebrations on this device.     │
+│                                                      │
+│  ┌─ Permission: Allowed ────────┐                   │   (or "Blocked" / "Not asked")
+│  │  Unsubscribe from this device │                   │
+│  └───────────────────────────────┘                   │
+│                                                      │
+│  ─ What to notify me about ──                        │
+│                                                      │
+│  Kid completes a task              [●  ]            │   (parents only)
+│  Streak milestone reached          [●  ]            │
+│                                                      │
+│  ─ Quiet hours ──                                    │
+│                                                      │
+│  Don't send between  [22:00]  and  [07:00]           │
+│                                                      │
+│  ─────────────────────────                           │
+│                                                      │
+│  [Send test notification]                            │
+│                                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+- Master toggle off → all type toggles disabled + greyed
+- Permission `denied` → show instruction: "You'll need to enable notifications in your browser settings"
+- Permission `default` → "Enable notifications" CTA triggers subscribe flow
+- Per-role visibility: "Kid completes a task" toggle only shown to parents
+- Changes debounced 500ms then PATCH to `/api/push/preferences`
+- Test button disabled if master toggle off or permission not granted
+
+### 7.2 Notification content
+
+| Type | Title | Body | URL |
+|---|---|---|---|
+| task_completed | `🎉 {childName} completed a task` | `"{taskTitle}" — tap to see` | `/quests` |
+| streak_milestone | `🔥 {days}-day streak!` | `{childName} hit a {days}-day streak` | `/me?tab=streaks` |
+| test | `Chore Champions test` | `Notifications are working on this device.` | `/me?tab=notifications` |
+
+## 8. Test plan — target 100% coverage on new code
+
+### 8.1 Unit tests (Jest + RTL)
+
+**`lib/push/quiet-hours.test.ts`** (pure function)
+- `null start/end` → `false`
+- Same-day range 9→17, current 10 → `true`
+- Same-day range 9→17, current 20 → `false`
+- Overnight range 22→7, current 23 → `true`
+- Overnight range 22→7, current 3 → `true`
+- Overnight range 22→7, current 12 → `false`
+- Non-UTC timezone (`'America/Los_Angeles'`) — mock Date to an absolute moment, verify tz conversion
+- Boundary: exactly `start` → `true`; exactly `end` → `false`
+
+**`lib/push/vapid.test.ts`**
+- `urlBase64ToUint8Array` round-trip with known VAPID public key
+- Padding handling (length % 4)
+
+**`lib/push/subscribe.test.ts`** (client helper; mock `navigator.serviceWorker` and `PushManager`)
+- `subscribe()` returns existing subscription if already subscribed
+- `subscribe()` registers SW, requests permission, subscribes, POSTs to `/api/push/subscribe`
+- Rejects if permission denied
+- `unsubscribe()` unsubs browser side + POSTs to `/api/push/unsubscribe`
+- SW registration failure bubbles up
+
+**`lib/push/send.test.ts`** (mock `web-push` module + supabase)
+- No preferences row → auto-creates default + sends
+- `push_enabled = false` → no send
+- Type disabled in `types_enabled` → no send
+- Within quiet hours → no send (verify via injected `now`)
+- Multiple subscriptions → all notified in parallel
+- `410 Gone` response → row deleted, observability event logged
+- Other error → `push_notification_failed` logged, no throw
+- `subscriberCount` in sent observability event matches actual count
+
+**`app/api/push/subscribe/route.test.ts`**
+- 401 when unauthenticated
+- 400 on missing/invalid payload (no endpoint, no keys)
+- 200 on valid payload; row upserted
+- Idempotent: second call with same endpoint returns 200, no duplicate
+
+**`app/api/push/unsubscribe/route.test.ts`**
+- 401 when unauthed
+- 400 on missing endpoint
+- 200 on success, row deleted
+- 200 when row didn't exist (idempotent)
+
+**`app/api/push/preferences/route.test.ts`** (GET + PATCH)
+- GET 401 unauthed
+- GET auto-creates default row if none exists
+- GET returns existing row
+- PATCH 401 unauthed
+- PATCH 400 on invalid `quiet_hours_start` (<0, >23, non-int)
+- PATCH 400 on invalid `types_enabled` shape
+- PATCH 200 and merges partial updates (only `push_enabled` provided leaves other fields untouched)
+
+**`app/api/push/test/route.test.ts`**
+- 401 unauthed
+- Calls `sendPushToUser` with type `'test'`
+- Returns 200 + `{ sent: count }`
+
+**`app/api/push/trigger/streak-milestone/route.test.ts`**
+- 401 unauthed
+- 400 on missing `days` in body
+- Sends push to child
+- Sends push to all parents in family
+- Parent pref off → only child notified
+
+**`app/api/tasks/complete/route.test.ts`**
+- 401 unauthed
+- 400 on missing `taskId`
+- 403 if user not in task's family
+- Inserts completion row
+- Fires `sendPushToUser` once per parent with type `'task_completed'`
+- Push failure does NOT fail the request (critical: completion must succeed)
+
+**`components/me/notification-settings-tab.test.tsx`**
+- Renders master toggle based on fetched prefs
+- Parent sees "Kid completes a task" toggle; child does not
+- Toggling master → PATCH debounced call
+- Toggling a type → PATCH with merged `types_enabled`
+- Permission denied → shows blocked message, CTA disabled
+- Permission default → clicking "Enable" calls subscribe helper
+- "Send test notification" → POSTs to `/api/push/test`, shows toast on success
+- Loading state shows skeleton
+- Error state shows retry
+
+**`components/me/permission-prompt.test.tsx`**
+- Renders state based on `Notification.permission` (mock)
+- Click calls `Notification.requestPermission`
+- Calls `onGranted` callback on grant
+
+### 8.2 E2E tests — UI flows (`e2e/push-notifications.spec.ts`)
+
+Pre-grant notification permission at the context level (`permissions: ['notifications']`) so the real subscribe path runs. No request stubbing for push endpoints — we want the real rows written and read, and we'll clean them up in `afterEach` via `runSQL` helper (already available from `e2e/supabase-admin.ts`).
+
+**parent project:**
+- Navigate to `/me`, click `Notifications` tab
+- Master toggle reflects fetched prefs (default on)
+- Toggle master off → PATCH to `/api/push/preferences` lands → reload → still off
+- Toggle master on → `subscribe()` runs → row appears in `push_subscriptions` (assert via `runSQL`)
+- Toggle `task_completed` off → PATCH with merged types → reload confirms
+- Set quiet hours 22→7 → PATCH observed → row reflects values
+- Click `Send test` button → see success toast
+- Unsubscribe via the tab → row deleted from `push_subscriptions` (assert via `runSQL`)
+
+**child project:**
+- Navigate to `/me` → `Notifications` tab
+- Parent-only `task_completed` toggle NOT rendered
+- `streak_milestone` toggle rendered and togglable
+
+### 8.3 E2E push delivery tests (`e2e/push-delivery.spec.ts`)
+
+These tests exercise the real end-to-end path — our server calls `web-push.sendNotification()`, and we use Chrome DevTools Protocol `ServiceWorker.deliverPushMessage` to deliver the push payload to the SW without going through FCM/Mozilla push. The SW's `push` handler runs for real, `registration.showNotification()` is called for real, and we assert the resulting notification via `registration.getNotifications()` evaluated in the page context.
+
+**Helper (`e2e/push-helpers.ts`):**
+
+```ts
+export async function getShownNotifications(page: Page) {
+  return page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.ready;
+    const notifs = await reg.getNotifications();
+    return notifs.map((n) => ({ title: n.title, body: n.body, tag: n.tag, data: n.data }));
+  });
+}
+
+export async function clearNotifications(page: Page) {
+  await page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.ready;
+    const notifs = await reg.getNotifications();
+    notifs.forEach((n) => n.close());
+  });
+}
+
+export async function waitForNotification(page: Page, predicate: (n: { title: string }) => boolean, timeout = 5000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const notifs = await getShownNotifications(page);
+    const match = notifs.find(predicate);
+    if (match) return match;
+    await page.waitForTimeout(100);
+  }
+  throw new Error('Timed out waiting for notification');
+}
+```
+
+We don't need to call CDP `deliverPushMessage` manually — `web-push.sendNotification()` POSTs to the browser's push endpoint which, in CI, is Chrome's test-mode push service that delivers synchronously in the same browser instance. If that proves flaky, we fall back to an explicit CDP session:
+
+```ts
+const cdp = await context.newCDPSession(page);
+await cdp.send('ServiceWorker.deliverPushMessage', { origin, registrationId, data });
+```
+
+**Tests:**
+
+1. **Test-button delivery (parent)** — subscribe, click "Send test", assert notification with title matching "Chore Champions test" appears via `waitForNotification`.
+2. **Click → navigation** — after #1, call `notification.click()` via `page.evaluate`, assert page navigates to `/me?tab=notifications`.
+3. **Task completion → parent push (two contexts in one spec)** — launch a second browser context with `.auth/child.json` alongside the parent context with `.auth/parent.json`. Both subscribe. Child completes a real task via the UI (using the existing quests flow). Assert the parent context's SW has a notification whose body contains the task title. Assert the child context has no such notification.
+4. **Streak milestone → child push** — same two-context pattern. Claim milestone (seed the streak via `runSQL` to a pre-milestone state first). Assert child context received streak push; assert parent also received it if their pref is on; flip parent pref off and repeat, assert parent does NOT receive it.
+5. **Type toggle suppresses send** — as parent, toggle `task_completed` off. Have child complete a task. `getShownNotifications` returns empty for parent. (Wait a fixed 1s to give any racing send time to land, then assert still empty.)
+6. **Quiet hours suppress send** — set quiet hours spanning the current hour (compute via `new Date().getHours()` and set start=current-1, end=current+1). Trigger test button. Assert no notification. Restore prefs.
+7. **Permission revoked → UI reflects state** — call `context.clearPermissions()`. Navigate to `/me?tab=notifications`. Assert the "Blocked" message renders. Attempting to subscribe is disabled.
+8. **Stale subscription cleanup** — seed a fake row via `runSQL` with a known-bad endpoint (points to a deliberately invalid push service URL). Trigger test button. Assert the bad row is deleted (via `runSQL`) and the valid row remains. Observability event `push_subscription_deleted` logged (check via `runSQL` on observability table).
+
+**Cleanup:** `afterEach` calls `runSQL` to delete any `push_subscriptions` or `notification_preferences` rows belonging to the test users, so tests are idempotent.
+
+**Registration:** add `push-notifications.spec.ts` and `push-delivery.spec.ts` to the `testMatch` regex in `playwright.config.ts` for both `parent` and `child` projects where applicable.
+
+### 8.4 DB integration tests (`__tests__/db/push-notifications.test.ts`)
+
+Runs against real Supabase via `npm run test:db`. Uses existing helpers from `__tests__/db/helpers/db-test-helpers.ts` — `callRpcAsUser()`, `ensureDbTestUser()`, plus direct `runSQL` for setup/cleanup. `maxWorkers: 1` already set in `jest.db.config.ts`.
+
+**Setup / teardown:**
+- Create two test profiles (`db-test-a`, `db-test-b`) in a shared family via `runSQL`
+- Each test clears `push_subscriptions` and `notification_preferences` for both users in `afterEach`
+- Use `set_config('request.jwt.claim.sub', <uuid>, true)` pattern already in helpers to simulate `auth.uid()`
+
+**`push_subscriptions` RLS + constraints:**
+- Insert as user A with `user_id = A` → succeeds
+- Insert as user A with `user_id = B` → RLS denies (WITH CHECK)
+- `SELECT` as user A sees only A's rows, not B's
+- `DELETE` as user A on A's row → succeeds
+- `DELETE` as user A on B's row → 0 rows affected (RLS filter)
+- `UNIQUE (user_id, endpoint)` — second insert with same pair fails with unique violation
+- Different user, same endpoint → succeeds (two devices shared by family members is allowed)
+- Cascade: delete profile A → A's `push_subscriptions` rows gone
+
+**`notification_preferences` RLS + constraints:**
+- First SELECT auto-create path (done in app code, not DB): verify app layer handles missing row — covered in API unit tests; here we verify the raw SQL insert path works
+- Insert as A with `user_id = A` → succeeds
+- Insert as A with `user_id = B` → RLS denies
+- SELECT as A sees only A's row (primary key = user_id ensures one row per user)
+- UPDATE as A on A's row → succeeds
+- UPDATE as A on B's row → 0 rows affected
+- `quiet_hours_start = -1` → check constraint rejects
+- `quiet_hours_start = 24` → check constraint rejects
+- `quiet_hours_start = 23` → accepted
+- `quiet_hours_start = NULL` → accepted
+- `types_enabled` accepts valid JSONB, rejects non-JSONB (implicit via column type)
+- Cascade: delete profile A → A's prefs row gone
+
+**`notification_type` enum:**
+- Casting `'task_completed'::notification_type` succeeds
+- Casting `'bogus'::notification_type` fails with invalid enum
+- Adding new enum value in future migration is non-breaking (documented, not tested)
+
+**Observability integration:**
+- None — observability is written by app code, not DB triggers, so DB tests don't assert on it.
+
+### 8.5 Remaining manual step
+
+Only one item can't be automated — it's a one-time setup, not a recurring test:
+
+- [ ] Generate VAPID keypair via `npx web-push generate-vapid-keys` and add `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` to `.env.local` and GitHub repo secrets.
+
+### 8.6 Coverage gate
+
+Target 100% line + branch coverage on:
+- `lib/push/*`
+- `app/api/push/**`
+- `app/api/tasks/complete/route.ts`
+- `components/me/notification-settings-tab.tsx`
+- `components/me/permission-prompt.tsx`
+
+Run `npm test -- --coverage --collectCoverageFrom='lib/push/**' --collectCoverageFrom='app/api/push/**' ...` and fail the task if any of the above files are below 100%.
+
+Not targeted for 100% (tested manually / integration):
+- `public/sw.js` (runs in SW context; logic is intentionally trivial)
+
+## 9. Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| iOS Safari web push only works for installed PWAs | Document in UI; don't block feature for other platforms |
+| User revokes browser permission — our DB still has their subscription | `web-push` returns `410`, cleanup logic deletes row |
+| VAPID keys committed by accident | Add to `.env.local` (already gitignored) + document in README |
+| Push sent during task completion adds latency | Run send in `waitUntil`-equivalent: fire and return response immediately, `await` the send in a non-blocking pattern (`Promise.resolve().then(...)` inside the handler after `NextResponse` is constructed) — but keep the send synchronous in tests so assertions are deterministic. Use a `runAfterResponse` helper. |
+| `types_enabled` JSONB drift if we add new types | Merge defaults at read time in `getPreferences` |
+| Test user has real push subscriptions polluting DB | E2E `afterEach` deletes test users' `push_subscriptions` + `notification_preferences` rows via `runSQL`; unit tests use mocked supabase |
+| CDP `deliverPushMessage` / Chrome test-mode push delivery is flaky in CI | Start with direct `web-push.sendNotification` (Chrome's in-browser push service handles it); fall back to explicit CDP session if flakes appear; last resort, mark the delivery spec as serial |
+| Existing client-side completion insert is called from multiple places? | Audit `quests/page.tsx` for other insert sites before refactor; there may be a modal |
+
+**Open questions for reviewer:**
+1. Is wiring `task_completed` (parent gets notified when child finishes) acceptable as the proof-of-concept, or do you want a different event since #46 approval flow isn't built?
+2. OK with refactoring `quests/page.tsx` to use a new `/api/tasks/complete` route? Alternative is a DB trigger + Edge Function, but that's new infra.
+3. OK with `web-push` as a runtime dep (~500kb, but server-only)? Alternative is hand-rolling VAPID/encryption, which is materially more code to own.
+4. Should prefs default to `push_enabled: true` or `false`? Plan currently says `true` but user hasn't granted browser permission yet — actual push delivery still requires that. Leaving as `true` means one fewer click once they grant permission.
+5. Where is `claim_streak_milestone` called from today? The plan assumes a client-side call site — need to verify during implementation and adjust trigger location.
+
+## 10. PR sequencing
+
+The work ships as **five independent PRs** off `main`. Each PR is complete on its own: migration + code + unit + DB-integration + E2E tests + green CI. Each is safe to ship in isolation — shipping PR 1 without PR 2 just adds unused tables; shipping PR 2 without PR 3 gives users a subscribe UI whose test button is hidden. Code review scope stays under ~600 LOC per PR (tests included).
+
+### PR 1 — DB schema + preferences API + observability constants
+**Branch:** `feature/issue-47-push-1-schema`
+**Depends on:** nothing
+**Size:** ~400 LOC
+
+- `supabase/migrations/017_add_push_notifications.sql` (tables, enum, RLS policies)
+- `lib/push/types.ts` (shared TS types)
+- `lib/push/quiet-hours.ts` (pure helper)
+- `lib/observability/constants.ts` — add 4 new `APP_EVENT_TYPES` + metadata keys
+- `app/api/push/preferences/route.ts` — GET (auto-creates default) + PATCH
+- **Tests:**
+  - `__tests__/db/push-notifications.test.ts` — **DB integration tests for the new tables ship in this PR** (runs via `npm run test:db`). Covers every case in §8.4: RLS on `push_subscriptions` (insert/select/delete scoped to `auth.uid()`, cross-user blocked), `UNIQUE (user_id, endpoint)` constraint, RLS on `notification_preferences`, `quiet_hours_start`/`quiet_hours_end` check constraints (reject -1, reject 24, accept 0–23, accept NULL), `notification_type` enum casting (valid + invalid), and cascade-on-profile-delete for both tables.
+  - `__tests__/lib/push/quiet-hours.test.ts`
+  - `__tests__/api/push/preferences.test.ts`
+- **Acceptance:** migration applied in prod Supabase; `npm run test:db` green including the new DB integration file; unit tests green; `lib/push/quiet-hours.ts` + `app/api/push/preferences/route.ts` at 100% coverage.
+- **User-visible:** nothing.
+- **Rollback risk:** zero — new tables only, no existing code touched.
+
+### PR 2 — Service worker + subscribe flow + settings UI
+**Branch:** `feature/issue-47-push-2-subscribe-ui`
+**Depends on:** PR 1 merged
+**Size:** ~600 LOC
+
+- `package.json` — add `web-push`, `@types/web-push`
+- `.env.local` + GitHub secrets — VAPID keys (one-time; done before this PR opens)
+- `next.config.ts` — `/sw.js` cache-control header
+- `public/sw.js` — push + notificationclick handlers
+- `lib/push/vapid.ts` — `urlBase64ToUint8Array` + public-key export
+- `lib/push/subscribe.ts` — client `subscribe()` / `unsubscribe()`
+- `app/api/push/subscribe/route.ts` + `app/api/push/unsubscribe/route.ts`
+- `components/me/permission-prompt.tsx`
+- `components/me/notification-settings-tab.tsx` (without test button — added in PR 3)
+- `app/(dashboard)/me/page.tsx` — add Notifications tab
+- **Tests:**
+  - `__tests__/lib/push/vapid.test.ts`
+  - `__tests__/lib/push/subscribe.test.ts`
+  - `__tests__/api/push/subscribe.test.ts`
+  - `__tests__/api/push/unsubscribe.test.ts`
+  - `__tests__/components/me/permission-prompt.test.tsx`
+  - `__tests__/components/me/notification-settings-tab.test.tsx` (covers prefs, toggles, quiet hours — no test-button cases)
+  - `e2e/push-notifications.spec.ts` (the §8.2 UI flows spec — subscribe, unsubscribe, toggles, quiet hours, cleanup via `runSQL`)
+- **Acceptance:** all listed files at 100% coverage; UI spec green on parent + child projects; screenshot of Notifications tab in PR description.
+- **User-visible:** new Notifications tab on `/me`. Users can opt in, manage prefs, unsubscribe. **No notifications are ever delivered** because there are no triggers yet.
+- **Rollback risk:** low — additive UI only; no existing flow touched.
+
+### PR 3 — Send helper + test button + delivery E2E harness
+**Branch:** `feature/issue-47-push-3-send-helper`
+**Depends on:** PR 2 merged
+**Size:** ~500 LOC
+
+- `lib/push/send.ts` — `sendPushToUser(userId, payload)` with prefs + quiet-hours gate, parallel send, 410-cleanup, observability events
+- `app/api/push/test/route.ts`
+- `components/me/notification-settings-tab.tsx` — add "Send test notification" button
+- `e2e/push-helpers.ts` — `getShownNotifications`, `waitForNotification`, `clearNotifications`
+- `e2e/push-delivery.spec.ts` — initial version covering §8.3 items **1 (test-button delivery)**, **2 (click → navigation)**, **7 (permission revoked)**, **8 (stale subscription cleanup)**. Two-context parent/child tests land in PRs 4 and 5.
+- **Tests:**
+  - `__tests__/lib/push/send.test.ts` (all of §8.1 send tests — prefs off, type off, quiet hours, 410 cleanup, other error, parallel)
+  - `__tests__/api/push/test.test.ts`
+  - `__tests__/components/me/notification-settings-tab.test.tsx` — extend with test-button cases
+  - `e2e/push-delivery.spec.ts` (items 1, 2, 7, 8)
+- **Acceptance:** `lib/push/send.ts` + `app/api/push/test/route.ts` at 100%; delivery E2E green (real SW push via Chrome); observability rows created correctly (asserted via `runSQL`).
+- **User-visible:** "Send test notification" button now works. Users get a real push on their device.
+- **Rollback risk:** low — only new routes + button. Reverting removes the button; prefs and subscribe flow from PR 2 keep working.
+
+### PR 4 — Task completion → parent push
+**Branch:** `feature/issue-47-push-4-task-completed`
+**Depends on:** PR 3 merged
+**Size:** ~400 LOC
+
+- `app/api/tasks/complete/route.ts` — wraps completion insert, fires `sendPushToUser` for each parent in family (fire-and-forget so completion latency is unchanged)
+- `app/(dashboard)/quests/page.tsx` — replace direct `task_completions` insert with `fetch('/api/tasks/complete', ...)`. Audit for all call sites before refactor.
+- **Tests:**
+  - `__tests__/api/tasks/complete.test.ts` — auth, 403 not-in-family, insert happens, push fires per parent, push failure does NOT fail the request
+  - `__tests__/app/dashboard/quests.test.tsx` — existing tests updated for new API call
+  - `e2e/push-delivery.spec.ts` — extend with §8.3 items **3 (two-context child-completes → parent-receives)**, **5 (type toggle suppresses send)**, **6 (quiet hours suppress send)**
+  - Existing `e2e/quests.spec.ts` must still pass — critical regression gate
+- **Acceptance:** `app/api/tasks/complete/route.ts` at 100%; no regression in quest completion flow; two-context delivery spec green.
+- **User-visible:** parents with prefs on get a push when their kid finishes a task.
+- **Rollback risk:** **moderate** — this refactors a hot path. Keep the PR diff small, test the golden path in Playwright, and have a clean revert plan (just revert the `quests/page.tsx` change; the new route can stay unused).
+
+### PR 5 — Streak milestone → child + parent push
+**Branch:** `feature/issue-47-push-5-streak-milestone`
+**Depends on:** PR 3 merged (can go in parallel with PR 4)
+**Size:** ~300 LOC
+
+- `app/api/push/trigger/streak-milestone/route.ts` — validates caller, sends push to child + opted-in parents
+- `components/streaks/streak-tab.tsx` (or wherever `claim_streak_milestone` is called) — POST to the trigger route after successful RPC
+- **Tests:**
+  - `__tests__/api/push/trigger-streak-milestone.test.ts` — auth, missing `days`, child pushed, parents pushed when pref on, parents skipped when pref off
+  - `e2e/push-delivery.spec.ts` — extend with §8.3 item **4 (streak milestone → child push; parent too when pref on)**
+- **Acceptance:** trigger route at 100%; streak-delivery spec green.
+- **User-visible:** celebratory push on milestone claim.
+- **Rollback risk:** low — additive only.
+
+---
+
+### Per-PR acceptance criteria (applies to every PR 1–5)
+
+- [ ] `npm run lint` clean
+- [ ] `npm test` green; new code at 100% line + branch coverage
+- [ ] `npm run test:db` green (PR 1 adds tests; PRs 2–5 must keep them green)
+- [ ] `npm run test:e2e` green on both parent + child projects
+- [ ] No regression in pre-existing specs
+- [ ] PR description links to this plan, states which section(s) of §10 it implements, and what the next PR in the sequence is
+- [ ] Screenshots for any UI changes
+
+### Cross-PR acceptance (when PR 5 merges — feature complete)
+
+- [ ] All file paths listed in §5 exist and are at 100% coverage per §8.6
+- [ ] VAPID keys present in GitHub repo secrets: `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`
+- [ ] Follow-up issue opened for Phase 2 (scheduled pushes — morning reminders, overdue alerts, streak-at-risk, weekly summary) with a link back to this plan
+- [ ] Issue #47 closed by PR 5

--- a/supabase/migrations/017_add_push_notifications.sql
+++ b/supabase/migrations/017_add_push_notifications.sql
@@ -1,0 +1,82 @@
+-- ============================================================
+-- 017: Push Notifications — subscriptions + preferences
+-- ============================================================
+
+-- Notification type enum — single source of truth shared by app + DB.
+-- Add new values with ALTER TYPE in a follow-up migration.
+CREATE TYPE notification_type AS ENUM (
+  'task_completed',
+  'streak_milestone',
+  'test'
+);
+
+-- ============================================================
+-- push_subscriptions — one row per (user, device/browser)
+-- ============================================================
+CREATE TABLE push_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  endpoint text NOT NULL,
+  p256dh_key text NOT NULL,
+  auth_key text NOT NULL,
+  user_agent text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, endpoint)
+);
+
+CREATE INDEX idx_push_subscriptions_user_id ON push_subscriptions(user_id);
+
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_select_own_subscriptions" ON push_subscriptions
+  FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY "users_insert_own_subscriptions" ON push_subscriptions
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "users_delete_own_subscriptions" ON push_subscriptions
+  FOR DELETE USING (user_id = auth.uid());
+
+-- No UPDATE: subscriptions are immutable. Re-subscribing inserts a new row
+-- (or hits the UNIQUE constraint and is a no-op at the app layer).
+
+-- ============================================================
+-- notification_preferences — one row per user
+-- ============================================================
+CREATE TABLE notification_preferences (
+  user_id uuid PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+  push_enabled boolean NOT NULL DEFAULT true,
+  types_enabled jsonb NOT NULL DEFAULT
+    '{"task_completed":true,"streak_milestone":true,"test":true}'::jsonb,
+  quiet_hours_start smallint CHECK (quiet_hours_start IS NULL OR (quiet_hours_start BETWEEN 0 AND 23)),
+  quiet_hours_end smallint CHECK (quiet_hours_end IS NULL OR (quiet_hours_end BETWEEN 0 AND 23)),
+  timezone text NOT NULL DEFAULT 'UTC',
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_select_own_preferences" ON notification_preferences
+  FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY "users_insert_own_preferences" ON notification_preferences
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "users_update_own_preferences" ON notification_preferences
+  FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "users_delete_own_preferences" ON notification_preferences
+  FOR DELETE USING (user_id = auth.uid());
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION set_notification_preferences_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER notification_preferences_updated_at
+  BEFORE UPDATE ON notification_preferences
+  FOR EACH ROW EXECUTE FUNCTION set_notification_preferences_updated_at();


### PR DESCRIPTION
## Summary

PR 1 of 5 for #47 (push notifications). Lays the foundation — no UI or delivery yet.

- **Migration 017**: `push_subscriptions` + `notification_preferences` tables with RLS (7 policies), `notification_type` enum, check constraints on quiet hours, cascade-on-profile-delete, `updated_at` trigger
- **`GET/PATCH /api/push/preferences`**: auto-creates default row on first read, merges partial `types_enabled` updates, validates quiet hours (0–23 or null), validates timezone via `Intl.DateTimeFormat`
- **`lib/push/quiet-hours.ts`**: pure timezone-aware quiet-hours check supporting same-day and overnight ranges
- **`lib/push/types.ts`**: `NotificationType` union, `isNotificationType` type guard, `DEFAULT_TYPES_ENABLED`, preference interfaces
- **Observability**: 4 new `APP_EVENT_TYPES` (`push_subscription_created/deleted`, `push_notification_sent/failed`) + 3 metadata keys
- **Plan**: `plans/issue-47-push-notifications.md` — full 5-PR breakdown with test matrix

## Test plan

- [x] **20 DB integration tests** (`npm run test:db`) — RLS enforcement on both tables (insert/select/update/delete scoped to `auth.uid()`, cross-user blocked), `UNIQUE(user_id, endpoint)`, check constraints on `quiet_hours_start/end` (reject -1/24, accept 0–23/null), `notification_type` enum casting, cascade-on-profile-delete
- [x] **55 unit tests** (`npm test`) — quiet-hours (same-day, overnight, timezone conversion), types (guard, defaults), preferences route (auth, validation for every field, merge semantics, auto-create, error paths)
- [x] **100% line/branch/function/statement coverage** on all new files — global gate passes (1612/1612 tests, 120/120 suites)
- [x] `npm run lint` — 0 errors
- [x] No regressions in existing tests

## What's next

- **PR 2**: Service worker + subscribe flow + settings UI
- **PR 3**: Send helper + test button + delivery E2E
- **PR 4**: Task completion → parent push
- **PR 5**: Streak milestone → child/parent push

See `plans/issue-47-push-notifications.md` §10 for full breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)