### PR TITLE
feat: streak milestone push notifications (#47 PR 5/5)

### DIFF
--- a/__tests__/api/push/trigger-streak-milestone.test.ts
+++ b/__tests__/api/push/trigger-streak-milestone.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/observability/middleware-timing', () => ({
+  withObservability: (h: unknown) => h,
+}))
+
+const mockSendPushToUser = jest.fn()
+jest.mock('@/lib/push/send', () => ({
+  sendPushToUser: (...args: unknown[]) => mockSendPushToUser(...args),
+}))
+
+const mockGetUser = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+}))
+
+import { POST } from '@/app/api/push/trigger/streak-milestone/route'
+import { NextRequest } from 'next/server'
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/push/trigger/streak-milestone', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+function selectChain(data: unknown) {
+  const chain: Record<string, unknown> = {}
+  chain.select = () => chain
+  chain.eq = () => chain
+  chain.single = () => Promise.resolve({ data, error: null })
+  return chain
+}
+
+function parentListChain(data: unknown) {
+  return {
+    select: () => ({
+      eq: () => ({
+        eq: () => Promise.resolve({ data, error: null }),
+      }),
+    }),
+  }
+}
+
+const PROFILE = { family_id: 'fam-1', display_name: 'Leo' }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'child-1' } } })
+  mockSendPushToUser.mockResolvedValue(1)
+})
+
+describe('POST /api/push/trigger/streak-milestone', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const res = await POST(makeRequest({ days: 7 }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 on invalid JSON', async () => {
+    const res = await POST(makeRequest('bad'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when days is missing', async () => {
+    const res = await POST(makeRequest({}))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/days/)
+  })
+
+  it('returns 400 when days is negative', async () => {
+    const res = await POST(makeRequest({ days: -1 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when days is not a number', async () => {
+    const res = await POST(makeRequest({ days: 'seven' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 403 when user has no family', async () => {
+    mockFrom.mockReturnValue(selectChain({ family_id: null, display_name: 'Leo' }))
+    const res = await POST(makeRequest({ days: 7 }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when profile is null', async () => {
+    mockFrom.mockReturnValue(selectChain(null))
+    const res = await POST(makeRequest({ days: 7 }))
+    expect(res.status).toBe(403)
+  })
+
+  it('sends push to child and parents, returns counts', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation(() => {
+      callNum++
+      if (callNum === 1) return selectChain(PROFILE)
+      return parentListChain([{ id: 'parent-1' }, { id: 'parent-2' }])
+    })
+
+    const res = await POST(makeRequest({ days: 7, badge: 'Week Warrior' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.childSent).toBe(1)
+    expect(body.parentSent).toBe(2)
+
+    expect(mockSendPushToUser).toHaveBeenCalledTimes(3)
+    expect(mockSendPushToUser).toHaveBeenCalledWith('child-1', expect.objectContaining({
+      type: 'streak_milestone',
+      title: 'Week Warrior!',
+      body: 'Leo hit a 7-day streak',
+    }))
+    expect(mockSendPushToUser).toHaveBeenCalledWith('parent-1', expect.objectContaining({
+      type: 'streak_milestone',
+    }))
+  })
+
+  it('uses fallback badge label when badge is not provided', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation(() => {
+      callNum++
+      if (callNum === 1) return selectChain(PROFILE)
+      return parentListChain([])
+    })
+
+    await POST(makeRequest({ days: 14 }))
+    expect(mockSendPushToUser).toHaveBeenCalledWith('child-1', expect.objectContaining({
+      title: '14-day streak!',
+    }))
+  })
+
+  it('handles no parents gracefully', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation(() => {
+      callNum++
+      if (callNum === 1) return selectChain(PROFILE)
+      return parentListChain([])
+    })
+
+    const res = await POST(makeRequest({ days: 7 }))
+    const body = await res.json()
+    expect(body.childSent).toBe(1)
+    expect(body.parentSent).toBe(0)
+  })
+
+  it('handles null parents data', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation(() => {
+      callNum++
+      if (callNum === 1) return selectChain(PROFILE)
+      return parentListChain(null)
+    })
+
+    const res = await POST(makeRequest({ days: 7 }))
+    const body = await res.json()
+    expect(body.parentSent).toBe(0)
+  })
+
+  it('counts parentSent correctly when some parents have no subscriptions', async () => {
+    let callNum = 0
+    mockFrom.mockImplementation(() => {
+      callNum++
+      if (callNum === 1) return selectChain(PROFILE)
+      return parentListChain([{ id: 'parent-1' }, { id: 'parent-2' }])
+    })
+
+    // First call (child) returns 1, parent-1 returns 1, parent-2 returns 0
+    mockSendPushToUser
+      .mockResolvedValueOnce(1) // child
+      .mockResolvedValueOnce(1) // parent-1
+      .mockResolvedValueOnce(0) // parent-2 (no subscriptions)
+
+    const res = await POST(makeRequest({ days: 7 }))
+    const body = await res.json()
+    expect(body.parentSent).toBe(1) // only parent-1 counted
+  })
+})

--- a/__tests__/components/streaks/streak-tab.test.tsx
+++ b/__tests__/components/streaks/streak-tab.test.tsx
@@ -10,6 +10,9 @@ jest.mock('sonner', () => ({
   },
 }))
 
+const mockFetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+const originalFetch = global.fetch
+
 // Mock Supabase
 const mockRpc = jest.fn()
 const mockFrom = jest.fn()
@@ -75,6 +78,12 @@ describe('StreakTab', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     setupMocks()
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    global.fetch = mockFetch as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
   })
 
   it('shows loading skeleton initially', () => {
@@ -220,6 +229,14 @@ describe('StreakTab', () => {
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('Week Warrior unlocked! +50 points')
+    })
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/push/trigger/streak-milestone', expect.objectContaining({
+        method: 'POST',
+      }))
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body)
+      expect(body).toEqual({ days: 7, badge: 'Week Warrior' })
     })
   })
 

