### PR TITLE
feat: parent push on task completion (#47 PR 4/5)

### DIFF
--- a/__tests__/api/tasks/complete.test.ts
+++ b/__tests__/api/tasks/complete.test.ts
@@ -1,0 +1,421 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+const mockSendPushToUser = jest.fn()
+jest.mock('@/lib/push/send', () => ({
+  sendPushToUser: (...args: unknown[]) => mockSendPushToUser(...args),
+}))
+
+const mockServiceFrom = jest.fn()
+jest.mock('@/lib/observability/service-client', () => ({
+  createServiceClient: () => ({ from: (...args: unknown[]) => mockServiceFrom(...args) }),
+}))
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+import { POST } from '@/app/api/tasks/complete/route'
+import { NextRequest } from 'next/server'
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/tasks/complete', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+function selectChain(data: unknown, error: unknown = null) {
+  const chain: Record<string, unknown> = {}
+  chain.select = () => chain
+  chain.eq = () => chain
+  chain.single = () => Promise.resolve({ data, error })
+  return chain
+}
+
+function updateChain(error: unknown = null) {
+  return {
+    update: () => ({
+      eq: () => Promise.resolve({ error }),
+    }),
+  }
+}
+
+function insertChain(error: unknown = null) {
+  return {
+    insert: () => Promise.resolve({ error }),
+  }
+}
+
+const TASK = {
+  id: 'task-1',
+  title: 'Take out trash',
+  points: 10,
+  recurring: null,
+  due_time: null,
+  due_date: null,
+  family_id: 'fam-1',
+  completed: false,
+}
+
+const PROFILE = { family_id: 'fam-1' }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'child-1' } } })
+  mockSendPushToUser.mockResolvedValue(1)
+})
+
+describe('POST /api/tasks/complete', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 on invalid JSON', async () => {
+    const res = await POST(makeRequest('bad'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when taskId is missing', async () => {
+    const res = await POST(makeRequest({}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when taskId is not a string', async () => {
+    const res = await POST(makeRequest({ taskId: 123 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 403 when user has no family', async () => {
+    mockFrom.mockReturnValue(selectChain({ family_id: null }))
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when profile is null', async () => {
+    mockFrom.mockReturnValue(selectChain(null))
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 404 when task not found', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      return selectChain(null)
+    })
+    const res = await POST(makeRequest({ taskId: 'nope' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when task is in a different family', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      return selectChain({ ...TASK, family_id: 'other-fam' })
+    })
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 409 when non-recurring task is already completed', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      return selectChain({ ...TASK, completed: true })
+    })
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(409)
+  })
+
+  it('completes non-recurring task, inserts completion, returns points', async () => {
+    let call = 0
+    mockFrom.mockImplementation((table: string) => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      if (call === 4) return insertChain()
+      return selectChain(null)
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.pointsEarned).toBe(10)
+    expect(body.taskTitle).toBe('Take out trash')
+  })
+
+  it('does not mark recurring task as completed on the task row', async () => {
+    const recurringTask = { ...TASK, recurring: 'daily' }
+    let call = 0
+    const updateFn = jest.fn()
+    mockFrom.mockImplementation((table: string) => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(recurringTask)
+      // call 3 should be insert (no update for recurring)
+      return { insert: () => Promise.resolve({ error: null }) }
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1', selectedDate: '2026-04-13' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 500 when task update fails', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      return updateChain({ message: 'DB error' })
+    })
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 500 when completion insert fails', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      return insertChain({ message: 'insert error' })
+    })
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('calculates half points when task is overdue', async () => {
+    const overdueTask = {
+      ...TASK,
+      due_time: '08:00:00',
+      due_date: '2020-01-01',
+    }
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(overdueTask)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    const body = await res.json()
+    expect(body.pointsEarned).toBe(5)
+  })
+
+  it('calculates half points for overdue recurring task using selectedDate', async () => {
+    const recurringOverdue = {
+      ...TASK,
+      recurring: 'daily',
+      due_time: '08:00:00',
+    }
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(recurringOverdue)
+      return insertChain()
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1', selectedDate: '2020-01-01' }))
+    const body = await res.json()
+    expect(body.pointsEarned).toBe(5)
+  })
+
+  it('awards full points when task has due_time but is not overdue', async () => {
+    const futureTask = {
+      ...TASK,
+      due_time: '23:59:00',
+      due_date: '2099-12-31',
+    }
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(futureTask)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    const body = await res.json()
+    expect(body.pointsEarned).toBe(10)
+  })
+
+  it('awards full points when no due_time', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    const body = await res.json()
+    expect(body.pointsEarned).toBe(10)
+  })
+
+  it('awards full points when due_time exists but no dateStr resolves', async () => {
+    const taskNoDueDate = { ...TASK, due_time: '08:00:00', due_date: null }
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(taskNoDueDate)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    const body = await res.json()
+    expect(body.pointsEarned).toBe(10)
+  })
+})
+
+describe('notifyParents (fire-and-forget)', () => {
+  it('sends push to parents in the family', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    let serviceCall = 0
+    mockServiceFrom.mockImplementation(() => {
+      serviceCall++
+      if (serviceCall === 1) {
+        // parents query: .select('id').eq('family_id', ...).eq('role', 'parent')
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({ data: [{ id: 'parent-1' }, { id: 'parent-2' }] }),
+            }),
+          }),
+        }
+      }
+      // child profile: .select('display_name').eq('id', ...).single()
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: { display_name: 'Leo' } }),
+          }),
+        }),
+      }
+    })
+
+    await POST(makeRequest({ taskId: 'task-1' }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(mockSendPushToUser).toHaveBeenCalledTimes(2)
+    expect(mockSendPushToUser).toHaveBeenCalledWith('parent-1', expect.objectContaining({
+      type: 'task_completed',
+      title: 'Leo completed a task',
+    }))
+  })
+
+  it('does not fail the response when push throws', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    mockServiceFrom.mockImplementation(() => {
+      throw new Error('service crash')
+    })
+
+    const res = await POST(makeRequest({ taskId: 'task-1' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('uses fallback name when child profile not found', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    let serviceCall = 0
+    mockServiceFrom.mockImplementation(() => {
+      serviceCall++
+      if (serviceCall === 1) {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({ data: [{ id: 'parent-1' }] }),
+            }),
+          }),
+        }
+      }
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: null }),
+          }),
+        }),
+      }
+    })
+
+    await POST(makeRequest({ taskId: 'task-1' }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(mockSendPushToUser).toHaveBeenCalledWith('parent-1', expect.objectContaining({
+      title: 'Your child completed a task',
+    }))
+  })
+
+  it('does nothing when no parents found', async () => {
+    let call = 0
+    mockFrom.mockImplementation(() => {
+      call++
+      if (call === 1) return selectChain(PROFILE)
+      if (call === 2) return selectChain(TASK)
+      if (call === 3) return updateChain()
+      return insertChain()
+    })
+
+    mockServiceFrom.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => Promise.resolve({ data: null }),
+        }),
+      }),
+    }))
+
+    await POST(makeRequest({ taskId: 'task-1' }))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(mockSendPushToUser).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/dashboard/quests.test.tsx
+++ b/__tests__/app/dashboard/quests.test.tsx
@@ -168,6 +168,9 @@ jest.mock('@/lib/supabase/client', () => ({
   }),
 }))
 
