### PR TITLE
Keep-alive: real write via dedicated probe table

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,27 +2,32 @@ name: Keep Supabase Alive
 
 on:
   schedule:
-    # Run every 5 days to stay well within the 7-day pause window
-    - cron: '0 8 */5 * *'
+    # Every 3 days — well inside Supabase's ~7-day inactivity window so
+    # one missed run still leaves margin before pause.
+    - cron: '0 8 */3 * *'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
   ping:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Ping Supabase
         env:
           SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
-          # Supabase now rejects anon keys on /rest/v1/. Ping a public RPC
-          # instead — get_family_by_invite_code is SECURITY DEFINER and
-          # accepts the anon key. An unknown code returns an empty set.
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
-            -X POST "${SUPABASE_URL}/rest/v1/rpc/get_family_by_invite_code" \
+          # Read-only RPCs do not always count toward Supabase's inactivity
+          # heuristic. The `keepalive_ping` RPC (migration 021) performs a
+          # real UPDATE on a singleton probe row, which is guaranteed to
+          # register as DB activity.
+          RESPONSE=$(curl -sS -w '\n%{http_code}' \
+            -X POST "${SUPABASE_URL}/rest/v1/rpc/keepalive_ping" \
             -H "apikey: ${SUPABASE_ANON_KEY}" \
             -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
             -H "Content-Type: application/json" \
-            -d '{"code":"keepalive"}')
-          echo "Supabase responded with HTTP ${STATUS}"
+            -d '{}')
+          BODY=$(echo "$RESPONSE" | sed '$d')
+          STATUS=$(echo "$RESPONSE" | tail -n1)
+          echo "Supabase responded with HTTP ${STATUS}: ${BODY}"
           [ "$STATUS" -eq 200 ]

--- a/supabase/migrations/021_keepalive_probe.sql
+++ b/supabase/migrations/021_keepalive_probe.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- 021: Keep-alive probe table + RPC
+-- ============================================================
+-- Supabase auto-pauses free-tier projects after ~7 days of inactivity.
+-- A read-only RPC ping (used previously) does not reliably register as
+-- activity, so we use a dedicated singleton table that the keep-alive
+-- workflow updates via an RPC. The UPDATE is a real DB write and is
+-- guaranteed to count.
+
+CREATE TABLE IF NOT EXISTS keepalive_pings (
+  id int PRIMARY KEY DEFAULT 1,
+  last_ping_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT keepalive_pings_singleton CHECK (id = 1)
+);
+
+INSERT INTO keepalive_pings (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- RLS enabled with no policies; only service_role / SECURITY DEFINER
+-- functions may read or write the table.
+ALTER TABLE keepalive_pings ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION keepalive_ping()
+RETURNS timestamptz
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE keepalive_pings
+  SET last_ping_at = now()
+  WHERE id = 1
+  RETURNING last_ping_at;
+$$;
+
+-- Anon may invoke this RPC; the function itself runs as the owner and
+-- mutates only the singleton row.
+GRANT EXECUTE ON FUNCTION keepalive_ping() TO anon, authenticated;


### PR DESCRIPTION
## Why

PR #90 fixed the keep-alive ping (anon was being rejected on `/rest/v1/`), but Supabase paused the project again on 4-30 even though the cron ran successfully on 4-22 and 4-26. Likely cause: a read-only SECURITY DEFINER RPC isn't reliably counted as activity by Supabase's inactivity heuristic, and the long gap of failed runs from 4-11 to 4-21 had already advanced the pause clock.

## What

- New `keepalive_pings` singleton table + `keepalive_ping()` SECURITY DEFINER RPC that does a real `UPDATE … SET last_ping_at = now()` on the row. RLS on with no policies; only the function (running as owner) touches the row.
- Workflow now calls `POST /rest/v1/rpc/keepalive_ping` instead of the read-only RPC. The UPDATE is a real DB write so it counts.
- Cron tightened from `*/5` to `*/3` days for margin.
- Added `timeout-minutes: 5` to the job.

## Test plan
- [x] Migration applied to dev DB; `curl POST /rest/v1/rpc/keepalive_ping` returns `200` with the new timestamp.
- [ ] Trigger the workflow manually after merge via Actions → Run workflow → confirm green and DB shows `last_ping_at` advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)