### PR TITLE
feat: push send helper and test notification button (#47 PR 3/5)

### DIFF
--- a/__tests__/api/push/test.test.ts
+++ b/__tests__/api/push/test.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+const mockSendPushToUser = jest.fn()
+jest.mock('@/lib/push/send', () => ({
+  sendPushToUser: (...args: unknown[]) => mockSendPushToUser(...args),
+}))
+
+const mockGetUser = jest.fn()
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+    }),
+}))
+
+import { POST } from '@/app/api/push/test/route'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('POST /api/push/test', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await POST()
+    expect(res.status).toBe(401)
+  })
+
+  it('calls sendPushToUser with test payload and returns sent count', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockSendPushToUser.mockResolvedValue(2)
+
+    const res = await POST()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.sent).toBe(2)
+
+    expect(mockSendPushToUser).toHaveBeenCalledWith('user-1', {
+      type: 'test',
+      title: 'Chore Champions test',
+      body: 'Notifications are working on this device.',
+      url: '/me?tab=notifications',
+    })
+  })
+
+  it('returns 0 sent when user has no subscriptions', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+    mockSendPushToUser.mockResolvedValue(0)
+
+    const res = await POST()
+    const body = await res.json()
+    expect(body.sent).toBe(0)
+  })
+})

--- a/__tests__/components/notifications/notification-settings-tab.test.tsx
+++ b/__tests__/components/notifications/notification-settings-tab.test.tsx
@@ -337,6 +337,94 @@ describe('NotificationSettingsTab', () => {
     })
   })
 