+const mockFetch = jest.fn()
+const originalFetch = global.fetch
+
 describe('QuestsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -176,6 +179,15 @@ describe('QuestsPage', () => {
     mockInsert.mockResolvedValue({ error: null })
     mockUpdate.mockResolvedValue({ error: null })
     mockDelete.mockResolvedValue({ error: null })
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ pointsEarned: 10, taskTitle: 'Clean Room' }),
+    })
+    global.fetch = mockFetch as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
     mockProfileData.current = mockProfile
     mockMembersData.current = mockMembers
     mockOneTimeTasksData.current = mockTasks
@@ -916,9 +928,49 @@ describe('QuestsPage', () => {
       await user.click(checkbox)
 
       await waitFor(() => {
-        // Should call update (mark completed on task) and insert (completion record)
-        expect(mockUpdate).toHaveBeenCalled()
-        expect(mockInsert).toHaveBeenCalled()
+        expect(mockFetch).toHaveBeenCalledWith('/api/tasks/complete', expect.objectContaining({
+          method: 'POST',
+        }))
+      })
+    })
+
+    it('completes a recurring task and sends selectedDate in the payload', async () => {
+      mockOneTimeTasksData.current = []
+      mockRecurringTasksData.current = [
+        {
+          id: 'rec-1',
+          family_id: 'family-1',
+          title: 'Daily Recurring',
+          description: null,
+          assigned_to: 'child-1',
+          points: 5,
+          time_of_day: 'morning',
+          recurring: 'daily',
+          due_date: '2024-01-01',
+          due_time: null,
+          completed: false,
+          created_by: 'user-1',
+          created_at: '2024-01-01T00:00:00Z',
+          end_date: null,
+          profiles: { id: 'child-1', display_name: 'Timmy', avatar_url: null, nickname: 'Little T' },
+        },
+      ]
+
+      const user = userEvent.setup()
+      render(<QuestsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Daily Recurring')).toBeInTheDocument()
+      })
+
+      const taskCard = screen.getByText('Daily Recurring').closest('div[class*="bg-white rounded-xl"]')!
+      const checkbox = taskCard.querySelector('button')!
+      await user.click(checkbox)
+
+      await waitFor(() => {
+        const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body)
+        expect(body.selectedDate).not.toBeNull()
+        expect(typeof body.selectedDate).toBe('string')
       })
     })
   })
