### PR TITLE
Restrict profile UPDATE; route role/family_id mutations through RPCs (#91)

### DIFF
--- a/__tests__/app/auth/join-code.test.tsx
+++ b/__tests__/app/auth/join-code.test.tsx
@@ -13,36 +13,36 @@ jest.mock('next/navigation', () => ({
 }))
 
 // Mock Supabase client
-const mockRpc = jest.fn()
+const mockGetFamilyByInviteCode = jest.fn() // RPC: get_family_by_invite_code (returns family details for the pre-check)
+const mockJoinFamilyViaInviteCode = jest.fn() // RPC: join_family_via_invite_code (the actual mutation)
 const mockSignUp = jest.fn()
-const mockUpdate = jest.fn()
 
 jest.mock('@/lib/supabase/client', () => ({
   createClient: () => ({
     auth: {
       signUp: mockSignUp,
     },
-    rpc: (...args: unknown[]) => ({
-      single: () => mockRpc(...args),
-    }),
-    from: () => ({
-      update: (...args: unknown[]) => ({
-        eq: (...eqArgs: unknown[]) => mockUpdate(...args, ...eqArgs),
-      }),
-    }),
+    rpc: (name: string, args?: unknown) => {
+      if (name === 'get_family_by_invite_code') {
+        // The page chains .single() on this RPC.
+        return { single: () => mockGetFamilyByInviteCode(args) }
+      }
+      // join_family_via_invite_code is awaited directly.
+      return mockJoinFamilyViaInviteCode(args)
+    },
   }),
 }))
 
 describe('Join Family Page (with code)', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockRpc.mockResolvedValue({ data: { id: 'family-1', name: 'The Smiths' }, error: null })
+    mockGetFamilyByInviteCode.mockResolvedValue({ data: { id: 'family-1', name: 'The Smiths' }, error: null })
+    mockJoinFamilyViaInviteCode.mockResolvedValue({ data: 'family-1', error: null })
     mockSignUp.mockResolvedValue({ data: { user: { id: 'new-user' } }, error: null })
-    mockUpdate.mockResolvedValue({ error: null })
   })
 
   it('shows checking state initially', () => {
-    mockRpc.mockReturnValue(new Promise(() => {}))
+    mockGetFamilyByInviteCode.mockReturnValue(new Promise(() => {}))
     render(<JoinFamilyPage />)
     expect(screen.getByText('Checking invite code...')).toBeInTheDocument()
   })
@@ -61,7 +61,7 @@ describe('Join Family Page (with code)', () => {
   })
 
   it('shows invalid invite when code is bad', async () => {
-    mockRpc.mockResolvedValue({ data: null, error: { message: 'Not found' } })
+    mockGetFamilyByInviteCode.mockResolvedValue({ data: null, error: { message: 'Not found' } })
 
     render(<JoinFamilyPage />)
 
@@ -111,8 +111,8 @@ describe('Join Family Page (with code)', () => {
     })
   })
 
-  it('shows error when profile update fails', async () => {
-    mockUpdate.mockResolvedValue({ error: { message: 'Profile update failed' } })
+  it('shows error when join_family_via_invite_code RPC fails', async () => {
+    mockJoinFamilyViaInviteCode.mockResolvedValue({ data: null, error: { message: 'RPC failed' } })
 
     render(<JoinFamilyPage />)
 

--- a/__tests__/app/dashboard/family.test.tsx
+++ b/__tests__/app/dashboard/family.test.tsx
@@ -53,8 +53,8 @@ const mockMembers = [
 
 // Supabase mock
 const mockGetUser = jest.fn()
-const mockInsert = jest.fn()
 const mockUpdate = jest.fn()
+const mockCreateFamilyAsParent = jest.fn() // RPC: replaces the old INSERT+UPDATE family-creation flow
 const mockProfileData = { current: mockProfile as unknown }
 const mockFamilyData = { current: mockFamily as unknown }
 const mockMembersData = { current: mockMembers as unknown[] }
@@ -92,20 +92,14 @@ jest.mock('@/lib/supabase/client', () => ({
           }),
         }
       },
-      insert: (...args: unknown[]) => {
-        const result = mockInsert(...args)
-        return {
-          ...result,
-          select: () => ({
-            single: () => result,
-          }),
-        }
-      },
       update: (...args: unknown[]) => ({
         eq: (...eqArgs: unknown[]) => mockUpdate(...args, ...eqArgs),
       }),
     }),
-    rpc: () => Promise.resolve({ data: [] }),
+    rpc: (name: string, args?: unknown) => {
+      if (name === 'create_family_as_parent') return mockCreateFamilyAsParent(args)
+      return Promise.resolve({ data: [] })
+    },
   }),
 }))
 