+  describe('send test button', () => {
+    it('is disabled when not subscribed', async () => {
+      mockGetState.mockResolvedValue('unsubscribed')
+      render(<NotificationSettingsTab userRole="parent" />)
+      await waitFor(() => expect(screen.getByTestId('notification-settings')).toBeInTheDocument())
+
+      expect(screen.getByRole('button', { name: /send test notification/i })).toBeDisabled()
+    })
+
+    it('is disabled when master toggle is off', async () => {
+      mockGetState.mockResolvedValue('subscribed')
+      setupNotification('granted')
+      setupFetch({ ...defaultPrefs, push_enabled: false })
+      render(<NotificationSettingsTab userRole="parent" />)
+      await waitFor(() => expect(screen.getByTestId('notification-settings')).toBeInTheDocument())
+
+      expect(screen.getByRole('button', { name: /send test notification/i })).toBeDisabled()
+    })
+
+    it('sends test notification and shows success toast', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockGetState.mockResolvedValue('subscribed')
+      setupNotification('granted')
+      global.fetch = jest.fn((url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        if (urlStr.includes('/api/push/test')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ sent: 1 }) })
+        }
+        if (urlStr.includes('/api/push/preferences')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: defaultPrefs }) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }) as unknown as typeof fetch
+
+      render(<NotificationSettingsTab userRole="parent" />)
+      await waitFor(() => expect(screen.getByTestId('notification-settings')).toBeInTheDocument())
+
+      const btn = screen.getByRole('button', { name: /send test notification/i })
+      await userEvent.click(btn)
+
+      await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Test notification sent to 1 device(s)'))
+    })
+
+    it('shows error toast when test request fails', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockGetState.mockResolvedValue('subscribed')
+      setupNotification('granted')
+      global.fetch = jest.fn((url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        if (urlStr.includes('/api/push/test')) {
+          return Promise.resolve({ ok: false })
+        }
+        if (urlStr.includes('/api/push/preferences')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: defaultPrefs }) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }) as unknown as typeof fetch
+
+      render(<NotificationSettingsTab userRole="parent" />)
+      await waitFor(() => expect(screen.getByTestId('notification-settings')).toBeInTheDocument())
+
+      await userEvent.click(screen.getByRole('button', { name: /send test notification/i }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to send test notification'))
+    })
+
+    it('shows error toast when test request throws', async () => {
+      const { toast } = jest.requireMock('sonner')
+      mockGetState.mockResolvedValue('subscribed')
+      setupNotification('granted')
+      global.fetch = jest.fn((url: string | URL | Request) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        if (urlStr.includes('/api/push/test')) {
+          return Promise.reject(new Error('Network error'))
+        }
+        if (urlStr.includes('/api/push/preferences')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: defaultPrefs }) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }) as unknown as typeof fetch
+
+      render(<NotificationSettingsTab userRole="parent" />)
+      await waitFor(() => expect(screen.getByTestId('notification-settings')).toBeInTheDocument())
+
+      await userEvent.click(screen.getByRole('button', { name: /send test notification/i }))
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to send test notification'))
+    })
+  })
+
   describe('unsupported browser', () => {
     it('renders unsupported prompt when Notification API is missing', async () => {
       Reflect.deleteProperty(window, 'Notification')

--- a/__tests__/lib/push/send.test.ts
+++ b/__tests__/lib/push/send.test.ts
@@ -1,0 +1,362 @@
+/**
+ * @jest-environment node
+ */
+
+const mockSendNotification = jest.fn()
+jest.mock('web-push', () => ({
+  setVapidDetails: jest.fn(),
+  sendNotification: (...args: unknown[]) => mockSendNotification(...args),
+}))
+
+const mockTrackEvent = jest.fn()
+jest.mock('@/lib/observability/event-tracker', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
+const mockFrom = jest.fn()
+jest.mock('@/lib/observability/service-client', () => ({
+  createServiceClient: () => ({ from: (...args: unknown[]) => mockFrom(...args) }),
+}))
+
+import { sendPushToUser, type PushPayload } from '@/lib/push/send'
+
+const PAYLOAD: PushPayload = {
+  type: 'test',
+  title: 'Test title',
+  body: 'Test body',
+  url: '/test',
+  tag: 'test-tag',
+}
+
+const SUB_ROW = {
+  id: 'sub-1',
+  endpoint: 'https://push.example.com/sub-1',
+  p256dh_key: 'pk',
+  auth_key: 'ak',
+}
+
+const DEFAULT_PREFS = {
+  push_enabled: true,
+  types_enabled: { task_completed: true, streak_milestone: true, test: true },
+  quiet_hours_start: null,
+  quiet_hours_end: null,
+  timezone: 'UTC',
+}
+
+function makeSelectChain(data: unknown) {
+  const chain: Record<string, unknown> = {}
+  chain.select = () => chain
+  chain.eq = () => chain
+  chain.maybeSingle = () => Promise.resolve({ data, error: null })
+  return chain
+}
+
+function makeDeleteChain() {
+  const chain: Record<string, unknown> = {}
+  chain.delete = () => chain
+  chain.eq = () => Promise.resolve({ error: null })
+  return chain
+}
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockSendNotification.mockResolvedValue({})
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'test-pub'
+  process.env.VAPID_PRIVATE_KEY = 'test-priv'
+  process.env.VAPID_SUBJECT = 'mailto:test@example.com'
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+describe('sendPushToUser', () => {
+  it('sends push to all subscriptions and returns count', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation((table: string) => {
+      callNum++
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      if (table === 'push_subscriptions') {
+        return {
+          select: () => ({
+            eq: () => Promise.resolve({ data: [SUB_ROW, { ...SUB_ROW, id: 'sub-2', endpoint: 'https://push.example.com/sub-2' }], error: null }),
+          }),
+        }
+      }
+      return makeDeleteChain()
+    })
+
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(2)
+    expect(mockSendNotification).toHaveBeenCalledTimes(2)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'push_notification_sent',
+        metadata: expect.objectContaining({ subscriberCount: 2 }),
+      }),
+    )
+  })
+
+  it('returns 0 when push_enabled is false', async () => {
+    mockFrom.mockReturnValue(makeSelectChain({ ...DEFAULT_PREFS, push_enabled: false }))
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+    expect(mockSendNotification).not.toHaveBeenCalled()
+  })
+
+  it('returns 0 when type is disabled', async () => {
+    mockFrom.mockReturnValue(
+      makeSelectChain({ ...DEFAULT_PREFS, types_enabled: { ...DEFAULT_PREFS.types_enabled, test: false } }),
+    )
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when within quiet hours', async () => {
+    const now = new Date()
+    const hour = now.getUTCHours()
+    mockFrom.mockReturnValue(
+      makeSelectChain({
+        ...DEFAULT_PREFS,
+        quiet_hours_start: hour,
+        quiet_hours_end: (hour + 2) % 24,
+        timezone: 'UTC',
+      }),
+    )
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when no subscriptions exist', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation((table: string) => {
+      callNum++
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [], error: null }),
+        }),
+      }
+    })
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when subscriptions data is null', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: null, error: null }),
+        }),
+      }
+    })
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when VAPID keys are missing', async () => {
+    delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when VAPID private key is missing', async () => {
+    delete process.env.VAPID_PRIVATE_KEY
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('returns 0 when VAPID subject is missing', async () => {
+    delete process.env.VAPID_SUBJECT
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+  })
+
+  it('deletes subscription and tracks event on 410 Gone', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      if (table === 'push_subscriptions') {
+        return {
+          select: () => ({
+            eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+          }),
+          delete: () => ({
+            eq: () => Promise.resolve({ error: null }),
+          }),
+        }
+      }
+      return makeDeleteChain()
+    })
+
+    mockSendNotification.mockRejectedValue({ statusCode: 410, message: 'Gone' })
+
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'push_subscription_deleted',
+        metadata: expect.objectContaining({ failureReason: '410 Gone' }),
+      }),
+    )
+  })
+
+  it('deletes subscription on 404', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+        delete: () => ({
+          eq: () => Promise.resolve({ error: null }),
+        }),
+      }
+    })
+
+    mockSendNotification.mockRejectedValue({ statusCode: 404, message: 'Not Found' })
+    await sendPushToUser('user-1', PAYLOAD)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: 'push_subscription_deleted' }),
+    )
+  })
+
+  it('tracks failure event on other errors without deleting', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+
+    mockSendNotification.mockRejectedValue(new Error('Network error'))
+
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(0)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'push_notification_failed',
+        metadata: expect.objectContaining({ failureReason: 'Network error' }),
+      }),
+    )
+  })
+
+  it('tracks failure with stringified error for non-Error throws', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+
+    mockSendNotification.mockRejectedValue('string error')
+
+    await sendPushToUser('user-1', PAYLOAD)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'push_notification_failed',
+        metadata: expect.objectContaining({ failureReason: 'string error' }),
+      }),
+    )
+  })
+
+  it('uses defaults when no preferences row exists', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(null)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(1)
+  })
+
+  it('handles non-object types_enabled gracefully', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain({ ...DEFAULT_PREFS, types_enabled: 'invalid' })
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+
+    const count = await sendPushToUser('user-1', PAYLOAD)
+    expect(count).toBe(1)
+  })
+
+  it('uses default url and tag when not provided', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'notification_preferences') {
+        return makeSelectChain(DEFAULT_PREFS)
+      }
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: [SUB_ROW], error: null }),
+        }),
+      }
+    })
+
+    await sendPushToUser('user-1', { type: 'test', title: 'T', body: 'B' })
+    const sentPayload = JSON.parse(mockSendNotification.mock.calls[0][1])
+    expect(sentPayload.url).toBe('/')
+    expect(sentPayload.tag).toBe('test')
+  })
+})