@@ -1101,7 +1153,7 @@ describe('QuestsPage', () => {
   })
 
   describe('handleCompleteTask error paths', () => {
-    it('throws when update fails for non-recurring task (line 285)', async () => {
+    it('throws when API returns an error', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
 
       const user = userEvent.setup()
@@ -1111,21 +1163,22 @@ describe('QuestsPage', () => {
         expect(screen.getByText('Clean Room')).toBeInTheDocument()
       })
 
-      // Make update fail AFTER render/fetchData (fetchData only uses select, not update)
-      mockUpdate.mockResolvedValue({ error: { message: 'Complete failed' } })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Failed to update task' }),
+      })
 
       const taskCard = screen.getByText('Clean Room').closest('div[class*="bg-white rounded-xl"]')!
       const checkbox = taskCard.querySelector('button')!
       await user.click(checkbox)
 
-      // The error propagates through TaskCard's handleComplete catch
       await waitFor(() => {
-        expect(consoleSpy).toHaveBeenCalledWith('Failed to complete task:', expect.objectContaining({ message: 'Complete failed' }))
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to complete task:', expect.objectContaining({ message: 'Failed to update task' }))
       })
       consoleSpy.mockRestore()
     })
 
-    it('throws when completion insert fails (line 303)', async () => {
+    it('throws with fallback message when API error has no error field', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
 
       const user = userEvent.setup()
@@ -1135,15 +1188,17 @@ describe('QuestsPage', () => {
         expect(screen.getByText('Clean Room')).toBeInTheDocument()
       })
 
-      // Make insert fail AFTER render (so fetchData's selects work fine)
-      mockInsert.mockResolvedValue({ error: { message: 'Completion failed' } })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({}),
+      })
 
       const taskCard = screen.getByText('Clean Room').closest('div[class*="bg-white rounded-xl"]')!
       const checkbox = taskCard.querySelector('button')!
       await user.click(checkbox)
 
       await waitFor(() => {
-        expect(consoleSpy).toHaveBeenCalledWith('Failed to complete task:', expect.objectContaining({ message: 'Completion failed' }))
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to complete task:', expect.objectContaining({ message: 'Failed to complete task' }))
       })
       consoleSpy.mockRestore()
     })
@@ -1196,101 +1251,6 @@ describe('QuestsPage', () => {
     })
   })
 
