### PR TITLE
Restrict task creation + enforce completed_by = auth.uid() (#95)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
         run: npm run test:db
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 

--- a/__tests__/db/task-rls.db.test.ts
+++ b/__tests__/db/task-rls.db.test.ts
@@ -1,0 +1,135 @@
+/**
+ * DB integration tests for task + task_completion INSERT RLS (migration 020).
+ *
+ * Regression guards the point-minting attack:
+ *   - Kids cannot INSERT arbitrary tasks.
+ *   - A family member cannot INSERT a completion row crediting someone else.
+ *
+ * These tests exercise RLS through PostgREST by signing in as the dedicated
+ * DB test user and calling supabase-js — the Management API used elsewhere
+ * bypasses RLS.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { runSQL } from '../../e2e/supabase-admin'
+import { ensureDbTestUser } from './helpers/db-test-helpers'
+
+const DB_TEST_EMAIL = 'db-test@chore-champions-test.local'
+const DB_TEST_PASSWORD = 'TestPassword123!'
+const SIBLING_EMAIL = `db-test-sibling-${Date.now()}@chore-champions-test.local`
+
+let client: SupabaseClient
+let childUserId: string
+let siblingUserId: string
+let familyId: string
+let seedTaskId: string
+
+async function createAuthUser(email: string): Promise<string> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  const res = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${serviceRoleKey}`,
+      apikey: serviceRoleKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password: 'TestPassword123!',
+      email_confirm: true,
+      user_metadata: { display_name: 'Sibling' },
+    }),
+  })
+  if (!res.ok) throw new Error(`createAuthUser failed: ${await res.text()}`)
+  const data = (await res.json()) as { id: string }
+  return data.id
+}
+
+async function deleteAuthUser(userId: string): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  await fetch(`${supabaseUrl}/auth/v1/admin/users/${userId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${serviceRoleKey}`, apikey: serviceRoleKey },
+  })
+}
+
+beforeAll(async () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !anonKey) throw new Error('Supabase env vars missing')
+
+  const user = await ensureDbTestUser()
+  childUserId = user.userId
+  familyId = user.familyId
+  // Force the test user to child role (previous runs may have upgraded it).
+  await runSQL(`UPDATE profiles SET role = 'child' WHERE id = '${childUserId}'`)
+
+  client = createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+  const { error } = await client.auth.signInWithPassword({
+    email: DB_TEST_EMAIL,
+    password: DB_TEST_PASSWORD,
+  })
+  if (error) throw new Error(`Sign-in failed: ${error.message}`)
+
+  // Create a sibling auth user in the same family so we have a real FK target
+  // for the "completed_by = other user" test.
+  siblingUserId = await createAuthUser(SIBLING_EMAIL)
+  await runSQL(`UPDATE profiles SET family_id = '${familyId}', role = 'child' WHERE id = '${siblingUserId}'`)
+
+  // Seed a task as service role so we have something legit to try completing.
+  const rows = (await runSQL(`
+    INSERT INTO tasks (title, points, family_id, created_by, assigned_to)
+    VALUES ('rls seed', 5, '${familyId}', '${childUserId}', '${childUserId}')
+    RETURNING id;
+  `)) as Array<{ id: string }>
+  seedTaskId = rows[0].id
+})
+
+afterAll(async () => {
+  await runSQL(`DELETE FROM task_completions WHERE task_id = '${seedTaskId}'`)
+  await runSQL(`DELETE FROM tasks WHERE id = '${seedTaskId}'`)
+  await client?.auth.signOut()
+  if (siblingUserId) await deleteAuthUser(siblingUserId)
+})
+
+describe('Task INSERT RLS (migration 020)', () => {
+  it('blocks a kid from INSERTing a task', async () => {
+    const { error } = await client.from('tasks').insert({
+      title: 'free pts',
+      points: 1000,
+      family_id: familyId,
+      created_by: childUserId,
+    })
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/row-level security|permission denied/i)
+  })
+})
+
+describe('task_completions INSERT RLS (migration 020)', () => {
+  it('blocks INSERT when completed_by does not match auth.uid()', async () => {
+    const { error } = await client.from('task_completions').insert({
+      task_id: seedTaskId,
+      completed_by: siblingUserId,
+      points_earned: 10,
+    })
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/row-level security|permission denied/i)
+  })
+
+  it('allows INSERT when completed_by = auth.uid()', async () => {
+    const { error } = await client.from('task_completions').insert({
+      task_id: seedTaskId,
+      completed_by: childUserId,
+      points_earned: 5,
+    })
+    expect(error).toBeNull()
+
+    const rows = (await runSQL(
+      `SELECT completed_by, points_earned FROM task_completions WHERE task_id = '${seedTaskId}'`,
+    )) as Array<{ completed_by: string; points_earned: number }>
+    expect(rows.some((r) => r.completed_by === childUserId && r.points_earned === 5)).toBe(true)
+  })
+})

--- a/supabase/migrations/020_restrict_task_creation_and_completions.sql
+++ b/supabase/migrations/020_restrict_task_creation_and_completions.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 020: Restrict task creation + enforce completed_by = auth.uid()
+-- ============================================================
+-- Previously any family member could INSERT tasks with arbitrary points
+-- and arbitrary assigned_to, and could INSERT task_completions with
+-- completed_by set to any family member. Combined, a kid could mint
+-- unlimited points for themselves (or swap attribution onto a sibling).
+--
+-- This migration:
+--   1. Restricts tasks INSERT to parents only.
+--   2. Forces task_completions INSERT to set completed_by = auth.uid().
+--
+-- It drops ALL existing INSERT policies on both tables (including an
+-- out-of-band "Users can create family tasks" / "Users can create completions"
+-- pair added via the dashboard) so the stricter replacements are not
+-- OR'd away by more permissive siblings.
+
+-- Tasks INSERT: clear all, install parents-only
+DROP POLICY IF EXISTS "Family members can create tasks" ON tasks;
+DROP POLICY IF EXISTS "Users can create family tasks" ON tasks;
+DROP POLICY IF EXISTS "Family parents can create tasks" ON tasks;
+
+CREATE POLICY "Family parents can create tasks"
+  ON tasks FOR INSERT
+  WITH CHECK (
+    family_id IN (
+      SELECT family_id FROM profiles
+      WHERE id = auth.uid() AND role = 'parent'
+    )
+  );
+
+-- task_completions INSERT: clear all, require completed_by = auth.uid()
+DROP POLICY IF EXISTS "Family members can create completions" ON task_completions;
+DROP POLICY IF EXISTS "Users can create completions" ON task_completions;
+DROP POLICY IF EXISTS "Users can only complete tasks as themselves" ON task_completions;
+
+CREATE POLICY "Users can only complete tasks as themselves"
+  ON task_completions FOR INSERT
+  WITH CHECK (
+    completed_by = auth.uid()
+    AND task_id IN (
+      SELECT id FROM tasks
+      WHERE family_id IN (SELECT family_id FROM profiles WHERE id = auth.uid())
+    )
+  );


### PR DESCRIPTION
## Summary
- Restrict `tasks` INSERT to parents only.
- Enforce `completed_by = auth.uid()` on `task_completions` INSERT.
- Drop three stale permissive INSERT policies (including two dashboard-added ones: `Users can create family tasks` and `Users can create completions`) that were OR'd with the stricter replacements, bypassing them.

## Context
Before this change, a kid could:
1. INSERT a task with `points=10000` assigned to themselves, then
2. INSERT a completion row to claim the points, or
3. INSERT a completion row crediting a sibling instead of themselves.

The dashboard-added policies were not tracked in migrations — worth flagging for follow-up (likely more untracked RLS).

## Test plan
- [x] `npm run test:db -- --testPathPatterns=task-rls` passes 3/3 (exercises RLS through PostgREST).
- [x] `npm run lint` — 0 errors.
- [x] `npm test` — 1769/1769 pass.
- [ ] CI.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)