--- a/app/api/push/test/route.ts
+++ b/app/api/push/test/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+import { sendPushToUser } from '@/lib/push/send'
+
+async function handler(): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sent = await sendPushToUser(user.id, {
+    type: 'test',
+    title: 'Chore Champions test',
+    body: 'Notifications are working on this device.',
+    url: '/me?tab=notifications',
+  })
+
+  return NextResponse.json({ sent })
+}
+
+export const POST = withObservability(handler)

--- a/components/notifications/notification-settings-tab.tsx
+++ b/components/notifications/notification-settings-tab.tsx
@@ -29,6 +29,7 @@ export function NotificationSettingsTab({ userRole }: NotificationSettingsTabPro
   const [prefs, setPrefs] = useState<NotificationPreferences | null>(null)
   const [loading, setLoading] = useState(true)
   const [subscribing, setSubscribing] = useState(false)
+  const [testSending, setTestSending] = useState(false)
   const [permissionState, setPermissionState] = useState<NotificationPermission | 'unsupported'>('default')
   const [subscriptionState, setSubscriptionState] = useState<'subscribed' | 'unsubscribed' | 'unsupported'>('unsubscribed')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -109,6 +110,23 @@ export function NotificationSettingsTab({ userRole }: NotificationSettingsTabPro
     const next: TypesEnabled = { ...prefs!.types_enabled, [type]: !prefs!.types_enabled[type] }
     setPrefs({ ...prefs!, types_enabled: next })
     patchPrefs({ types_enabled: { [type]: next[type] } })
+  }
+
+  const handleSendTest = async () => {
+    setTestSending(true)
+    try {
+      const res = await fetch('/api/push/test', { method: 'POST' })
+      if (res.ok) {
+        const data = await res.json()
+        toast.success(`Test notification sent to ${data.sent} device(s)`)
+      } else {
+        toast.error('Failed to send test notification')
+      }
+    } catch {
+      toast.error('Failed to send test notification')
+    } finally {
+      setTestSending(false)
+    }
   }
 
   const handleQuietHoursChange = (field: 'quiet_hours_start' | 'quiet_hours_end', value: string) => {
@@ -234,6 +252,17 @@ export function NotificationSettingsTab({ userRole }: NotificationSettingsTabPro
             ))}
           </select>
         </div>