-  describe('isTaskOverdue edge cases', () => {
-    it('completes task with no due_date (line 349 - dateStr null)', async () => {
-      mockOneTimeTasksData.current = [
-        {
-          ...mockTasks[0],
-          due_date: null,
-          due_time: '14:30:00',
-        },
-      ]
-
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-      const user = userEvent.setup()
-      render(<QuestsPage />)
-
-      await waitFor(() => {
-        expect(screen.getByText('Clean Room')).toBeInTheDocument()
-      })
-
-      // Complete the task - this calls isTaskOverdue which should return false for null dateStr
-      const taskCard = screen.getByText('Clean Room').closest('div[class*="bg-white rounded-xl"]')!
-      const checkbox = taskCard.querySelector('button')!
-      await user.click(checkbox)
-
-      await waitFor(() => {
-        expect(mockUpdate).toHaveBeenCalled()
-      })
-      consoleSpy.mockRestore()
-    })
-  })
-
-  describe('isTaskOverdue', () => {
-    it('completes a recurring task with due_time (exercises recurring branch)', async () => {
-      mockOneTimeTasksData.current = []
-      mockRecurringTasksData.current = [
-        {
-          id: 'rec-overdue',
-          family_id: 'family-1',
-          title: 'Overdue Recurring',
-          description: null,
-          assigned_to: 'child-1',
-          points: 10,
-          time_of_day: 'morning',
-          recurring: 'daily',
-          due_date: '2024-01-01',
-          due_time: '00:01:00',
-          completed: false,
-          created_by: 'user-1',
-          created_at: '2024-01-01T00:00:00Z',
-          end_date: null,
-          profiles: { id: 'child-1', display_name: 'Timmy', avatar_url: null, nickname: 'Little T' },
-        },
-      ]
-
-      const user = userEvent.setup()
-      render(<QuestsPage />)
-      await waitFor(() => {
-        expect(screen.getByText('Overdue Recurring')).toBeInTheDocument()
-      })
-
-      // Click the checkbox to complete (this calls handleCompleteTask which calls isTaskOverdue)
-      const taskCard = screen.getByText('Overdue Recurring').closest('div[class*="bg-white rounded-xl"]')!
-      const checkbox = taskCard.querySelector('button')!
-      await user.click(checkbox)
-
-      await waitFor(() => {
-        expect(mockInsert).toHaveBeenCalled()
-      })
-    })
-
-    it('completes a non-recurring task with due_time (exercises non-recurring branch)', async () => {
-      mockOneTimeTasksData.current = [
-        {
-          ...mockTasks[0],
-          due_time: '00:01:00',
-        },
-      ]
-
-      const user = userEvent.setup()
-      render(<QuestsPage />)
-      await waitFor(() => {
-        expect(screen.getByText('Clean Room')).toBeInTheDocument()
-      })
-
-      // Click the checkbox to complete
-      const taskCard = screen.getByText('Clean Room').closest('div[class*="bg-white rounded-xl"]')!
-      const checkbox = taskCard.querySelector('button')!
-      await user.click(checkbox)
-
-      await waitFor(() => {
-        expect(mockUpdate).toHaveBeenCalled()
-        expect(mockInsert).toHaveBeenCalled()
-      })
-    })
-  })
-
   describe('weekly recurring task with null due_date', () => {
     it('filters out weekly task with null due_date (returns false)', async () => {
       mockRecurringTasksData.current = [
@@ -1318,47 +1278,6 @@ describe('QuestsPage', () => {
         expect(screen.getByRole('heading', { name: 'Quests' })).toBeInTheDocument()
       })
       expect(screen.queryByText('Weekly No Date')).not.toBeInTheDocument()
-    })
-  })
-
-  describe('handleCompleteTask with overdue non-recurring', () => {
-    it('completes an overdue non-recurring task (half points, line 289)', async () => {
-      // We need a task with due_time set in the past so isTaskOverdue returns true
-      // and it's non-recurring so we hit both the non-recurring update AND half-points path
-      mockOneTimeTasksData.current = [
-        {
-          id: 'task-overdue',
-          family_id: 'family-1',
-          title: 'Overdue Non-Recurring',
-          description: null,
-          assigned_to: 'child-1',
-          points: 10,
-          time_of_day: 'morning',
-          recurring: null,
-          due_date: new Date().toISOString().slice(0, 10),
-          due_time: '00:01:00', // Past time
-          completed: false,
-          created_by: 'user-1',
-          created_at: '2024-01-01T00:00:00Z',
-          end_date: null,
-          profiles: { id: 'child-1', display_name: 'Timmy', avatar_url: null, nickname: 'Little T' },
-        },
-      ]
-
-      const user = userEvent.setup()
-      render(<QuestsPage />)
-      await waitFor(() => {
-        expect(screen.getByText('Overdue Non-Recurring')).toBeInTheDocument()
-      })
-
-      const taskCard = screen.getByText('Overdue Non-Recurring').closest('div[class*="bg-white rounded-xl"]')!
-      const checkbox = taskCard.querySelector('button')!
-      await user.click(checkbox)
-
-      await waitFor(() => {
-        expect(mockUpdate).toHaveBeenCalled()
-        expect(mockInsert).toHaveBeenCalled()
-      })
     })
   })
 
@@ -1599,7 +1518,7 @@ describe('QuestsPage', () => {
       })
     })
 
