### PR TITLE
Fix keep-alive workflow after Supabase anon 401 on /rest/v1/

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -15,9 +15,14 @@ jobs:
           SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
+          # Supabase now rejects anon keys on /rest/v1/. Ping a public RPC
+          # instead — get_family_by_invite_code is SECURITY DEFINER and
+          # accepts the anon key. An unknown code returns an empty set.
           STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
-            "${SUPABASE_URL}/rest/v1/" \
+            -X POST "${SUPABASE_URL}/rest/v1/rpc/get_family_by_invite_code" \
             -H "apikey: ${SUPABASE_ANON_KEY}" \
-            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}")
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
+            -H "Content-Type: application/json" \
+            -d '{"code":"keepalive"}')
           echo "Supabase responded with HTTP ${STATUS}"
           [ "$STATUS" -eq 200 ]


### PR DESCRIPTION
## Summary
- Scheduled `Keep Supabase Alive` workflow started failing: Supabase now rejects the anon key on `GET /rest/v1/` with `"Only the service_role API key can be used for this endpoint."`
- Switches the ping to `POST /rest/v1/rpc/get_family_by_invite_code` with `{"code":"keepalive"}` — that RPC is `SECURITY DEFINER` and accepts the anon key. Returns 200 for any input, so it's a safe no-op ping.
- Verified locally against the production project (200 OK).

## Test plan
- [x] Local curl against prod Supabase returns 200 with anon key.
- [ ] Workflow run succeeds on next schedule (or via manual `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)