+      </section>
+
+      {/* Send test notification */}
+      <section>
+        <button
+          onClick={handleSendTest}
+          disabled={!prefs.push_enabled || subscriptionState !== 'subscribed' || testSending}
+          className="w-full text-sm text-purple-600 border border-purple-200 rounded-lg px-4 py-2.5 hover:bg-purple-50 disabled:opacity-50 disabled:cursor-not-allowed transition"
+        >
+          {testSending ? 'Sending...' : 'Send test notification'}
+        </button>
       </section>
     </div>
   )

--- a/lib/push/send.ts
+++ b/lib/push/send.ts
@@ -1,0 +1,141 @@
+import webpush from 'web-push'
+import { createServiceClient } from '@/lib/observability/service-client'
+import { trackEvent } from '@/lib/observability/event-tracker'
+import { isWithinQuietHours } from './quiet-hours'
+import { DEFAULT_TYPES_ENABLED, type NotificationType, type TypesEnabled } from './types'
+
+export interface PushPayload {
+  type: NotificationType
+  title: string
+  body: string
+  url?: string
+  tag?: string
+}
+
+interface SubscriptionRow {
+  id: string
+  endpoint: string
+  p256dh_key: string
+  auth_key: string
+}
+
+interface PrefsRow {
+  push_enabled: boolean
+  types_enabled: unknown
+  quiet_hours_start: number | null
+  quiet_hours_end: number | null
+  timezone: string
+}
+
+function getTypesEnabled(raw: unknown): TypesEnabled {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return { ...DEFAULT_TYPES_ENABLED, ...(raw as Partial<TypesEnabled>) }
+  }
+  return { ...DEFAULT_TYPES_ENABLED }
+}
+
+export async function sendPushToUser(
+  userId: string,
+  payload: PushPayload,
+): Promise<number> {
+  const supabase = createServiceClient()
+
+  const { data: prefs } = await supabase
+    .from('notification_preferences')
+    .select('push_enabled, types_enabled, quiet_hours_start, quiet_hours_end, timezone')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  const effectivePrefs: PrefsRow = prefs ?? {
+    push_enabled: true,
+    types_enabled: DEFAULT_TYPES_ENABLED,
+    quiet_hours_start: null,
+    quiet_hours_end: null,
+    timezone: 'UTC',
+  }
+
+  if (!effectivePrefs.push_enabled) return 0
+
+  const typesEnabled = getTypesEnabled(effectivePrefs.types_enabled)
+  if (!typesEnabled[payload.type]) return 0
+
+  if (isWithinQuietHours(
+    new Date(),
+    effectivePrefs.quiet_hours_start,
+    effectivePrefs.quiet_hours_end,
+    effectivePrefs.timezone,
+  )) return 0
+
+  const { data: subscriptions } = await supabase
+    .from('push_subscriptions')
+    .select('id, endpoint, p256dh_key, auth_key')
+    .eq('user_id', userId)
+
+  if (!subscriptions || subscriptions.length === 0) return 0
+
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY
+  const vapidSubject = process.env.VAPID_SUBJECT
+
+  if (!vapidPublicKey || !vapidPrivateKey || !vapidSubject) return 0
+
+  webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey)
+
+  const pushPayload = JSON.stringify({
+    title: payload.title,
+    body: payload.body,
+    url: payload.url ?? '/',
+    tag: payload.tag ?? payload.type,
+  })
+
+  let sentCount = 0
+  const results = await Promise.allSettled(
+    (subscriptions as SubscriptionRow[]).map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: sub.endpoint,
+            keys: { p256dh: sub.p256dh_key, auth: sub.auth_key },
+          },
+          pushPayload,
+        )
+        sentCount++
+      } catch (err: unknown) {
+        const statusCode = (err as { statusCode?: number })?.statusCode
+        if (statusCode === 410 || statusCode === 404) {
+          await supabase
+            .from('push_subscriptions')
+            .delete()
+            .eq('id', sub.id)
+
+          trackEvent({
+            event_type: 'push_subscription_deleted',
+            user_id: userId,
+            metadata: { notificationType: payload.type, failureReason: `${statusCode} Gone` },
+          })
+        } else {
+          trackEvent({
+            event_type: 'push_notification_failed',
+            user_id: userId,
+            metadata: {
+              notificationType: payload.type,
+              failureReason: err instanceof Error ? err.message : String(err),
+            },
+          })
+        }
+      }
+    }),
+  )
+
+  void results
+
+  if (sentCount > 0) {
+    trackEvent({
+      event_type: 'push_notification_sent',
+      user_id: userId,
+      metadata: { notificationType: payload.type, subscriberCount: sentCount },
+    })
+  }
+
+  return sentCount
+}