-    it('handles complete when user is null (line 273 guard)', async () => {
+    it('handles complete when API returns 401', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
       const user = userEvent.setup()
       render(<QuestsPage />)
@@ -1608,8 +1527,10 @@ describe('QuestsPage', () => {
         expect(screen.getByText('Clean Room')).toBeInTheDocument()
       })
 
-      // Make getUser return null AFTER render
-      mockGetUser.mockResolvedValue({ data: { user: null } })
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Unauthorized' }),
+      })
 
       const taskCard = screen.getByText('Clean Room').closest('div[class*="bg-white rounded-xl"]')!
       const checkbox = taskCard.querySelector('button')!

--- a/app/(dashboard)/quests/page.tsx
+++ b/app/(dashboard)/quests/page.tsx
@@ -9,7 +9,7 @@ import { TaskForm } from '@/components/tasks/task-form'
 import { MemberFilter } from '@/components/family/member-filter'
 import { Modal } from '@/components/ui/modal'
 import { Button } from '@/components/ui/button'
-import { toDateString, combineDateAndTime } from '@/lib/utils'
+import { toDateString } from '@/lib/utils'
 import { useEncouragement } from '@/lib/hooks/use-encouragement'
 import type { Profile, TaskWithAssignee } from '@/lib/types'
 
@@ -275,42 +275,26 @@ export default function QuestsPage() {
   }
 
   async function handleCompleteTask(taskId: string) {
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user) throw new Error('Not authenticated')
-
     const task = tasks.find((t) => t.id === taskId)
     /* istanbul ignore next -- task always exists; checkbox is rendered from the tasks array */
     if (!task) throw new Error('Task not found')
 
-    // For non-recurring tasks, mark as completed on the task row
-    if (!task.recurring) {
-      const { error: updateError } = await supabase
-        .from('tasks')
-        .update({ completed: true })
-        .eq('id', taskId)
+    const res = await fetch('/api/tasks/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId,
+        selectedDate: task.recurring ? toDateString(selectedDate) : null,
+      }),
+    })
 
-      if (updateError) throw updateError
+    if (!res.ok) {
+      const data = await res.json()
+      throw new Error(data.error || 'Failed to complete task')
     }
 
-    // Calculate points: half points if the task is overdue
-    const pointsEarned = isTaskOverdue(task) ? Math.floor(task.points / 2) : task.points
-
-    // Create completion record
-    // For recurring tasks, store the completion_date so we can query by date.
-    // completed_at keeps its database default (now()) for audit purposes.
-    const { error: completionError } = await supabase
-      .from('task_completions')
-      .insert({
-        task_id: taskId,
-        completed_by: user.id,
-        points_earned: pointsEarned,
-        completion_date: task.recurring ? toDateString(selectedDate) : null,
-      })
-
-    if (completionError) throw completionError
-
+    const { pointsEarned } = await res.json()
     showEncouragement({ task, pointsEarned, currentUser: currentUser!, tasks })
-
     fetchData()
   }
 
@@ -349,16 +333,6 @@ export default function QuestsPage() {
 
     // Database trigger handles point deduction
     fetchData()
-  }
-
-  // Check if a task with a due_time is past its deadline
-  function isTaskOverdue(task: TaskWithAssignee): boolean {
-    if (!task.due_time) return false
-    // For recurring tasks, use selectedDate; for one-time tasks, use due_date
-    const dateStr = task.recurring ? toDateString(selectedDate) : task.due_date
-    if (!dateStr) return false
-    const deadline = combineDateAndTime(dateStr, task.due_time)
-    return new Date() > deadline
   }
 
   // Filter tasks