@@ -125,7 +119,7 @@ describe('FamilyPage', () => {
     mockProfileData.current = mockProfile
     mockFamilyData.current = mockFamily
     mockMembersData.current = mockMembers
-    mockInsert.mockResolvedValue({ data: { id: 'new-family', name: 'New Family', invite_code: 'XYZ', created_at: '' }, error: null })
+    mockCreateFamilyAsParent.mockResolvedValue({ data: 'new-family-id', error: null })
     mockUpdate.mockResolvedValue({ error: null })
   })
 
@@ -276,7 +270,7 @@ describe('FamilyPage', () => {
       mockFamilyData.current = null
     })
 
-    it('does nothing when family name is empty (line 79 guard)', async () => {
+    it('does nothing when family name is empty (guard)', async () => {
       const { fireEvent: fe } = await import('@testing-library/react')
       render(<FamilyPage />)
 
@@ -288,8 +282,7 @@ describe('FamilyPage', () => {
       const form = document.querySelector('form')!
       fe.submit(form)
 
-      // handleCreateFamily should return early due to empty familyName
-      expect(mockInsert).not.toHaveBeenCalled()
+      expect(mockCreateFamilyAsParent).not.toHaveBeenCalled()
     })
 
     it('shows error when profile is not loaded', async () => {
@@ -306,7 +299,7 @@ describe('FamilyPage', () => {
       consoleSpy.mockRestore()
     })
 
-    it('creates a family successfully', async () => {
+    it('creates a family successfully via create_family_as_parent RPC', async () => {
       const user = userEvent.setup()
       render(<FamilyPage />)
 
@@ -318,13 +311,13 @@ describe('FamilyPage', () => {
       await user.click(screen.getByRole('button', { name: 'Create Family' }))
 
       await waitFor(() => {
-        expect(mockInsert).toHaveBeenCalled()
+        expect(mockCreateFamilyAsParent).toHaveBeenCalledWith({ p_name: 'New Family' })
       })
     })
 
-    it('shows error when family insert fails', async () => {
+    it('shows error when create_family_as_parent RPC fails', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-      mockInsert.mockResolvedValue({ data: null, error: { message: 'Insert failed' } })
+      mockCreateFamilyAsParent.mockResolvedValue({ data: null, error: { message: 'RPC failed' } })
 
       const user = userEvent.setup()
       render(<FamilyPage />)
@@ -337,68 +330,7 @@ describe('FamilyPage', () => {
       await user.click(screen.getByRole('button', { name: 'Create Family' }))
 
       await waitFor(() => {
-        expect(screen.getByText(/failed to create family/i)).toBeInTheDocument()
-      })
-      consoleSpy.mockRestore()
-    })
-
-    it('shows Unknown error when familyError has no message (line 98 || branch)', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-      // Error without message property
-      mockInsert.mockResolvedValue({ data: null, error: {} })
-
-      const user = userEvent.setup()
-      render(<FamilyPage />)
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Family Name')).toBeInTheDocument()
-      })
-
-      await user.type(screen.getByLabelText('Family Name'), 'Test Family')
-      await user.click(screen.getByRole('button', { name: 'Create Family' }))
-
-      await waitFor(() => {
-        expect(screen.getByText('Failed to create family: Unknown error')).toBeInTheDocument()
-      })
-      consoleSpy.mockRestore()
-    })
-
-    it('shows Unknown error when newFamily is null but no error (line 96 !newFamily branch)', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-      mockInsert.mockResolvedValue({ data: null, error: null })
-
-      const user = userEvent.setup()
-      render(<FamilyPage />)
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Family Name')).toBeInTheDocument()
-      })
-
-      await user.type(screen.getByLabelText('Family Name'), 'Test Family')
-      await user.click(screen.getByRole('button', { name: 'Create Family' }))
-
-      await waitFor(() => {
-        expect(screen.getByText('Failed to create family: Unknown error')).toBeInTheDocument()
-      })
-      consoleSpy.mockRestore()
-    })
-
-    it('shows error when profile update fails after family creation', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-      mockUpdate.mockResolvedValue({ error: { message: 'Update failed' } })
-
-      const user = userEvent.setup()
-      render(<FamilyPage />)
-
-      await waitFor(() => {
-        expect(screen.getByLabelText('Family Name')).toBeInTheDocument()
-      })
-
-      await user.type(screen.getByLabelText('Family Name'), 'Test Family')
-      await user.click(screen.getByRole('button', { name: 'Create Family' }))
-
-      await waitFor(() => {
-        expect(screen.getByText(/failed to update profile/i)).toBeInTheDocument()
+        expect(screen.getByText('Failed to create family: RPC failed')).toBeInTheDocument()
       })
       consoleSpy.mockRestore()
     })

--- a/__tests__/db/profile-rls.db.test.ts
+++ b/__tests__/db/profile-rls.db.test.ts
@@ -1,0 +1,221 @@
+/**
+ * DB integration tests for profile UPDATE restrictions (migration 022).
+ *
+ * Verifies:
+ *   - The trigger blocks self-changes to role / points / family_id.
+ *   - The trigger lets self-changes to display_name / nickname / avatar_url through.
+ *   - create_family_as_parent + join_family_via_invite_code RPCs work as expected.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { runSQL } from '../../e2e/supabase-admin'
+import { ensureDbTestUser } from './helpers/db-test-helpers'
+
+const DB_TEST_EMAIL = 'db-test@chore-champions-test.local'
+const DB_TEST_PASSWORD = 'TestPassword123!'
+
+let client: SupabaseClient
+let userId: string
+let familyId: string
+
+beforeAll(async () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !anonKey) throw new Error('Supabase env vars missing')
+
+  const seed = await ensureDbTestUser()
+  userId = seed.userId
+  familyId = seed.familyId
+  // Ensure the seed user is a 'child' for the self-update tests.
+  await runSQL(`UPDATE profiles SET role = 'child', points = 0 WHERE id = '${userId}'`)
+
+  client = createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+  const { error } = await client.auth.signInWithPassword({
+    email: DB_TEST_EMAIL,
+    password: DB_TEST_PASSWORD,
+  })
+  if (error) throw new Error(`Sign-in failed: ${error.message}`)
+})
+
+afterAll(async () => {
+  await client?.auth.signOut()
+})
+
+describe('profile UPDATE trigger (migration 022)', () => {
+  it('blocks self-promotion to parent role', async () => {
+    const { error } = await client
+      .from('profiles')
+      .update({ role: 'parent' })
+      .eq('id', userId)
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/role/i)
+  })
+
+  it('blocks self-grant of points', async () => {
+    const { error } = await client
+      .from('profiles')
+      .update({ points: 999999 })
+      .eq('id', userId)
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/points/i)
+  })
+
+  it('blocks self-change of family_id', async () => {
+    const { error } = await client
+      .from('profiles')
+      .update({ family_id: '00000000-0000-0000-0000-000000000001' })
+      .eq('id', userId)
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/family_id/i)
+  })
+
+  it('allows self-update of display_name + nickname', async () => {
+    const newName = `Renamed ${Date.now()}`
+    const { error } = await client
+      .from('profiles')
+      .update({ display_name: newName, nickname: 'Tester' })
+      .eq('id', userId)
+    expect(error).toBeNull()
+
+    const rows = (await runSQL(
+      `SELECT display_name, nickname FROM profiles WHERE id = '${userId}'`,
+    )) as Array<{ display_name: string; nickname: string }>
+    expect(rows[0].display_name).toBe(newName)
+    expect(rows[0].nickname).toBe('Tester')
+
+    // Restore so other tests / reruns aren't surprised.
+    await runSQL(
+      `UPDATE profiles SET display_name = 'DB Test User', nickname = NULL WHERE id = '${userId}'`,
+    )
+  })
+})
+
+describe('create_family_as_parent + join_family_via_invite_code RPCs', () => {
+  // Each test uses a fresh transient auth user with no family so we don't
+  // disturb the seed user's permanent membership.
+  let transientUserId: string
+  let transientClient: SupabaseClient
+  const transientEmail = `db-test-rpc-${Date.now()}@chore-champions-test.local`
+  const transientPassword = 'TestPassword123!'
+
+  async function createTransientUser(): Promise<void> {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+    const res = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${serviceRoleKey}`,
+        apikey: serviceRoleKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: transientEmail,
+        password: transientPassword,
+        email_confirm: true,
+        user_metadata: { display_name: 'Transient' },
+      }),
+    })
+    if (!res.ok) throw new Error(`createTransientUser failed: ${await res.text()}`)
+    const body = (await res.json()) as { id: string }
+    transientUserId = body.id
+
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    transientClient = createClient(url, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    })
+    const { error } = await transientClient.auth.signInWithPassword({
+      email: transientEmail,
+      password: transientPassword,
+    })
+    if (error) throw new Error(`Transient sign-in failed: ${error.message}`)
+  }
+
+  async function deleteTransientUser(): Promise<void> {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+    // Profile cascades via auth.users ON DELETE CASCADE; family rows
+    // created during the test are scoped per-test and cleaned up below.
+    await fetch(`${supabaseUrl}/auth/v1/admin/users/${transientUserId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${serviceRoleKey}`, apikey: serviceRoleKey },
+    })
+  }
+
+  beforeEach(async () => {
+    await createTransientUser()
+  })
+
+  afterEach(async () => {
+    // Drop any family the transient user may have created so reruns
+    // don't accumulate. Look up via the profile (which still exists
+    // because we haven't deleted the auth user yet).
+    const rows = (await runSQL(
+      `SELECT family_id FROM profiles WHERE id = '${transientUserId}'`,
+    )) as Array<{ family_id: string | null }>
+    const fid = rows[0]?.family_id
+    if (fid) {
+      await runSQL(`DELETE FROM families WHERE id = '${fid}'`)
+    }
+    await transientClient?.auth.signOut()
+    await deleteTransientUser()
+  })
+
+  it('create_family_as_parent: creates the family and elevates the caller to parent', async () => {
+    const { data, error } = await transientClient.rpc('create_family_as_parent', {
+      p_name: 'Test Parent Family',
+    })
+    expect(error).toBeNull()
+    expect(typeof data).toBe('string')
+
+    const rows = (await runSQL(
+      `SELECT role, family_id FROM profiles WHERE id = '${transientUserId}'`,
+    )) as Array<{ role: string; family_id: string }>
+    expect(rows[0].role).toBe('parent')
+    expect(rows[0].family_id).toBe(data)
+  })
+
+  it('create_family_as_parent: rejects empty family name', async () => {
+    const { error } = await transientClient.rpc('create_family_as_parent', { p_name: '   ' })
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/family name required/i)
+  })
+
+  it('create_family_as_parent: rejects when the caller is already in a family', async () => {
+    // First call succeeds.
+    await transientClient.rpc('create_family_as_parent', { p_name: 'First Family' })
+    // Second should fail.
+    const { error } = await transientClient.rpc('create_family_as_parent', { p_name: 'Second Family' })
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/already in a family/i)
+  })
+
+  it('join_family_via_invite_code: joins the family and stays a child', async () => {
+    // Look up the seed family's invite code.
+    const codeRows = (await runSQL(
+      `SELECT invite_code FROM families WHERE id = '${familyId}'`,
+    )) as Array<{ invite_code: string }>
+    const inviteCode = codeRows[0].invite_code
+
+    const { data, error } = await transientClient.rpc('join_family_via_invite_code', {
+      p_code: inviteCode,
+    })
+    expect(error).toBeNull()
+    expect(data).toBe(familyId)
+
+    const rows = (await runSQL(
+      `SELECT role, family_id FROM profiles WHERE id = '${transientUserId}'`,
+    )) as Array<{ role: string; family_id: string }>
+    expect(rows[0].role).toBe('child')
+    expect(rows[0].family_id).toBe(familyId)
+  })
+
+  it('join_family_via_invite_code: rejects an unknown code', async () => {
+    const { error } = await transientClient.rpc('join_family_via_invite_code', {
+      p_code: 'totally-not-a-real-code',
+    })
+    expect(error).not.toBeNull()
+    expect(error!.message).toMatch(/invalid invite code/i)
+  })
+})

--- a/__tests__/db/profile-rls.db.test.ts
+++ b/__tests__/db/profile-rls.db.test.ts
@@ -148,14 +148,14 @@ describe('create_family_as_parent + join_family_via_invite_code RPCs', () => {
   })
 
   afterEach(async () => {
-    // Drop any family the transient user may have created so reruns
-    // don't accumulate. Look up via the profile (which still exists
-    // because we haven't deleted the auth user yet).
+    // Drop any family the transient user *created* so reruns don't
+    // accumulate. Skip the seed family (which other tests share) when
+    // the transient user merely joined it via invite code.
     const rows = (await runSQL(
       `SELECT family_id FROM profiles WHERE id = '${transientUserId}'`,
     )) as Array<{ family_id: string | null }>
     const fid = rows[0]?.family_id
-    if (fid) {
+    if (fid && fid !== familyId) {
       await runSQL(`DELETE FROM families WHERE id = '${fid}'`)
     }
     await transientClient?.auth.signOut()

--- a/app/(auth)/join/[code]/page.tsx
+++ b/app/(auth)/join/[code]/page.tsx
@@ -70,14 +70,14 @@ export default function JoinFamilyPage() {
       return
     }
 
-    // Update the profile with family_id and role
+    // Server-side RPC sets family_id atomically — direct UPDATE on profile
+    // family_id is blocked by the profile-update trigger (migration 022).
     if (authData.user) {
-      const { error: profileError } = await supabase
-        .from('profiles')
-        .update({ family_id: familyId })
-        .eq('id', authData.user.id)
+      const { error: rpcError } = await supabase.rpc('join_family_via_invite_code', {
+        p_code: code,
+      })
 
-      if (profileError) {
+      if (rpcError) {
         setError('Failed to join family. Please try again.')
         setLoading(false)
         return

--- a/app/(dashboard)/family/page.tsx
+++ b/app/(dashboard)/family/page.tsx
@@ -86,29 +86,16 @@ export default function FamilyPage() {
     setCreating(true)
     setError(null)
 
-    // Create family
-    const { data: newFamily, error: familyError } = await supabase
-      .from('families')
-      .insert({ name: familyName.trim() })
-      .select()
-      .single()
+    // Server-side RPC creates the family and elevates the caller to parent
+    // atomically — direct UPDATEs to role/family_id are blocked by the
+    // profile-update trigger (migration 022).
+    const { error: rpcError } = await supabase.rpc('create_family_as_parent', {
+      p_name: familyName.trim(),
+    })
 
-    if (familyError || !newFamily) {
-      console.error('Failed to create family:', familyError)
-      setError('Failed to create family: ' + (familyError?.message || 'Unknown error'))
-      setCreating(false)
-      return
-    }
-
-    // Update profile with family_id and make them a parent
-    const { error: profileError } = await supabase
-      .from('profiles')
-      .update({ family_id: newFamily.id, role: 'parent' })
-      .eq('id', currentUser.id)
-
-    if (profileError) {
-      console.error('Failed to update profile:', profileError)
-      setError('Failed to update profile: ' + profileError.message)
+    if (rpcError) {
+      console.error('Failed to create family:', rpcError)
+      setError('Failed to create family: ' + rpcError.message)
       setCreating(false)
       return
     }

--- a/supabase/migrations/022_restrict_profile_updates.sql
+++ b/supabase/migrations/022_restrict_profile_updates.sql
@@ -1,0 +1,171 @@
+-- ============================================================
+-- 022: Restrict profile UPDATE — block role/points/family_id from clients
+-- ============================================================
+-- Previously the profile UPDATE policy only checked USING (id = auth.uid()).
+-- Without column restrictions or a WITH CHECK clause, any authenticated
+-- user could:
+--   UPDATE profiles SET role = 'parent', points = 999999, family_id = '<any>'
+--                   WHERE id = auth.uid();
+-- via the anon key, breaking the entire trust model.
+--
+-- This migration:
+--   1. Replaces the policy with a version that has both USING and WITH CHECK.
+--   2. Adds a BEFORE UPDATE trigger that rejects changes to role / points /
+--      family_id from authenticated callers. Service role and SECURITY
+--      DEFINER RPCs bypass (their current_user is the function owner).
+--   3. Adds two SECURITY DEFINER RPCs as the only legitimate way to
+--      mutate role + family_id from the client:
+--         - create_family_as_parent(name)        — creator becomes parent
+--         - join_family_via_invite_code(code)    — joiner stays as child
+
+-- ------------------------------------------------------------
+-- (1) Tighten the existing UPDATE policy
+-- ------------------------------------------------------------
+DROP POLICY IF EXISTS "Users can update their own profile" ON profiles;
+
+CREATE POLICY "Users can update their own profile"
+  ON profiles FOR UPDATE
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+-- The migration-009 "Parents can remove family members" policy is left
+-- in place; the new trigger below tightens what columns can change in
+-- that flow.
+
+-- ------------------------------------------------------------
+-- (2) Trigger: forbid sensitive column changes from clients
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION enforce_profile_update_constraints()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  -- Service role and SECURITY DEFINER calls run as the function owner
+  -- (e.g. 'postgres' / 'supabase_admin' / 'service_role'), so they bypass.
+  -- Only the 'authenticated' role — used by user-driven REST calls — is
+  -- subjected to the constraints.
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.id = auth.uid() THEN
+    -- Self-update: block sensitive columns.
+    IF NEW.role IS DISTINCT FROM OLD.role THEN
+      RAISE EXCEPTION 'Cannot change role directly; use create_family_as_parent()';
+    END IF;
+    IF NEW.points IS DISTINCT FROM OLD.points THEN
+      RAISE EXCEPTION 'Cannot change points directly; awarded only via task completions';
+    END IF;
+    IF NEW.family_id IS DISTINCT FROM OLD.family_id THEN
+      RAISE EXCEPTION 'Cannot change family_id directly; use create_family_as_parent() or join_family_via_invite_code()';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- Updating another user's profile: only legal when a parent is removing
+  -- a family member (migration 009). Allow ONLY family_id -> NULL.
+  IF NEW.family_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Cannot set family_id on another user; only NULL is permitted (removal flow)';
+  END IF;
+  IF NEW.role            IS DISTINCT FROM OLD.role
+     OR NEW.points       IS DISTINCT FROM OLD.points
+     OR NEW.display_name IS DISTINCT FROM OLD.display_name
+     OR NEW.avatar_url   IS DISTINCT FROM OLD.avatar_url
+     OR NEW.nickname     IS DISTINCT FROM OLD.nickname THEN
+    RAISE EXCEPTION 'Removal flow may only clear family_id; no other columns may change';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_profile_update_constraints_trigger ON profiles;
+
+CREATE TRIGGER enforce_profile_update_constraints_trigger
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_profile_update_constraints();
+
+-- ------------------------------------------------------------
+-- (3) RPC: create a family and become its parent
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION create_family_as_parent(p_name text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id   uuid := auth.uid();
+  v_existing  uuid;
+  v_family_id uuid;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+  IF p_name IS NULL OR length(trim(p_name)) = 0 THEN
+    RAISE EXCEPTION 'Family name required';
+  END IF;
+
+  SELECT family_id INTO v_existing FROM profiles WHERE id = v_user_id;
+  IF v_existing IS NOT NULL THEN
+    RAISE EXCEPTION 'User is already in a family';
+  END IF;
+
+  INSERT INTO families (name) VALUES (trim(p_name))
+  RETURNING id INTO v_family_id;
+
+  UPDATE profiles
+  SET family_id = v_family_id, role = 'parent'
+  WHERE id = v_user_id;
+
+  RETURN v_family_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_family_as_parent(text) TO authenticated;
+
+-- ------------------------------------------------------------
+-- (4) RPC: join an existing family via invite code (joiner stays child)
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION join_family_via_invite_code(p_code text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id   uuid := auth.uid();
+  v_existing  uuid;
+  v_family_id uuid;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+  IF p_code IS NULL OR length(trim(p_code)) = 0 THEN
+    RAISE EXCEPTION 'Invite code required';
+  END IF;
+
+  SELECT family_id INTO v_existing FROM profiles WHERE id = v_user_id;
+  IF v_existing IS NOT NULL THEN
+    RAISE EXCEPTION 'User is already in a family';
+  END IF;
+
+  -- Match invite_code case-insensitively (consistent with migration 008).
+  SELECT id INTO v_family_id
+  FROM families
+  WHERE LOWER(invite_code) = LOWER(trim(p_code));
+
+  IF v_family_id IS NULL THEN
+    RAISE EXCEPTION 'Invalid invite code';
+  END IF;
+
+  UPDATE profiles
+  SET family_id = v_family_id
+  WHERE id = v_user_id;
+
+  RETURN v_family_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION join_family_via_invite_code(text) TO authenticated;


### PR DESCRIPTION
## Summary
Closes the largest hole found in the security review: any authenticated user could `UPDATE profiles SET role='parent', points=999999, family_id='<any>' WHERE id = auth.uid()` via the anon key.

Fix is layered:
- **RLS**: tightens the existing UPDATE policy with both `USING` and `WITH CHECK` on `id = auth.uid()` (defence in depth).
- **Trigger** (`enforce_profile_update_constraints`): from the `authenticated` role, blocks self-changes to `role` / `points` / `family_id`, and on the migration-009 parent-removes-member path allows only `family_id` → NULL with no other column changes. Service-role and SECURITY DEFINER calls bypass.
- **Two new RPCs** as the only legitimate client paths for role/family_id mutations:
  - `create_family_as_parent(p_name)` — creator becomes parent atomically.
  - `join_family_via_invite_code(p_code)` — joiner stays as child.

## Client changes
- `app/(dashboard)/family/page.tsx` — replaces the old `INSERT into families` + `UPDATE profile` flow with the RPC.
- `app/(auth)/join/[code]/page.tsx` — replaces the direct `UPDATE profile` with the RPC.

## Test plan
- [x] DB integration tests (`__tests__/db/profile-rls.db.test.ts`, 9/9): self-promote blocked, points block, family_id block, display_name allowed, both RPCs happy + guard paths.
- [x] Unit tests updated to mock the RPC calls; 100% coverage on both client pages preserved.
- [x] `npm run lint` — 0 errors.
- [x] `npm test` — 1766/1766 pass.
- [ ] CI green.

## Notes
- Behaviour change: parents can no longer modify another member's `display_name`/`avatar_url`/`nickname` — that was previously possible via raw RLS but is not a documented feature. Issue #15 ("Allow parents to edit family member profiles") covers the future legit version, which would land as another SECURITY DEFINER RPC.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)