### PR DESCRIPTION
## Summary

PR 3 of 5 for #47. Adds the server-side send pipeline and the "Send test notification" button, completing the end-to-end subscribe → send → receive path.

- **`lib/push/send.ts`** — `sendPushToUser(userId, payload)`: reads notification preferences (or uses defaults if no row exists), checks master toggle + per-type toggle + quiet hours, sends to all subscriptions via `web-push` in parallel, deletes stale subscriptions on 410/404, fires observability events (`push_notification_sent`, `push_notification_failed`, `push_subscription_deleted`)
- **`POST /api/push/test`** — sends a test push to the authenticated user with title "Chore Champions test"
- **"Send test notification" button** on the Alerts tab — disabled when not subscribed or master toggle is off; shows toast with device count on success

## Test plan

- [x] **16 unit tests** for `lib/push/send.ts` — prefs off, type disabled, quiet hours, no subscriptions, null subscriptions, all 3 VAPID env vars missing, 410/404 cleanup + observability event, other error + tracking, non-Error throw, defaults when no prefs row, non-object types_enabled, default url/tag
- [x] **3 unit tests** for `POST /api/push/test` — 401, success with count, zero-sent
- [x] **5 component tests** for test button — disabled when unsubscribed, disabled when master off, success toast, error response toast, network error toast
- [x] `npm run build` — green
- [x] `npm run test:coverage` — 1705/1705 pass, 128 suites, global 100% gate holds
- [x] `npm run lint` — 0 errors
- [x] All new files at **100% line/branch/function/statement coverage**

## What's next

- **PR 4**: Task completion → parent push (refactor `quests/page.tsx`)
- **PR 5**: Streak milestone → child/parent push

🤖 Generated with [Claude Code](https://claude.com/claude-code)