--- a/app/api/tasks/complete/route.ts
+++ b/app/api/tasks/complete/route.ts
@@ -1,0 +1,148 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+import { sendPushToUser } from '@/lib/push/send'
+import { combineDateAndTime } from '@/lib/utils'
+
+interface TaskRow {
+  id: string
+  title: string
+  points: number
+  recurring: string | null
+  due_time: string | null
+  due_date: string | null
+  family_id: string
+  completed: boolean
+}
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: { taskId?: string; selectedDate?: string | null }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!body.taskId || typeof body.taskId !== 'string') {
+    return NextResponse.json({ error: 'taskId is required' }, { status: 400 })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return NextResponse.json({ error: 'User has no family' }, { status: 403 })
+  }
+
+  const { data: task } = await supabase
+    .from('tasks')
+    .select('id, title, points, recurring, due_time, due_date, family_id, completed')
+    .eq('id', body.taskId)
+    .single()
+
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 })
+  }
+
+  const typedTask = task as TaskRow
+
+  if (typedTask.family_id !== profile.family_id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  if (!typedTask.recurring && typedTask.completed) {
+    return NextResponse.json({ error: 'Task already completed' }, { status: 409 })
+  }
+
+  // For non-recurring tasks, mark as completed
+  if (!typedTask.recurring) {
+    const { error: updateError } = await supabase
+      .from('tasks')
+      .update({ completed: true })
+      .eq('id', body.taskId)
+
+    if (updateError) {
+      return NextResponse.json({ error: 'Failed to update task' }, { status: 500 })
+    }
+  }
+
+  // Calculate points: half if overdue
+  let pointsEarned = typedTask.points
+  if (typedTask.due_time) {
+    const dateStr = typedTask.recurring ? body.selectedDate : typedTask.due_date
+    if (dateStr) {
+      const deadline = combineDateAndTime(dateStr, typedTask.due_time)
+      if (new Date() > deadline) {
+        pointsEarned = Math.floor(typedTask.points / 2)
+      }
+    }
+  }
+
+  const completionDate = typedTask.recurring && body.selectedDate ? body.selectedDate : null
+
+  const { error: completionError } = await supabase
+    .from('task_completions')
+    .insert({
+      task_id: body.taskId,
+      completed_by: user.id,
+      points_earned: pointsEarned,
+      completion_date: completionDate,
+    })
+
+  if (completionError) {
+    return NextResponse.json({ error: 'Failed to record completion' }, { status: 500 })
+  }
+
+  // Fire push to parents (async, never blocks response)
+  void notifyParents(profile.family_id, user.id, typedTask.title)
+
+  return NextResponse.json({
+    pointsEarned,
+    taskTitle: typedTask.title,
+  })
+}
+
+async function notifyParents(familyId: string, completedBy: string, taskTitle: string) {
+  try {
+    const supabase = (await import('@/lib/observability/service-client')).createServiceClient()
+    const { data: parents } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('family_id', familyId)
+      .eq('role', 'parent')
+
+    if (!parents) return
+
+    const childProfile = await supabase
+      .from('profiles')
+      .select('display_name')
+      .eq('id', completedBy)
+      .single()
+
+    const childName = childProfile.data?.display_name ?? 'Your child'
+
+    await Promise.allSettled(
+      parents.map((parent: { id: string }) =>
+        sendPushToUser(parent.id, {
+          type: 'task_completed',
+          title: `${childName} completed a task`,
+          body: `"${taskTitle}" — tap to see`,
+          url: '/quests',
+        }),
+      ),
+    )
+  } catch {
+    // Push failure must never affect the completion response
+  }
+}
+
+export const POST = withObservability(handler)


### PR DESCRIPTION
## Summary

PR 4 of 5 for #47. Parents now receive a push notification when their child completes a task (if they have the `task_completed` preference enabled).

- **New `POST /api/tasks/complete`** — wraps the completion insert. Validates family membership, marks non-recurring tasks as completed, computes overdue half-points server-side, inserts the completion row, then fire-and-forget sends pushes to all parents in the family via `sendPushToUser` (from PR 3).
- **Refactored `quests/page.tsx`** — `handleCompleteTask` now POSTs to `/api/tasks/complete` instead of writing directly to `task_completions`. Auth + overdue calc moved server-side.
- **Removed dead client code** — `isTaskOverdue` helper + `combineDateAndTime` import (both were only used in the old client-side completion path).

## Refactor risk

The only hot path touched is quest completion. Mitigation: all 29 existing `quests.spec.ts` E2E tests still pass.

## Test plan

- [x] **22 unit tests** for `POST /api/tasks/complete` — auth, validation, family isolation, 409 on already-completed non-recurring, recurring path (no task update), overdue with `due_time` + `due_date`, overdue recurring using `selectedDate`, not-overdue with `due_time`, no-due_time full points, null `due_date`, update + insert errors, parent push per-parent, fallback name when child profile missing, no parents case, service-role crash swallowed
- [x] **Updated `quests.test.tsx`** — 60/60 pass, migrated to mock fetch instead of supabase internals
- [x] **29/29 `quests.spec.ts` E2E tests pass** — no regressions in completion flow
- [x] `npm run test:coverage` — 1724/1724 pass, global 100% gate holds
- [x] `npm run build` + `npm run lint` — green, 0 errors
- [x] All new files at **100% coverage**

## What's next

- **PR 5**: Streak milestone → child/parent push (last one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)