--- a/app/api/push/trigger/streak-milestone/route.ts
+++ b/app/api/push/trigger/streak-milestone/route.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { withObservability } from '@/lib/observability/middleware-timing'
+import { sendPushToUser } from '@/lib/push/send'
+
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: { days?: number; badge?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (typeof body.days !== 'number' || body.days < 1) {
+    return NextResponse.json({ error: 'days is required and must be a positive number' }, { status: 400 })
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id, display_name')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return NextResponse.json({ error: 'User has no family' }, { status: 403 })
+  }
+
+  const badgeLabel = body.badge ?? `${body.days}-day streak`
+  const payload = {
+    type: 'streak_milestone' as const,
+    title: `${badgeLabel}!`,
+    body: `${profile.display_name} hit a ${body.days}-day streak`,
+    url: '/me?tab=streaks',
+  }
+
+  // Send to the child who earned it
+  const childSent = await sendPushToUser(user.id, payload)
+
+  // Send to parents in the family
+  const { data: parents } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('family_id', profile.family_id)
+    .eq('role', 'parent')
+
+  let parentSent = 0
+  if (parents && parents.length > 0) {
+    const results = await Promise.allSettled(
+      parents.map((p: { id: string }) => sendPushToUser(p.id, payload)),
+    )
+    parentSent = results
+      .filter((r) => r.status === 'fulfilled' && (r as PromiseFulfilledResult<number>).value > 0)
+      .length
+  }
+
+  return NextResponse.json({ childSent, parentSent })
+}
+
+export const POST = withObservability(handler)

--- a/components/streaks/streak-tab.tsx
+++ b/components/streaks/streak-tab.tsx
@@ -64,6 +64,11 @@ export function StreakTab({ userId, userPoints }: StreakTabProps) {
       toast.success(`${result.badge} unlocked! +${result.bonus} points`)
       setPoints((prev) => prev + (result.bonus ?? 0))
       fetchData()
+      void fetch('/api/push/trigger/streak-milestone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ days, badge: result.badge }),
+      })
     } else if (result?.error) {
       toast.error(result.error)
     }


### PR DESCRIPTION
## Summary

PR 5 of 5 for #47. Final piece — when a child claims a streak milestone, they and their parents receive a celebratory push notification. **This completes the push notification feature.**

- **`POST /api/push/trigger/streak-milestone`** — validates `days` param, looks up child profile + family, sends push to the child via `sendPushToUser`, then sends to all parents in the family. Parents who have `streak_milestone` preference disabled are skipped (handled by `sendPushToUser`). Returns `{ childSent, parentSent }` counts.
- **`streak-tab.tsx`** — fire-and-forget `fetch` to the trigger route after a successful `claim_streak_milestone` RPC. Uses `void` to avoid blocking the UI or suppressing the success toast.

## Feature complete checklist

With this PR merged, #47 is complete:

- [x] **PR 1**: DB schema + preferences API + observability constants
- [x] **PR 2**: Service worker + subscribe flow + settings UI
- [x] **PR 3**: Send helper + test notification button
- [x] **PR 4**: Task completion → parent push
- [x] **PR 5**: Streak milestone → child + parent push (this PR)

## Test plan

- [x] **12 unit tests** for trigger route — auth, validation (missing/negative/non-number days), family isolation, child + parent delivery, fallback badge label, no parents, null parents data, partial parent delivery counting
- [x] **Updated streak-tab test** — verifies trigger call payload after successful claim
- [x] `npm run build` — green
- [x] `npm run test:coverage` — 1736/1736 pass, 130 suites, global 100% gate holds
- [x] `npm run lint` — 0 errors

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)